### PR TITLE
Mobile Firefox URL fix

### DIFF
--- a/apps/addons/templates/addons/mobile/home.html
+++ b/apps/addons/templates/addons/mobile/home.html
@@ -6,7 +6,7 @@
   <header id="home-header">
     {% include "mobile/header.html" %}
     <div class="get-fx-message">
-      {{ _('You need Firefox to install add-ons. <a href="http://mozilla.com/firefox">Learn More&nbsp;&raquo;</a>') }}
+      {{ _('You need Firefox to install add-ons. <a href="http://mozilla.com/mobile">Learn More&nbsp;&raquo;</a>') }}
     </div>
     <hgroup>
       <h1 class="site-title">

--- a/templates/mobile/base.html
+++ b/templates/mobile/base.html
@@ -46,7 +46,7 @@
             </h1>
           </hgroup>
           <div class="get-fx-message">
-            {{ _('You need Firefox to install add-ons. <a href="http://mozilla.com/firefox">Learn More&nbsp;&raquo;</a>') }}
+            {{ _('You need Firefox to install add-ons. <a href="http://mozilla.com/mobile">Learn More&nbsp;&raquo;</a>') }}
           </div>
           {% block back_link %}
           <a href="{{ url('home') }}" id="home">


### PR DESCRIPTION
Changing URL to direct mobile users to mobile Firefox, rather than desktop Firefox - Bug 640744
