### PR TITLE
Bug 504685: fix listing of hidden addons on dev profile

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -140,7 +140,8 @@ class UserProfile(amo.models.ModelBase):
     @amo.cached_property
     def addons_listed(self):
         """Public add-ons this user is listed as author of."""
-        return self.addons.valid().filter(addonuser__listed=True).distinct()
+        return self.addons.valid().filter(addonuser__user=self,
+                                          addonuser__listed=True)
 
     @property
     def picture_dir(self):

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -22,8 +22,8 @@ from users.models import (UserProfile, get_hexdigest, BlacklistedEmailDomain,
 
 
 class TestUserProfile(test_utils.TestCase):
-    fixtures = ('base/addon_3615', 'base/user_2519', 'users/test_backends',
-                'base/apps',)
+    fixtures = ('base/addon_3615', 'base/user_2519', 'base/user_4043307',
+                'users/test_backends', 'base/apps',)
 
     def test_anonymize(self):
         u = User.objects.get(id='4043307').get_profile()
@@ -120,6 +120,14 @@ class TestUserProfile(test_utils.TestCase):
         u = UserProfile.objects.get(id=2519)
         addons = u.addons_listed.values_list('id', flat=True)
         eq_(sorted(addons), [3615])
+
+    def test_addons_not_listed(self):
+        """Make sure user is not listed when another is."""
+        AddonUser.objects.create(addon_id=3615, user_id=2519, listed=False)
+        AddonUser.objects.create(addon_id=3615, user_id=4043307, listed=True)
+        u = UserProfile.objects.get(id=2519)
+        addons = u.addons_listed.values_list('id', flat=True)
+        assert 3615 not in addons
 
     def test_mobile_collection(self):
         u = UserProfile.objects.get(id='4043307')


### PR DESCRIPTION
Fixed bug 504685 where the non-listed addons show up on the dev's profile.
