### PR TITLE
[Bug 548959] Different handler404 and handler500 for API

### DIFF
--- a/apps/api/tests/test_views.py
+++ b/apps/api/tests/test_views.py
@@ -19,6 +19,7 @@ import api.utils
 from amo import helpers
 from amo.tests import TestCase
 from amo.urlresolvers import reverse
+from amo.views import handler500
 from addons.cron import reset_featured_addons
 from addons.models import (Addon, AppSupport, CompatOverride,
                            CompatOverrideRange, Feature, Preview)
@@ -192,6 +193,33 @@ class APITest(TestCase):
 
         self.assertContains(response, 'Add-on not found!', status_code=404)
 
+    def test_handler404(self):
+        """
+        Check separate handler404 response for API.
+        """
+        response = self.client.get('/en-us/firefox/api/nonsense')
+        doc = pq(response.content)
+        eq_(response.status_code, 404)
+        d = doc('error')
+        self.assertTemplateUsed(response, 'api/message.xml')
+        eq_(d.length, 1)
+        eq_(d.text(), 'Not Found')
+
+    def test_handler500(self):
+        """
+        Check separate handler500 response for API.
+        """
+        req = self.client.get('/en-US/firefox/api/').context['request']
+        try:
+            raise NameError('an error')
+        except NameError:
+            r = handler500(req)
+            eq_(r.status_code, 500)
+            doc = pq(r.content)
+            d = doc('error')
+            eq_(d.length, 1)
+            eq_(d.text(), 'Server Error')
+       
     def test_addon_detail_appid(self):
         """
         Make sure we serve an appid.  See

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -84,6 +84,16 @@ def render_xml(request, template, context={}, **kwargs):
     return HttpResponse(rendered, **kwargs)
 
 
+def handler404(request):
+    context = {'error_level': ERROR, 'msg': 'Not Found'}
+    return render_xml(request, 'api/message.xml', context, status=404)
+
+
+def handler500(request):
+    context = {'error_level': ERROR, 'msg': 'Server Error'}
+    return render_xml(request, 'api/message.xml', context, status=500)
+
+
 def validate_api_version(version):
     """
     We want to be able to deprecate old versions of the API, therefore we check


### PR DESCRIPTION
This uses amo.views.handler404 and checks if the requested url targets API if it does, then api.views.handler404 takes control. So in the case of handler505.

Also wrote an api test to check 404 response.
