### PR TITLE
Dynamic navigation tree support for fragments (bug 795185)

### DIFF
--- a/media/js/mkt/navigation.js
+++ b/media/js/mkt/navigation.js
@@ -6,6 +6,8 @@ var nav = (function() {
             type: 'root'
         }
     ];
+    // Ask potch.
+    var path_a = document.createElement('a');
 
     z.page.on('fragmentloaded', function(event, href, popped, state) {
 
@@ -16,6 +18,10 @@ var nav = (function() {
                 break;
             }
         }
+        // <ask potch>
+        path_a.href = state.path;
+        state.path = path_a.pathname;
+        // </ask>
 
         // Are we home? clear any history.
         if (state.type == 'root') {
@@ -30,6 +36,24 @@ var nav = (function() {
                 stack.shift();
             } else {
                 stack.unshift(state);
+            }
+
+            // Does the page have a parent? If so, handle the parent logic.
+            if (z.context.parent) {
+                var parent = _.indexOf(_.pluck(stack, 'path'), z.context.parent);
+
+                if (parent > 1) {
+                    // The parent is in the stack and it's not immediately
+                    // behind the current page in the stack.
+                    stack.splice(1, parent - 1);
+                    console.log('Closing navigation loop to parent (1 to ' + (parent - 1) + ')');
+                } else if (parent == -1) {
+                    // The parent isn't in the stack. Splice it in just below
+                    // where the value we just pushed in is.
+                    stack.splice(1, 0, {path: z.context.parent});
+                    console.log('Injecting parent into nav stack at 1');
+                }
+                console.log('New stack size: ' + stack.length);
             }
         }
 

--- a/mkt/account/templates/account/feedback.html
+++ b/mkt/account/templates/account/feedback.html
@@ -1,6 +1,7 @@
 {% extends 'mkt/base.html' %}
 
 {% set pagetitle = _('Feedback') %}
+{% set page_parent = '/' %}
 
 {% block content %}
     <section class="account">

--- a/mkt/account/templates/account/purchases.html
+++ b/mkt/account/templates/account/purchases.html
@@ -1,7 +1,8 @@
 {% extends 'mkt/base.html' %}
 
-{% set pagetitle = _('Apps') %}{
-% set cache_fragment = 'no' %}
+{% set pagetitle = _('Apps') %}
+{% set cache_fragment = 'no' %}
+{% set page_parent = '/' %}
 
 {% block content %}
   <section class="account full">

--- a/mkt/account/templates/account/settings.html
+++ b/mkt/account/templates/account/settings.html
@@ -3,6 +3,7 @@
 {% set pagetitle = _('Account Settings') %}
 {% set headertitle = _('Settings') %}
 {% set bodyclass = 'settings' %}
+{% set page_parent = '/' %}
 
 {% block content %}
   <section id="account-settings" class="account">

--- a/mkt/fragments/middleware.py
+++ b/mkt/fragments/middleware.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 from django.core.urlresolvers import resolve
 from django.utils.cache import patch_vary_headers
@@ -17,20 +18,37 @@ class HijackRedirectMiddleware(object):
                 request.POST.get('_hijacked', False) and
                 response.status_code in (301, 302)):
             view_url = location = response['Location']
+            frag_bust = response.get('x-frag-bust', None)
 
             # TODO: We should remove the need for this.
             if get_carrier():
                 # Strip carrier from URL.
                 view_url = '/' + '/'.join(location.split('/')[2:])
 
-            r = copy.copy(request)
-            r.method = 'GET'
+            req = copy.copy(request)
+            req.method = 'GET'
             # We want only the fragment response.
-            r.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+            req.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
             # Pass back the URI so we can pushState it.
-            r.FRAGMENT_URI = location
+            req.FRAGMENT_URI = location
+
             view = resolve(view_url)
-            response = view.func(r, *view.args, **view.kwargs)
+            response = view.func(req, *view.args, **view.kwargs)
+
+            response['X-URI'] = location
+            # If we have a fragment cache bust flag on the first request,
+            # perpetrate it on the new request.
+            if frag_bust:
+                # If there's a fragment bust flag in the new request, merge it
+                # with the flag from the old request in the second grossest
+                # possible way.
+                if 'x-frag-bust' in response:
+                    frag_bust = json.dumps(
+                        json.loads(frag_bust) +
+                        json.loads(response['x-frag-bust']))
+
+                response['x-frag-bust'] = frag_bust
+
         return response
 
 

--- a/mkt/fragments/tests/test_decorators.py
+++ b/mkt/fragments/tests/test_decorators.py
@@ -27,13 +27,13 @@ class TestBustFragmentCacheDecorator(BustFragmentCacheCase):
     def test_post(self):
         """Assert that bust_fragments_on_post only applies on POST."""
         self.meth_str_prefix(self.req)
-        self.assert_cookie_set('["/foo/bar"]')
+        self.assert_header_set('["/foo/bar"]')
 
     def test_not_post(self):
         """Assert that bust_fragments_on_post only applies on POST."""
         self.req.method = 'GET'
         self.meth_str_prefix(self.req)
-        self.assert_cookie_not_set()
+        self.assert_header_not_set()
 
     def test_not_weird_status_code(self):
         """
@@ -41,36 +41,36 @@ class TestBustFragmentCacheDecorator(BustFragmentCacheCase):
         """
         self.resp.status_code = 404
         self.meth_str_prefix(self.req)
-        self.assert_cookie_not_set()
+        self.assert_header_not_set()
 
     def test_list_post(self):
         """Test that a list is correctly encoded for busting."""
         self.meth_list_prefix(self.req)
-        self.assert_cookie_set('["/foo/bar", "/zip/zap"]')
+        self.assert_header_set('["/foo/bar", "/zip/zap"]')
 
     def test_only_2xx(self):
         self.meth_2xx_prefix(self.req)
-        self.assert_cookie_set('["/foo/bar"]')
+        self.assert_header_set('["/foo/bar"]')
 
     def test_only_3xx(self):
         self.resp.status_code = 301
         self.meth_3xx_prefix(self.req)
-        self.assert_cookie_set('["/foo/bar"]')
+        self.assert_header_set('["/foo/bar"]')
 
     def test_not_2xx(self):
         self.resp.status_code = 301
         self.meth_2xx_prefix(self.req)
-        self.assert_cookie_not_set()
+        self.assert_header_not_set()
 
     def test_not_3xx(self):
         self.meth_3xx_prefix(self.req)
-        self.assert_cookie_not_set()
+        self.assert_header_not_set()
 
     meth_formatted_prefix = static_bfop(url_prefix='/foo/{1}/{asdf}')
 
     def test_formatted_prefix(self):
         self.meth_formatted_prefix(self.req, 'first', 'second', asdf='kw')
-        self.assert_cookie_set('["/foo/second/kw"]')
+        self.assert_header_set('["/foo/second/kw"]')
 
     @raises(AssertionError)
     def test_decorator_order(self):

--- a/mkt/fragments/tests/test_middleware.py
+++ b/mkt/fragments/tests/test_middleware.py
@@ -18,6 +18,8 @@ class TestHijackRedirectMiddleware(amo.tests.TestCase):
     def test_post_synchronous(self):
         res = self.client.post(self.url, {'display_name': 'omg'})
         self.assert3xx(res, self.url)
+        assert res['Location']
+        assert 'X-URI' not in res
 
     def test_unhijacked_ajax(self):
         res = self.client.post_ajax(self.url, {'display_name': 'omg'})
@@ -29,6 +31,8 @@ class TestHijackRedirectMiddleware(amo.tests.TestCase):
         eq_(res.status_code, 200)
         eq_(json.loads(pq(res.content)('#page').attr('data-context'))['uri'],
             self.url)
+        assert 'Location' not in res
+        assert res['X-URI']
 
     def test_post_ajax_carrier(self):
         url = '/telefonica' + self.url

--- a/mkt/fragments/tests/test_utils.py
+++ b/mkt/fragments/tests/test_utils.py
@@ -1,4 +1,7 @@
 import mock
+from nose.tools import eq_
+
+from django.http import HttpResponse
 
 import amo.tests
 from mkt.fragments.utils import bust_fragments
@@ -10,16 +13,16 @@ class BustFragmentCacheCase(object):
         self.req = mock.Mock()
         self.req.method = 'POST'
 
-        self.resp = mock.Mock()
+        self.resp = HttpResponse()
         self.resp.status_code = 200
 
         self.req.response = self.resp
 
-    def assert_cookie_not_set(self):
-        assert not self.resp.set_cookie.called
+    def assert_header_not_set(self):
+        assert 'x-frag-bust' not in self.resp
 
-    def assert_cookie_set(self, value):
-        self.resp.set_cookie.assert_called_with('fcbust', value)
+    def assert_header_set(self, value):
+        eq_(self.resp['x-frag-bust'], value)
 
 
 class TestBustFragmentCache(BustFragmentCacheCase):
@@ -27,15 +30,15 @@ class TestBustFragmentCache(BustFragmentCacheCase):
     def test_min_args(self):
         """Assert that bust_fragments applies with the minimum args."""
         bust_fragments(self.resp, '/foo/bar')
-        self.assert_cookie_set('["/foo/bar"]')
+        self.assert_header_set('["/foo/bar"]')
 
     def test_list(self):
         """Assert that bust_fragments applies a list properly."""
         bust_fragments(self.resp, ['/foo/bar', '/zip/zap'])
-        self.assert_cookie_set('["/foo/bar", "/zip/zap"]')
+        self.assert_header_set('["/foo/bar", "/zip/zap"]')
 
     def test_formatted_prefix(self):
         """Assert that bust_fragments formats (kw)?args into the URLs ok."""
         bust_fragments(self.resp, '/foo/{1}/{asdf}', 'first', 'second',
                        asdf='kw')
-        self.assert_cookie_set('["/foo/second/kw"]')
+        self.assert_header_set('["/foo/second/kw"]')

--- a/mkt/fragments/utils.py
+++ b/mkt/fragments/utils.py
@@ -39,4 +39,4 @@ def bust_fragments(response, prefix, *args, **kwargs):
     prefix = json.dumps(prefix)
 
     # At this point, we know we're busting the fragment cache.
-    response.set_cookie('fcbust', prefix)
+    response['x-frag-bust'] = prefix

--- a/mkt/ratings/templates/ratings/add.html
+++ b/mkt/ratings/templates/ratings/add.html
@@ -1,11 +1,5 @@
 {% from 'includes/forms.html' import required_note %}
 
-{# TODO:
-#
-# This page should be replaced with an overlay: http://cl.ly/0o1E1z0i0M3B1C1B2D3e
-#
-#}
-
 {% extends 'mkt/base.html' %}
 
 {% set cache_fragment = 'no' %}

--- a/mkt/ratings/templates/ratings/listing.html
+++ b/mkt/ratings/templates/ratings/listing.html
@@ -4,6 +4,7 @@
 {% set pagetitle = _('Reviews for {0}')|f(product.name) %}
 {% set headertitle = _('Reviews') %}
 {% set bodyclass = 'reviews-listing' %}
+{% set page_parent = product.get_detail_url() %}
 
 {% block extrahead %}
   {{ super() }}

--- a/mkt/ratings/views.py
+++ b/mkt/ratings/views.py
@@ -252,4 +252,5 @@ def add(request, addon):
                         {'product': addon, 'form': form,
                          'support_url': support_url,
                          'has_review': has_review,
-                         'support_email': support_email})
+                         'support_email': support_email,
+                         'page_parent': addon.get_detail_url()})

--- a/mkt/templates/mkt/base.html
+++ b/mkt/templates/mkt/base.html
@@ -71,11 +71,12 @@
       <div id="page" role="main"
            data-context="{{
              {'type': pagetype or 'leaf',
-              'title': titletag,
               'cache': cache_fragment,
               'hash': get_media_hash(),
+              'title': titletag,
               'headertitle': headertitle,
               'bodyclass': bodyclass or '',
+              'parent': page_parent or '',
               'category': category.name ~ '' if category else ''}|json }}">
         {# `outer_content` is for stuff you want above `content` on every page. #}
         {% block outer_content %}

--- a/mkt/templates/mkt/fragment.html
+++ b/mkt/templates/mkt/fragment.html
@@ -7,6 +7,7 @@
         'title': titletag,
         'headertitle': headertitle,
         'bodyclass': bodyclass or '',
+        'parent': page_parent or '',
         'category': category.name ~ '' if category else ''}|json }}">
   {# `outer_content` is for stuff you want above `content` on every page. #}
   {% block outer_content %}


### PR DESCRIPTION
- Fixes POST hijacking
- Fixes Django cookie munching (replaced cookie code w/headers)
- Fixed @cvan's weird hijack post middleware for header support
- Add parent page support, parent declarations
- Strip query parameter in navigation stack
- Removed Herobrine
