### PR TITLE
Bugfix:  validator wrong link to "Changes in..."

### DIFF
--- a/media/js/zamboni/validator.js
+++ b/media/js/zamboni/validator.js
@@ -126,7 +126,7 @@ function initValidator($doc) {
                            // L10n: Example: Changes in Firefox 5
                            gettext(format('Changes in {0} {1}',
                                           this.app.trans[this.app.guid],
-                                          this.app.version.substring(0,1)))));
+                                          /\d+/.exec(this.app.version)))));
             }
         } else if (!$title.text()) {
             $title.text(gettext('Tests'));


### PR DESCRIPTION
(untested with these failure cases:
1.  What if that regex is null?
2.  Is /d+/ the right regex?
   )
