### PR TITLE
Revert "remove perf view/urls as they are not used"

### DIFF
--- a/apps/perf/urls.py
+++ b/apps/perf/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls.defaults import patterns, url, include
+
+from . import views
+
+
+urlpatterns = patterns('',
+    url('^$', views.index, name='perf.index'),
+)

--- a/apps/perf/views.py
+++ b/apps/perf/views.py
@@ -1,0 +1,42 @@
+from django import http
+from django.conf import settings
+from django.db.models import Avg
+from django.shortcuts import get_list_or_404
+from django.views.decorators.cache import cache_control
+
+import jingo
+import redisutils
+
+import amo
+from addons.models import Addon
+
+from .models import Performance, PerformanceOSVersion
+
+
+# TODO(wraithan): remove this as the code the powers this is no longer around
+@cache_control(max_age=60 * 60 * 24)  # Cache for a day.
+def index(request):
+    raise NotImplementedError, ('This relies on redis, theoretically it is'
+                                'disabled so you should never see this.')
+    # By default don't show less than 25; bug 647398
+    threshold = Performance.get_threshold()
+
+    addons = (Addon.objects.listed(request.APP, *amo.MIRROR_STATUSES)
+              .filter(ts_slowness__gte=threshold)
+              .order_by('-ts_slowness')[:50])
+
+    ctx = {'addons': addons}
+
+    if addons:
+        ids = [a.id for a in addons]
+        redis = redisutils.connections['master']
+        os_perf = dict(zip(ids, redis.hmget(Performance.ALL_PLATFORMS, ids)))
+        platforms = dict((unicode(p), p.id)
+                         for p in PerformanceOSVersion.uncached.all())
+        ctx.update(
+            os_perf=os_perf,
+            platforms=platforms,
+            show_os=any(os_perf.values()),
+        )
+
+    return jingo.render(request, 'perf/index.html', ctx)

--- a/lib/urls_base.py
+++ b/lib/urls_base.py
@@ -62,6 +62,9 @@ urlpatterns = patterns('',
     # AMO admin (not django admin).
     ('^admin/', include('zadmin.urls')),
 
+    # Performance wall of shame.
+    ('^performance/', include('perf.urls')),
+
     # Localizable pages.
     ('', include('pages.urls')),
 


### PR DESCRIPTION
They are still not used, but they are referenced.
Due to the setting that disables them I made certain
it isnt run by adding an exception.

This reverts commit ef418af8ffdb839a88c8f05b445bff0107c49556.
