### PR TITLE
Bug 543047: Prevent editors from deleting reviews for their own add-ons:

### DIFF
--- a/apps/editors/templates/editors/queue.html
+++ b/apps/editors/templates/editors/queue.html
@@ -76,7 +76,7 @@
           {{ csrf() }}
           {{ reviews_formset.management_form }}
           {% for review in reviews_formset.forms %}
-          <div class="review-flagged">
+          <div class="review-flagged{%- if not check_review_delete(review.instance) %} disabled{% endif %}">
             <div class="review-flagged-actions">
               {{ review.errors }}
               <strong>{{ _('Moderation actions:') }}</strong>

--- a/apps/reviews/forms.py
+++ b/apps/reviews/forms.py
@@ -72,8 +72,11 @@ class BaseReviewFlagFormSet(BaseModelFormSet):
         super(BaseReviewFlagFormSet, self).__init__(*args, **kwargs)
 
     def save(self):
+        from reviews.helpers import user_can_delete_review
+
         for form in self.forms:
-            if form.cleaned_data:
+            if form.cleaned_data and user_can_delete_review(self.request,
+                                                            form.instance):
                 action = int(form.cleaned_data['action'])
 
                 is_flagged = (form.instance.reviewflag_set.count() > 0)

--- a/apps/reviews/helpers.py
+++ b/apps/reviews/helpers.py
@@ -75,9 +75,10 @@ def user_can_delete_review(request, review):
     is_author = review.addon.has_author(request.user)
     return (
         review.user_id == request.user.id or
-        (is_editor and not is_author) or
-        acl.action_allowed(request, 'Users', 'Edit') or
-        acl.action_allowed(request, 'Addons', 'Edit'))
+        not is_author and (
+            is_editor or
+            acl.action_allowed(request, 'Users', 'Edit') or
+            acl.action_allowed(request, 'Addons', 'Edit')))
 
 
 @jingo.register.function

--- a/media/css/zamboni/zamboni.css
+++ b/media/css/zamboni/zamboni.css
@@ -132,6 +132,13 @@ ul.errorlist {
     color: #ccc;
 }
 
+.disabled,
+.disabled a[href],
+.disabled label,
+.disabled h3 {
+    color: #888 !important;
+}
+
 /************************************/
 /*             GRADIENTS            */
 /************************************/

--- a/media/js/zamboni/reviews.js
+++ b/media/js/zamboni/reviews.js
@@ -106,4 +106,6 @@ $(document).ready(function() {
     });
 
     $("select[name='rating']").ratingwidget();
+
+    $('.review-flagged.disabled input').attr('disabled', true);
 });


### PR DESCRIPTION
• Prevents senior editors from deleting reviews on their own add-ons
 • Prevents all editors from deleting their own reviews from the editor tools
 • Displays flagged reviews for editors' own add-ons as disabled in the queues.
