### PR TITLE
Add to collection -> Start a new collection on addon pages shows error when description is longer than 200 chars (bug 725643)

### DIFF
--- a/apps/bandwagon/templates/bandwagon/ajax_new.html
+++ b/apps/bandwagon/templates/bandwagon/ajax_new.html
@@ -6,7 +6,7 @@
       {{ field(form.name, _('Name:')) }}
       {% set slug_base = url('collections.user', user.get_profile().username, add_prefix=False) %}
       <p id="collection-form-slug">
-        {{ form.errors['slug'] }}
+        {{ form.errors.slug }}
         <label>{{ form.slug.label }}</label>
         <span id="slug_edit" class="edit_with_prefix edit_initially_hidden">
           <span>{{ slug_base }}</span>{{ form.slug }}
@@ -17,6 +17,7 @@
         </span>
       </p>
       <p>
+        {{ form.errors.description }}
         <label for="id_description">{{ form.description.label }}</label> {{ _('(optional)') }}
         {{ form.description }}
       </p>

--- a/apps/bandwagon/tests/test_views.py
+++ b/apps/bandwagon/tests/test_views.py
@@ -755,15 +755,27 @@ class AjaxTest(amo.tests.TestCase):
     def test_new_collection(self):
         num_collections = Collection.objects.all().count()
         r = self.client.post(reverse('collections.ajax_new'),
-                {'addon_id': 5299,
-                 'name': 'foo',
-                 'slug': 'auniqueone',
-                 'description': 'yermom',
-                 'listed': True},
-                follow=True)
+                             {'addon_id': 5299,
+                              'name': 'foo',
+                              'slug': 'auniqueone',
+                              'description': 'yermom',
+                              'listed': True},
+                             follow=True)
         doc = pq(r.content)
         eq_(len(doc('li.selected')), 1, "The new collection is not selected.")
         eq_(Collection.objects.all().count(), num_collections + 1)
+
+    def test_new_collection_long_description(self):
+        r = self.client.post(reverse('collections.ajax_new'),
+                             {'addon_id': 5299,
+                              'name': 'foo',
+                              'slug': 'auniqueone',
+                              'description': '1'*250,
+                              'listed': True},
+                             follow=True)
+        self.assertFormError(r, 'form', 'description',
+                                'Ensure this value has at '
+                                'most 200 characters (it has 250).')
 
     def test_add_other_collection(self):
         "403 when you try to add to a collection that isn't yours."


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=725643

Collection description is not allowed to be more than 200 chars. On entering a description longer than 200, the form doesn't work and doesn't show an error as well.
