### PR TITLE
abnormally long tags for addons are broken using word-wrap (bug 723871)

### DIFF
--- a/media/css/impala/addon_details.less
+++ b/media/css/impala/addon_details.less
@@ -430,6 +430,7 @@ h1.addon,
         display: inline;
         padding: 0 1px 0 0;
         line-height: 1.2em;
+        word-wrap: break-word;
     }
     li:not(:last-child):after {
         content: '\00B7';


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=723871

Abnormally long tags for addons would go out of page bounds like so:
https://bugzilla.mozilla.org/attachment.cgi?id=594110

Fixed using CSS word-wrap instead of horizontal truncation as horizontal truncation can be very less informative in such a case. 

Hyphenation may be a better solution but chrome sucks at hyphenation. Hyphenator.js (http://code.google.com/p/hyphenator/) may be a good solution.
