### PR TITLE
deploy app to all servers before restarting services

### DIFF
--- a/scripts/update/update.py
+++ b/scripts/update/update.py
@@ -105,6 +105,7 @@ def install_cron(ctx):
 def deploy_app(ctx):
     ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
 
+
 @hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def restart_services(ctx):
     if getattr(settings, 'GUNICORN', False):


### PR DESCRIPTION
This should fix issues with CDN assets being out of sync during pushes.
