### PR TITLE
fix broken build - missing metlog-cef

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -16,6 +16,8 @@ django-tastypie==0.9.11
 easy-thumbnails==1.1
 gunicorn==0.14.6
 metlog-py==0.9.7
+metlog-cef==0.1
+cef==0.3
 moz_inapp_pay==1.0.2
 oauth2==1.5.211
 PyBrowserID==0.6


### PR DESCRIPTION
The metlog-cef library adds the '.cef' method to the metlog client library
