### PR TITLE
Replace all old BrowserID URLs and references with the new Persona ones

### DIFF
--- a/apps/users/templates/users/login.html
+++ b/apps/users/templates/users/login.html
@@ -34,7 +34,7 @@
         and are not accepting any new registrations</strong>. To be notified of our progress, including any future tester openings,
         subscribe to our Apps newsletter in our <a href="https://developer.mozilla.org/en-US/apps">documentation area</a>. Thanks for your interest!</p>
       {% else %}
-        <p>If you'd like to try a demo of our app submission process, log in or register below with your <a href="https://browserid.org">BrowserID</a>
+        <p>If you'd like to try a demo of our app submission process, log in or register below with your <a href="https://login.persona.org">Persona</a>
           account. We're only accepting a limited number of registrations for this preview, but we encourage everyone interested in apps to
           <a href="https://developer.mozilla.org/en-US/apps">read our documentation</a>.</p>
       {% endif %}
@@ -45,7 +45,7 @@
     {% elif waffle.switch('browserid-login') %}
       <p>
         {# TODO: Localize! #}
-        {% with url='https://browserid.org/' %}
+        {% with url='https://login.persona.org/' %}
         The add-ons website is now using <a href="{{ url }}">BrowserID</a> for sign in. If you already have an account here, just use the
         same email when signing in to BrowserID.
         {% endwith %}

--- a/apps/users/templates/users/login_form.html
+++ b/apps/users/templates/users/login_form.html
@@ -17,7 +17,7 @@
     </a>
     <div class="user-message">
       <p>
-        <a href="https://browserid.org/forgot">
+        <a href="https://login.persona.org/forgot">
           {{ loc('Forgot your password?') }}</a>
           &nbsp;&middot;
           {% trans %}

--- a/docs/topics/install-zamboni/installation.rst
+++ b/docs/topics/install-zamboni/installation.rst
@@ -287,10 +287,10 @@ Run The Marketplace Server
 
 
 
-Browser ID
-----------
+Persona
+-------
 
-We use `Browser ID (Persona) <https://browserid.org/>`_ to log in and create accounts.
+We use `Persona <https://login.persona.org/>`_ to log in and create accounts.
 In order for this to work you need to set ``SITE_URL`` in your local
 settings file based on how you run your dev server. Here is an example::
 

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1198,7 +1198,6 @@ CSP_IMG_SRC = ("'self'", STATIC_URL,
               )
 CSP_SCRIPT_SRC = ("'self'", STATIC_URL,
                   "https://www.google.com",  # Recaptcha
-                  "https://browserid.org",
                   "https://login.persona.org",
                   "https://www.paypalobjects.com",
                   "http://raw.github.com",

--- a/mkt/developers/templates/developers/skeleton_impala.html
+++ b/mkt/developers/templates/developers/skeleton_impala.html
@@ -205,7 +205,7 @@
           <div class="new">
             <h2>{{ _('Please sign in') }}</h2>
             <p>
-              {% trans url='https://persona.org/' %}
+              {% trans url='https://login.persona.org/' %}
                 Just log in or register with your
                 <a href="{{ url }}">Persona</a> account below.
               {% endtrans %}

--- a/mkt/templates/mkt/base.html
+++ b/mkt/templates/mkt/base.html
@@ -143,7 +143,7 @@
           <div class="new">
             <h2>{{ _('Please sign in') }}</h2>
             <p>
-              {% trans url='https://persona.org/' %}
+              {% trans url='https://login.persona.org/' %}
                 Just log in or register with your
                 <a href="{{ url }}">Persona</a> account below.
               {% endtrans %}

--- a/templates/impala/base.html
+++ b/templates/impala/base.html
@@ -222,7 +222,7 @@
         <script src="https://myapps.mozillalabs.com/jsapi/include.js"></script>
       {% endif %}
       {% if waffle.switch('browserid-login') %}
-        <script async defer src="https://browserid.org/include.js"></script>
+        <script async defer src="https://login.persona.org/include.js"></script>
       {% endif %}
       {{ js('impala') }}
       <script async defer src="{{ static(url('addons.buttons.js')) }}"></script>

--- a/templates/mobile/base_addons.html
+++ b/templates/mobile/base_addons.html
@@ -105,7 +105,7 @@
       <script src="{{ static(url('jsi18n')) }}"></script>
       {{ js('zamboni/mobile') }}
       {% if waffle.switch('browserid-login') %}
-        <script async defer src="https://browserid.org/include.js"></script>
+        <script async defer src="https://login.persona.org/include.js"></script>
       {% endif %}
     {% endblock %}
     {% block js %}{% endblock %}

--- a/templates/mobile/base_apps.html
+++ b/templates/mobile/base_apps.html
@@ -89,7 +89,7 @@
         <script src="https://myapps.mozillalabs.com/jsapi/include.js"></script>
       {% endif %}
       {% if waffle.switch('browserid-login') %}
-        <script async defer src="https://browserid.org/include.js"></script>
+        <script async defer src="https://login.persona.org/include.js"></script>
       {% endif %}
       {{ js('zamboni/mobile') }}
     {% endblock %}


### PR DESCRIPTION
In particular the include.js ones will speed up page load by
eliminating an extra redirect over HTTPS.

Now that all of the browserid.org URLs are gone, there is no need
to whitelist that domain in the CSP headers.
