### PR TITLE
A few wording changes for the automated review emails.

### DIFF
--- a/mkt/reviewers/templates/reviewers/emails/decisions/info.txt
+++ b/mkt/reviewers/templates/reviewers/emails/decisions/info.txt
@@ -8,4 +8,7 @@ URL: {{ detail_url }}
 {{ reviewer }} wrote:
 
 {{ comments }}
+
+Please reply to this email to supply the information requested.
+
 {% endblock %}

--- a/mkt/reviewers/templates/reviewers/emails/decisions/pending_to_public.txt
+++ b/mkt/reviewers/templates/reviewers/emails/decisions/pending_to_public.txt
@@ -1,6 +1,8 @@
 {% extends 'reviewers/emails/base.txt' %}
 {% block content %}
-Congratulations! Your App has been approved for the Firefox Marketplace and will be available for download in the coming weeks. Follow Mozilla Hacks (http://hacks.mozilla.org, http://twitter.com/mozhacks) to stay updated on when we plan to open for consumer testing and App installation.
+Congratulations! Your app has been approved for the Firefox Marketplace and will be available for installation by Firefox users within a few minutes.
+
+Follow Mozilla Hacks (http://hacks.mozilla.org, http://twitter.com/mozhacks) to stay updated on when we plan to launch on other platforms.
 
 {% include 'reviewers/emails/decisions/includes/details.txt' %}
 

--- a/mkt/reviewers/templates/reviewers/emails/decisions/pending_to_public_waiting.txt
+++ b/mkt/reviewers/templates/reviewers/emails/decisions/pending_to_public_waiting.txt
@@ -1,8 +1,8 @@
 {% extends 'reviewers/emails/base.txt' %}
 {% block content %}
-Congratulations! Your App has been approved for the Firefox Marketplace. Because you requested to make the App available to public when you want, you will need to log into the Firefox Marketplace and make it public manually. To enable it, visit its <a href="{{ status_url }}">Manage Status page</a>.
+Congratulations! Your App has been approved for the Firefox Marketplace. Because you requested to make the App available to public when you want, you will need to log into the Firefox Marketplace and make it public manually. To enable it, visit its Manage Status page ({{ status_url }}). (If you did not request a publishing delay read the reviewer comments below for more details).
 
-Follow Mozilla Hacks (http://hacks.mozilla.org, http://twitter.com/mozhacks) to stay updated on when we plan to open for consumer testing and App installation.
+Follow Mozilla Hacks (http://hacks.mozilla.org, http://twitter.com/mozhacks) to stay updated on when we plan to launch on other platforms.
 
 {% include 'reviewers/emails/decisions/includes/details.txt' %}
 


### PR DESCRIPTION
The emails still implied we were still in closed beta.  And the info email didn't actually say to email us in response.
