### PR TITLE
fix clean_redis command (bug 797886)

### DIFF
--- a/apps/amo/management/commands/clean_redis.py
+++ b/apps/amo/management/commands/clean_redis.py
@@ -47,9 +47,10 @@ def vacuum(master, slave):
     tmp.close()
 
     # It's hard to get Python to clean up the memory from slave.keys(), so
-    # we'll let the OS do it. argv[0] is a dummy argument, the rest get passed
-    # like a normal command line.
-    os.execl(sys.executable, 'argv[0]', sys.argv[0], sys.argv[1], tmp.name)
+    # we'll let the OS do it. You have to pass sys.executable both as the
+    # thing to run and so argv[0] is set properly.
+    os.execl(sys.executable, sys.executable, sys.argv[0],
+             sys.argv[1], tmp.name)
 
 
 def cleanup(master, slave, filename):


### PR DESCRIPTION
execl was being called wrong. props to @oremj for figuring it out.
