### PR TITLE
bug 784722 - bump metlog dependency up to add support for multiple logstash listeners

### DIFF
--- a/docs/settings/settings_local.prod.py
+++ b/docs/settings/settings_local.prod.py
@@ -49,8 +49,8 @@ DEBUG_PROPAGATE_EXCEPTIONS = DEBUG
 #     'logger': 'zamboni',
 #     'sender': {
 #         'class': 'metlog.senders.UdpSender',
-#         'host': '127.0.0.1',
-#         'port': '5566',
+#         'host': ['10.0.1.5', '10.0.1.10']
+#         'port': 5566
 #     },
 #     'plugins': {
 #         'raven': ('metlog_raven.raven_plugin.config_plugin',

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,3 @@
 Django==1.4.1
 gunicorn==0.14.6
+metlog-py>=0.9.6


### PR DESCRIPTION
zamboni needs to use metlog >= 0.9.6 to send to multiple logstash instances using the UdpSender.  This is required as all metlog messages must hit _all_ logstash instances.
