### PR TITLE
Bug 780223 -- switch to browserid .watch() method

### DIFF
--- a/media/js/zamboni/browserid_support.js
+++ b/media/js/zamboni/browserid_support.js
@@ -72,8 +72,13 @@ function initBrowserID(win, ctx) {
         e.preventDefault();
         $el.addClass('loading-submit');
         $('.primary .notification-box', ctx).remove();
-        navigator.id.getVerifiedEmail(function(assertion) {
-            gotVerifiedEmail(assertion, redirectTo);
+        navigator.id.watch(
+            onlogin: function(assertion) {
+                gotVerifiedEmail(assertion, redirectTo);
+            },
+            onlogout: function() {
+                // even if no action, this must be included.
+            }
         });
     });
 }


### PR DESCRIPTION
Simple patch to use the new BrowserID .watch() method instead of .getVerifiedEmail()
