### PR TITLE
Make the install_landfill command use the db pass if any.

### DIFF
--- a/apps/amo/management/commands/install_landfill.py
+++ b/apps/amo/management/commands/install_landfill.py
@@ -53,6 +53,10 @@ class Command(BaseCommand):
             'db_name': settings.DATABASES['default']['NAME'],
         }
 
+        db_password = settings.DATABASES['default'].get('PASSWORD')
+        if db_password:
+            write_dump += ' -p%s' % db_password
+
         if kw['no_download']:
             if os.path.exists(file_location):
                 print('Skipping landfill download and using %s' % file_location)


### PR DESCRIPTION
the script was trying to connect as the specified user without considering the password entered in the configuration file. This fixes it and add -p{password} to the mysql command if a password exists.
