### PR TITLE
Bug 634138 Adding the description of the Persona to the page if it's avai

### DIFF
--- a/apps/addons/templates/addons/persona_detail.html
+++ b/apps/addons/templates/addons/persona_detail.html
@@ -35,7 +35,7 @@
             {% include "addons/persona_detail_table.html" %}
           </table>
 
-          <p{{ addon.summary|locale_html }}>{{ addon.description|nl2br }}</p>
+          <p{{ addon.description|locale_html }}>{{ addon.description|nl2br }}</p>
 
           {{ big_install_button(addon, show_warning=False) }}
 


### PR DESCRIPTION
Bug 634138 Adding the description of the Persona to the page if it's available.
