### PR TITLE
Input buttons should have cursor (hand) pointer instead of default (arrow) pointer for uniformity (bug 627630)

### DIFF
--- a/media/css/zamboni/zamboni.css
+++ b/media/css/zamboni/zamboni.css
@@ -236,6 +236,7 @@ button,
 input[type=submit],
 input[type=button] {
     padding: .2em .95em .3em;
+    cursor: pointer;
 }
 
 .button span,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=627630

Currently, the "Create Collection" button on https://addons.allizom.org/en-US/firefox/collections/add has the arrow (default) pointer, and so do other input buttons on other pages like collections.edit. On the other hand, similar looking anchor elements have a  hand (cursor) pointer. Both of them show default behaviors but are not uniform.
