### PR TITLE
removed "Collection Description", added addon icon next to "Add to Collection" in collection.add (bug 592957)

### DIFF
--- a/apps/bandwagon/templates/bandwagon/includes/addedit.html
+++ b/apps/bandwagon/templates/bandwagon/includes/addedit.html
@@ -1,8 +1,5 @@
 {{ csrf() }}
 
-<div class="content">
-  <h3>{{ _('Collection Description') }}</h3>
-</div>
 <fieldset>
   {{ field(form.name, _('Name:'), class='long') }}
   {% if form.slug %}

--- a/apps/bandwagon/templates/bandwagon/includes/addon_selector.html
+++ b/apps/bandwagon/templates/bandwagon/includes/addon_selector.html
@@ -4,8 +4,8 @@
     {% trans %}
     To include an add-on in this collection, enter its name
     in the box below and hit enter.  You can also use the
-    <strong>Add to Collection</strong> links throughout the
-    site to include add-ons later.
+    <strong class="collectionitem">Add to Collection</strong>
+    links throughout the site to include add-ons later.
     {% endtrans %}
   </p>
 </div>

--- a/media/css/legacy/main-mozilla.css
+++ b/media/css/legacy/main-mozilla.css
@@ -1333,19 +1333,17 @@ html[xmlns] .clearfix {
     padding-right: 20px;
 }
 
-.addon-collections li .collectionitem,
-.collection-add > span,
-#addons-edit p strong {
-	padding-left: 22px;
-	background-image: url(../../img/icons/icons.png);
-	background-repeat: no-repeat;
-	background-position: 0px -300px;
+.collectionitem,
+.collection-add > span {
+    padding-left: 22px;
+    background: url(../../img/icons/icons.png) no-repeat 0 -300px;
 }
 
-.html-rtl .addon-collections li .collectionitem {
-	padding-right: 20px;
-	padding-left: 0;
-	background-position: 100% -300px;
+.html-rtl .collectionitem {
+    padding-right: 20px;
+    padding-left: 0;
+    background-position: 100% -300px;
+    display: inline-block;
 }
 
 .addon-otheraddons li .addonitem {


### PR DESCRIPTION
On the collections.add page:
1. "Collection Description" heading has been removed
2. "Add to Collection" heading now has an addon icon next to it.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=592957
