### PR TITLE
Updated apps JS to match API (bug 685428)

### DIFF
--- a/media/js/zamboni/buttons.js
+++ b/media/js/zamboni/buttons.js
@@ -25,12 +25,12 @@ var notavail = '<div class="extra"><span class="notavail">{0}</span></div>',
 var webappButton = function() {
     var $this = $(this),
         manifestURL = $this.attr('data-manifest-url');
-    if (navigator.apps && navigator.apps.install) {
+    if (navigator.mozApps && navigator.mozApps.install) {
         $this.find('.button')
             .removeClass('disabled')
             .click(function(e) {
                 e.preventDefault();
-                navigator.apps.install({url: manifestURL});
+                navigator.mozApps.install(manifestURL);
             });
     } else {
         // Attach something that says you can't install apps.

--- a/media/js/zamboni/mobile/buttons.js
+++ b/media/js/zamboni/mobile/buttons.js
@@ -278,12 +278,12 @@
 
 
         function initWebapp() {
-            if (navigator.apps && navigator.apps.install) {
+            if (navigator.mozApps && navigator.mozApps.install) {
                 dom.self.find('.button')
                     .removeClass('disabled')
                     .click(function(e) {
                         e.preventDefault();
-                        navigator.apps.install({url: manifestURL});
+                        navigator.mozApps.install(manifestURL);
                     });
             } else {
                 // Attach something that says you can't install apps.


### PR DESCRIPTION
The current code has been updated to the current version at https://developer.mozilla.org/en/OpenWebApps/The_JavaScript_API

Changes are:
- use navigator.mozApps instead of navigator.apps
- the install() call signature has change

Bug 685428
