### PR TITLE
[Bug 698722] Created date is not displayed for sort=created filter.

### DIFF
--- a/apps/devhub/templates/devhub/addons/listing/items.html
+++ b/apps/devhub/templates/devhub/addons/listing/items.html
@@ -24,9 +24,15 @@
               <li>{{ _('<strong>Latest version:</strong> <a href="{0}">{1}</a>'|
                        f(link, addon.current_version))|xssafe }}</li>
             {% endif %}
-            {# L10n: {0} is a date. #}
-            <li>{{ _('<strong>Last updated:</strong> {0}'|
+            {% if sorting == 'created' %}
+              {# L10n: {0} is a date. #}
+              <li class="date-created">{{ _('<strong>Created:</strong> {0}'|
+                     f(addon.created|datetime))|safe }}</li>
+            {% else %}
+              {# L10n: {0} is a date. #}
+              <li class="date-updated">{{ _('<strong>Last updated:</strong> {0}'|
                      f(addon.last_updated|datetime))|safe }}</li>
+            {% endif %}
           {% endif %}
           <li id="version-status-item">
             <strong>{{ _('Status:') }}</strong>

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.utils.http import urlencode
 
 import jingo
+from jingo.helpers import datetime as datetime_filter
 import mock
 from nose.tools import eq_, assert_not_equal, assert_raises
 from nose.plugins.attrib import attr
@@ -232,6 +233,26 @@ class TestDashboard(HubTest):
         eq_(doc('.blog-posts li').length, 5)
         eq_(doc('.blog-posts li a').eq(0).text(), "hi 0")
         eq_(doc('.blog-posts li a').eq(4).text(), "hi 4")
+
+    def test_sort_created_filter(self):
+        a_pk = self.clone_addon(1)[0]
+        addon = Addon.objects.get(pk=a_pk)
+        response = self.client.get(self.url + '?sort=created')
+        doc = pq(response.content)
+        eq_(doc('.item-details').length, 1)
+        d = doc('.item-details .date-created')
+        eq_(d.length, 1)
+        eq_(d.remove('strong').text(), datetime_filter(addon.created))
+
+    def test_sort_updated_filter(self):
+        a_pk = self.clone_addon(1)[0]
+        addon = Addon.objects.get(pk=a_pk)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        eq_(doc('.item-details').length, 1)
+        d = doc('.item-details .date-updated')
+        eq_(d.length, 1)
+        eq_(d.remove('strong').text(), datetime_filter(addon.last_updated))
 
 
 class TestAppDashboard(HubTest):


### PR DESCRIPTION
Touched the template apps/devhub/templates/devhub/addons/listing/items.html to pickup sort=created filter while displaying the date.
Also wrote a devhub unit test which checks if created date is displayed when sort=created filter is used.
