### PR TITLE
Test that set are equals rather than lists.

### DIFF
--- a/mkt/lookup/tests/test_views.py
+++ b/mkt/lookup/tests/test_views.py
@@ -444,7 +444,7 @@ class TestAppSummaryPurchases(AppSummaryTest):
         three_euro = numbers.format_currency(3,
                 'EUR',
                 locale=numbers.LC_NUMERIC)
-        eq_(sorted(data['amounts']), [six_bucks, three_euro])
+        eq_(set(data['amounts']), set([six_bucks, three_euro]))
 
     def assert_empty(self, data):
         eq_(data['total'], 0)


### PR DESCRIPTION
This is because some locales put the currency in front of the number (e.g $6) and some others put it after (6$), which made this fail under the french locale.
