### PR TITLE
bug 822759 - testing patch to re-break metlog 

### DIFF
--- a/apps/zadmin/forms.py
+++ b/apps/zadmin/forms.py
@@ -329,19 +329,23 @@ class GenerateErrorForm(happyforms.Form):
                             'logger_type': 'settings.METLOG'})
 
         elif error == 'metlog_sentry':
+            # These are local variables only used
+            # by Sentry's frame hacking magic.  
+            # They won't be referenced which may trigger flake8
+            # errors.
+            metlog_conf = settings.METLOG_CONF  # NOQA
+            active_metlog_conf = settings.METLOG._config  # NOQA
+
             # Try to fire off two messages to verify that we don't
             # have some kind of transient issue where settings.METLOG
             # doesn't work
+
             try:
                 2 / 0
             except:
-                new_metlog.raven('new_metlog: metlog_sentry error triggered',
-                            metlog_conf=settings.METLOG_CONF,
-                            active_metlog_conf=settings.METLOG._config,)
+                new_metlog.raven('new_metlog: metlog_sentry error triggered')
             finally:
                 try:
                     1 / 0
                 except:
-                    settings.METLOG.raven('metlog_sentry error triggered',
-                            metlog_conf=settings.METLOG_CONF,
-                            active_metlog_conf=settings.METLOG._config,)
+                    settings.METLOG.raven('metlog_sentry error triggered')

--- a/sites/dev/settings_addons.py
+++ b/sites/dev/settings_addons.py
@@ -80,20 +80,6 @@ AMO_LANGUAGES = AMO_LANGUAGES + ('dbg',)
 LANGUAGES = lazy(lazy_langs, dict)(AMO_LANGUAGES)
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
 
-METLOG_CONF = {
-    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {}),
-                'raven': (
-                    'metlog_raven.raven_plugin:config_plugin', {'dsn': private_addons.SENTRY_DSN}),
-        },
-    'sender': {
-        'class': 'metlog.senders.UdpSender',
-        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
-        'port': private.METLOG_CONF_SENDER_PORT,
-    },
-    'logger': 'addons-dev',
-}
-
+METLOG_CONF['logger'] = 'addons-dev'
+METLOG_CONF['plugins']['raven'] = ('metlog_raven.raven_plugin:config_plugin', {'dsn': private_addons.SENTRY_DSN})
 METLOG = client_from_dict_config(METLOG_CONF)
-
-USE_METLOG_FOR_CEF = True
-USE_METLOG_FOR_RAVEN = False

--- a/sites/dev/settings_base.py
+++ b/sites/dev/settings_base.py
@@ -188,4 +188,16 @@ XSENDFILE_HEADER = 'X-Accel-Redirect'
 
 GEOIP_NOOP = 0
 
+METLOG_CONF = {
+    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {})},
+    'sender': {
+        'class': 'metlog.senders.UdpSender',
+        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
+        'port': private.METLOG_CONF_SENDER_PORT,
+    },
+}
+
+USE_METLOG_FOR_CEF = True
+USE_METLOG_FOR_RAVEN = False
+
 ALLOW_SELF_REVIEWS = True

--- a/sites/dev/settings_mkt.py
+++ b/sites/dev/settings_mkt.py
@@ -146,21 +146,10 @@ SIGNED_APPS_SERVER = private_mkt.SIGNED_APPS_SERVER
 SIGNED_APPS_REVIEWER_SERVER_ACTIVE = True
 SIGNED_APPS_REVIEWER_SERVER = private_mkt.SIGNED_APPS_REVIEWER_SERVER
 
-METLOG_CONF = {
-    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {}),
-                'raven': (
-                    'metlog_raven.raven_plugin:config_plugin', {'dsn': SENTRY_DSN}),
-        },
-    'sender': {
-        'class': 'metlog.senders.UdpSender',
-        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
-        'port': private.METLOG_CONF_SENDER_PORT,
-    },
-    'logger': 'addons-marketplace-dev',
-}
+METLOG_CONF['logger'] = 'addons-marketplace-dev'
+METLOG_CONF['plugins']['raven'] = (
+    'metlog_raven.raven_plugin:config_plugin', {'dsn': SENTRY_DSN})
 METLOG = client_from_dict_config(METLOG_CONF)
-USE_METLOG_FOR_CEF = True
-USE_METLOG_FOR_RAVEN = False
 
 WEBTRENDS_USERNAME = private_mkt.WEBTRENDS_USERNAME
 WEBTRENDS_PASSWORD = private_mkt.WEBTRENDS_PASSWORD


### PR DESCRIPTION
This patch should cause the settings.METLOG instance to stop working.

If that happens, then the cause of metlog not working in zamboni is due to configuring METLOG_CONF in multiple settings_\* files.

Changes:
- i expect that this will cause the settings.METLOG instance to stop working in the admin.explode() page
- also reverted the use of kwargs and switched back to using local variables for sentry
