### PR TITLE
bug 822759 - more debugging patches to diagnose problem in -dev

### DIFF
--- a/mkt/zadmin/tests/test_views.py
+++ b/mkt/zadmin/tests/test_views.py
@@ -4,7 +4,6 @@ import json
 
 from django.conf import settings
 from nose.tools import eq_
-from nose import SkipTest
 from pyquery import PyQuery as pq
 
 import amo
@@ -51,7 +50,6 @@ class TestGenerateError(amo.tests.TestCase):
         self.metlog.sender.msgs.clear()
 
     def test_metlog_statsd(self):
-        raise SkipTest("this always passes in test, but not on -dev")
         self.url = reverse('zadmin.generate-error')
         self.client.post(self.url,
                          {'error': 'metlog_statsd'})
@@ -67,7 +65,6 @@ class TestGenerateError(amo.tests.TestCase):
         eq_(msg['fields']['name'], 'z.zadmin')
 
     def test_metlog_json(self):
-        raise SkipTest("this always passes in test, but not on -dev")
         self.url = reverse('zadmin.generate-error')
         self.client.post(self.url,
                          {'error': 'metlog_json'})
@@ -81,7 +78,6 @@ class TestGenerateError(amo.tests.TestCase):
         eq_(msg['fields']['secret'], 42)
 
     def test_metlog_cef(self):
-        raise SkipTest("this always passes in test, but not on -dev")
         self.url = reverse('zadmin.generate-error')
         self.client.post(self.url,
                          {'error': 'metlog_cef'})
@@ -93,7 +89,6 @@ class TestGenerateError(amo.tests.TestCase):
         eq_(msg['logger'], 'zamboni')
 
     def test_metlog_sentry(self):
-        raise SkipTest("this always passes in test, but not on -dev")
         self.url = reverse('zadmin.generate-error')
         self.client.post(self.url,
                          {'error': 'metlog_sentry'})

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -44,7 +44,7 @@ html5lib==0.90
 httplib2==0.7.6
 importlib==1.0.2
 kombu==2.1.2
-metlog-py==0.9.9
+metlog-py==0.9.10
 metlog-cef==0.2
 metlog-raven==0.3
 mimeparse==0.1.3

--- a/sites/dev/settings_addons.py
+++ b/sites/dev/settings_addons.py
@@ -80,6 +80,20 @@ AMO_LANGUAGES = AMO_LANGUAGES + ('dbg',)
 LANGUAGES = lazy(lazy_langs, dict)(AMO_LANGUAGES)
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
 
-METLOG_CONF['logger'] = 'addons-dev'
-METLOG_CONF['plugins']['raven'] = ('metlog_raven.raven_plugin:config_plugin', {'dsn': private_addons.SENTRY_DSN})
+METLOG_CONF = {
+    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {}),
+                'raven': (
+                    'metlog_raven.raven_plugin:config_plugin', {'dsn': private_addons.SENTRY_DSN}),
+        },
+    'sender': {
+        'class': 'metlog.senders.UdpSender',
+        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
+        'port': private.METLOG_CONF_SENDER_PORT,
+    },
+    'logger': 'addons-dev',
+}
+
 METLOG = client_from_dict_config(METLOG_CONF)
+
+USE_METLOG_FOR_CEF = True
+USE_METLOG_FOR_RAVEN = False

--- a/sites/dev/settings_base.py
+++ b/sites/dev/settings_base.py
@@ -188,16 +188,4 @@ XSENDFILE_HEADER = 'X-Accel-Redirect'
 
 GEOIP_NOOP = 0
 
-METLOG_CONF = {
-    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {})},
-    'sender': {
-        'class': 'metlog.senders.UdpSender',
-        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
-        'port': private.METLOG_CONF_SENDER_PORT,
-    },
-}
-
-USE_METLOG_FOR_CEF = True
-USE_METLOG_FOR_RAVEN = False
-
 ALLOW_SELF_REVIEWS = True

--- a/sites/dev/settings_mkt.py
+++ b/sites/dev/settings_mkt.py
@@ -146,10 +146,21 @@ SIGNED_APPS_SERVER = private_mkt.SIGNED_APPS_SERVER
 SIGNED_APPS_REVIEWER_SERVER_ACTIVE = True
 SIGNED_APPS_REVIEWER_SERVER = private_mkt.SIGNED_APPS_REVIEWER_SERVER
 
-METLOG_CONF['logger'] = 'addons-marketplace-dev'
-METLOG_CONF['plugins']['raven'] = (
-    'metlog_raven.raven_plugin:config_plugin', {'dsn': SENTRY_DSN})
+METLOG_CONF = {
+    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {}),
+                'raven': (
+                    'metlog_raven.raven_plugin:config_plugin', {'dsn': SENTRY_DSN}),
+        },
+    'sender': {
+        'class': 'metlog.senders.UdpSender',
+        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
+        'port': private.METLOG_CONF_SENDER_PORT,
+    },
+    'logger': 'addons-marketplace-dev',
+}
 METLOG = client_from_dict_config(METLOG_CONF)
+USE_METLOG_FOR_CEF = True
+USE_METLOG_FOR_RAVEN = False
 
 WEBTRENDS_USERNAME = private_mkt.WEBTRENDS_USERNAME
 WEBTRENDS_PASSWORD = private_mkt.WEBTRENDS_PASSWORD


### PR DESCRIPTION
- re-enabled the tests for test_metlog_*
- added double logging for each of the generate_error events that
  route through metlog. one through the default metlog instance,
  another through the local metlog client instance
- bumped to metlog-py 0.9.10 to see the full client configuration as a
  JSON blob
- pulled out all METLOG_CONF configuration from settings_base and just
  set it at once.  This has to be done in settings_mkt.py and
  settings_addons.py

I've uploaded a new version of metlog 0.9.10 into pyrepo1:/data/pyrepo
