### PR TITLE
myisam -> innodb; bug 804136

### DIFF
--- a/migrations/491-finish-off-myisam.sql
+++ b/migrations/491-finish-off-myisam.sql
@@ -1,0 +1,13 @@
+-- Convert the last of our myisam tables to innodb. bug 804136
+
+ALTER TABLE addons_dependencies engine=InnoDB;
+ALTER TABLE appsupport engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE discovery_modules engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE email_preview engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE featured_collections engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE file_validation engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE schema_version engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE validation_job engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE validation_result engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE zadmin_siteevent engine=InnoDB, CONVERT TO CHARSET utf8;
+ALTER TABLE zadmin_siteevent_mkt engine=InnoDB, CONVERT TO CHARSET utf8;


### PR DESCRIPTION
Our last db crash was due to an FK pointing to a MyISAM table.  MyISAM doesn't support rolling back so when a transaction was cancelled the MyISAM table didn't change eventually causing db inconsistency and breakage.  This removes the last of our MyISAM tables save two, which I'm filing bugs to delete.
