### PR TITLE
Fix for bug 756123

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = git://github.com/mozilla/django-moz-header.git
 [submodule "vendor"]
 	path = vendor
-	url = git://github.com/jbalogh/zamboni-lib.git
+	url = git://github.com/mozilla/zamboni-lib.git

--- a/media/js/zamboni/mobile/buttons.js
+++ b/media/js/zamboni/mobile/buttons.js
@@ -95,7 +95,7 @@
                 if (self.classes.persona) {
                     return;
                 }
-                var href = activeInstaller.attr('href'),
+                var href = activeInstaller.href,
                     hash = hashes[href],
                     attr = self.attr,
                     install = attr.search ? z.installSearch : z.installAddon;


### PR DESCRIPTION
This uses the href property rather than the attribute, which I think should fix a relative link problem we have in Fennec (not sure how to test). This probably means the calculated hash is incorrect, but it doesn't seem to be used. I can look at doing something more complex (bringing more of the desktop code over) if you'd rather.
