### PR TITLE
Workaround for test failure in test_monitor

### DIFF
--- a/apps/amo/monitors.py
+++ b/apps/amo/monitors.py
@@ -14,6 +14,7 @@ import requests
 from amo.utils import memoize
 from applications.management.commands import dump_apps
 from lib.crypto import receipt
+from lib.crypto.receipt import SigningError
 
 monitor_log = commonware.log.getLogger('z.monitor')
 
@@ -195,7 +196,7 @@ def signer():
 
     try:
         result = receipt.sign(data)
-    except receipt.SigningError as err:
+    except SigningError as err:
         msg = 'Error on signing (%s): %s' % (destination, err)
         return msg, msg
 

--- a/apps/amo/tests/test_monitor.py
+++ b/apps/amo/tests/test_monitor.py
@@ -20,7 +20,8 @@ class TestMonitor(amo.tests.TestCase):
 
     @patch('amo.monitors.receipt')
     def test_sign_fails(self, receipt):
-        receipt.sign.side_effect = receipt.SigningError
+        from lib.crypto.receipt import SigningError
+        receipt.sign.side_effect = SigningError
         eq_(signer()[0][:16], 'Error on signing')
 
     @patch('amo.monitors.receipt')


### PR DESCRIPTION
Mocking was getting in the way, resulting in different magic mock instances for the exception and the side_effect.
