### PR TITLE
long titles in collection listings dont go out of bounds (bug 723083)

### DIFF
--- a/media/css/zamboni/zamboni.css
+++ b/media/css/zamboni/zamboni.css
@@ -1848,7 +1848,7 @@ form .error .note.error {
 }
 
 .listing .item h3 {
-    float: left;
+    width: 400px;
 }
 
 .html-rtl .listing .item h3 {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=723083

In collections listings, long collection names are not wrapped and they go out of bounds, messing up everything around them.
