### PR TITLE
Bug 792795 - Call "dibs" on installing persona handlers

### DIFF
--- a/media/js/mkt/login.js
+++ b/media/js/mkt/login.js
@@ -70,7 +70,14 @@ function init_persona() {
     // quite ready.
     if(navigator.id) {
         if ($('body').data('pers-timeout')) {
-            clearTimeout($('body').data('pers-timeout'));
+            clearInterval($('body').data('pers-timeout'));
+        }
+        if ($('body').data('pers-handle')) {
+            /// there is another handler already installed.
+            return;
+        } else {
+            // call DIBS on persona event handling
+            $('body').data('pers-handle', true);
         }
         $('.browserid').css('cursor', 'pointer');
         var email = '';

--- a/media/js/zamboni/browserid_support.js
+++ b/media/js/zamboni/browserid_support.js
@@ -48,8 +48,15 @@ function gotVerifiedEmail(assertion, redirectTo, domContext) {
         return null;
     };
 }
+
 function initBrowserID(win, ctx) {
     // Initialize BrowserID login.
+    if ($('body').data('pers-handle')) {
+        return;
+    } else {
+        // call DIBS on persona event handling.
+        $('body').data('pers-handle', true);
+    }
     var toArg = win.location.href.split('?to=')[1],
         to = "/";
 
@@ -61,7 +68,6 @@ function initBrowserID(win, ctx) {
         // No 'to' and not a log in page; redirect to the current page
         to = win.location.href;
     }
-
     $(ctx || win).delegate('.browserid-login', 'click', function(e) {
         var $el = $(this),
             // If there's a data-event on the login button, fire that event


### PR DESCRIPTION
Unfortunately, both (MKT)login.js and (AMO)browserid_support.js files
are included on some templates. This can lead to bad behaviors as the
wrong handler may be called for certain events.

The patch has a handler set a 'pers-handle' data handle on the page body
to indicate that it is handling the persona transactions.

added ; after returns
