### PR TITLE
bug 821015 - corrected the namespace for the Sentry client 

### DIFF
--- a/sites/dev/settings_mkt.py
+++ b/sites/dev/settings_mkt.py
@@ -156,5 +156,4 @@ WEBTRENDS_PASSWORD = private_mkt.WEBTRENDS_PASSWORD
 # Allow /developers/?refresh to refresh all MDN content for Developer Hub.
 MDN_LAZY_REFRESH = True
 
-# Bug 792436
-SENTRY_CLIENT = 'djangometlog.raven.MetlogDjangoClient'
+SENTRY_CLIENT = 'djangoraven.metlog.MetlogDjangoClient'

--- a/sites/prod/settings_mkt.py
+++ b/sites/prod/settings_mkt.py
@@ -114,4 +114,4 @@ CARRIER_URLS = splitstrip(private_mkt.CARRIER_URLS)
 WEBTRENDS_USERNAME = private_mkt.WEBTRENDS_USERNAME
 WEBTRENDS_PASSWORD = private_mkt.WEBTRENDS_PASSWORD
 
-SENTRY_CLIENT = 'djangometlog.raven.MetlogDjangoClient'
+SENTRY_CLIENT = 'djangoraven.metlog.MetlogDjangoClient'


### PR DESCRIPTION
the namespace for the sentry client was improperly specified as djangometlog.raven instead of the correct version -  djangoraven.metlog
