### PR TITLE
introducing FactoryBro, AddonFactory, and AppFactory

### DIFF
--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -19,7 +19,7 @@ from addons.models import (Addon, AddonCategory, AddonDeviceType, AddonPremium,
                            BlacklistedSlug, Category, Preview, version_changed)
 from addons.signals import version_changed as version_changed_signal
 from amo.helpers import absolutify
-from amo.tests import app_factory, version_factory
+from amo.tests import AppFactory, version_factory
 from amo.urlresolvers import reverse
 from constants.applications import DEVICE_TYPES
 from editors.models import RereviewQueue
@@ -264,10 +264,10 @@ class TestWebapp(amo.tests.TestCase):
             sorted(w2_regions))
 
     def test_package_helpers(self):
-        app1 = app_factory()
-        eq_(app1.is_packaged, False)
-        app2 = app_factory(is_packaged=True)
-        eq_(app2.is_packaged, True)
+        app = AppFactory()
+        eq_(app.is_packaged, False)
+        app.is_packaged = True
+        eq_(app.is_packaged, True)
 
     def test_package_no_version(self):
         webapp = Webapp.objects.create(manifest_url='http://foo.com')
@@ -356,7 +356,7 @@ class TestWebappManager(amo.tests.TestCase):
 
     def test_listed(self):
         # Public status, non-null current version, non-user-disabled.
-        w = app_factory(status=amo.STATUS_PUBLIC)
+        w = AppFactory.create(status=amo.STATUS_PUBLIC)
         self.listed_eq([w])
 
     def test_unlisted(self):
@@ -1020,35 +1020,35 @@ class TestUpdateStatus(amo.tests.TestCase):
         eq_(app.status, amo.STATUS_NULL)
 
     def test_only_version_deleted(self):
-        app = amo.tests.app_factory(status=amo.STATUS_REJECTED)
+        app = AppFactory.create(status=amo.STATUS_REJECTED)
         app.current_version.delete()
         app.update_status()
         eq_(app.status, amo.STATUS_NULL)
 
     def test_other_version_deleted(self):
-        app = amo.tests.app_factory(status=amo.STATUS_REJECTED)
+        app = AppFactory.create(status=amo.STATUS_REJECTED)
         amo.tests.version_factory(addon=app)
         app.current_version.delete()
         app.update_status()
         eq_(app.status, amo.STATUS_REJECTED)
 
     def test_one_version_pending(self):
-        app = amo.tests.app_factory(status=amo.STATUS_REJECTED,
-                                    file_kw=dict(status=amo.STATUS_DISABLED))
+        app = AppFactory.create(status=amo.STATUS_REJECTED,
+                               file_kw=dict(status=amo.STATUS_DISABLED))
         amo.tests.version_factory(addon=app,
                                   file_kw=dict(status=amo.STATUS_PENDING))
         app.update_status()
         eq_(app.status, amo.STATUS_PENDING)
 
     def test_one_version_public(self):
-        app = amo.tests.app_factory(status=amo.STATUS_PUBLIC)
+        app = AppFactory.create(status=amo.STATUS_PUBLIC)
         amo.tests.version_factory(addon=app,
                                   file_kw=dict(status=amo.STATUS_DISABLED))
         app.update_status()
         eq_(app.status, amo.STATUS_PUBLIC)
 
     def test_blocklisted(self):
-        app = amo.tests.app_factory(status=amo.STATUS_BLOCKED)
+        app = AppFactory.create(status=amo.STATUS_BLOCKED)
         app.current_version.delete()
         app.update_status()
         eq_(app.status, amo.STATUS_BLOCKED)

--- a/mkt/webapps/tests/test_tasks.py
+++ b/mkt/webapps/tests/test_tasks.py
@@ -61,7 +61,7 @@ class TestUpdateManifest(amo.tests.TestCase):
     def setUp(self):
         UserProfile.objects.get_or_create(id=settings.TASK_USER_ID)
 
-        self.addon = amo.tests.app_factory()
+        self.addon = AppFactory.create()
         self.version = self.addon.versions.latest()
         self.file = self.version.files.latest()
         self.file.update(hash=ohash)

--- a/mkt/webapps/tests/test_views.py
+++ b/mkt/webapps/tests/test_views.py
@@ -1,5 +1,5 @@
 import amo
-from amo.tests import app_factory
+from amo.tests import AppFactory
 from market.models import AddonPremium, Price
 from mkt.webapps.models import Webapp
 
@@ -8,10 +8,10 @@ class PaidAppMixin(object):
 
     def setup_paid(self, type_=None):
         type_ = amo.ADDON_PREMIUM if type_ is None else type_
-        self.free = [Webapp.objects.get(id=337141), app_factory()]
+        self.free = [Webapp.objects.get(id=337141), AppFactory.create()]
         self.paid = []
         for x in xrange(1, 3):
-            app = app_factory(weekly_downloads=x * 100)
+            app = AppFactory.create(weekly_downloads=x * 100)
             if type_ in amo.ADDON_PREMIUMS:
                 price = Price.objects.create(price=x)
                 AddonPremium.objects.create(price=price, addon=app)
@@ -21,14 +21,14 @@ class PaidAppMixin(object):
                 self.free.append(app)
 
         # For measure add some disabled free apps ...
-        app_factory(disabled_by_user=True)
-        app_factory(status=amo.STATUS_NULL)
+        AppFactory.create(disabled_by_user=True)
+        AppFactory.create(status=amo.STATUS_NULL)
 
         # ... and some disabled paid apps.
         price = Price.objects.create(price='50.00')
-        a = app_factory(disabled_by_user=True, premium_type=amo.ADDON_PREMIUM)
+        a = AppFactory.create(disabled_by_user=True, premium_type=amo.ADDON_PREMIUM)
         AddonPremium.objects.create(price=price, addon=a)
-        a = app_factory(status=amo.STATUS_NULL, premium_type=amo.ADDON_PREMIUM)
+        a = AppFactory.create(status=amo.STATUS_NULL, premium_type=amo.ADDON_PREMIUM)
         AddonPremium.objects.create(price=price, addon=a)
 
         self.both = sorted(self.free + self.paid,


### PR DESCRIPTION
let's you create `Addon` objects (unsaved or saved) with some nice defaults. this is an improvement to the previous `addon_factory` which did 4 saves. and it speeds up tests a tad:

```
 (z)(Chris-MacBook-Pro.local) %% python /opt/speed.py factories "webapps search"                                                                                                    /opt/zamboni (factories)Benchmarks for webapps search:
 After (factories):
      Dropping database ...
      Trial 1:
           Ran 181 tests in 33.986s
      Dropping database ...
      Trial 2:
           Ran 181 tests in 31.541s
      Dropping database ...
      Trial 3:
           Ran 181 tests in 31.702s
      Dropping database ...
      Trial 4:
           Ran 181 tests in 31.457s
      Dropping database ...
      Trial 5:
           Ran 181 tests in 31.730s
      Total duration: 160.4160s
      Average time per trial: 32.0832s
 Before (master):
      Dropping database ...
      Trial 1:
           Ran 181 tests in 41.873s
      Dropping database ...
      Trial 2:
           Ran 181 tests in 43.294s
      Dropping database ...
      Trial 3:
           Ran 181 tests in 39.206s
      Dropping database ...
      Trial 4:
           Ran 181 tests in 35.471s
      Dropping database ...
      Trial 5:
           Ran 181 tests in 35.499s
      Total duration: 195.3430s
      Average time per trial: 39.0686s
 Before (195.3430 / 5) vs. After (160.4160 / 5) => 6.9854s faster (1.2177x speedup)
```
