### PR TITLE
Update app name when new version approved (bug 828738)

### DIFF
--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -1840,6 +1840,12 @@ class TestUpdateNames(amo.tests.TestCase):
         self.check_names(names)
         eq_(self.addon.reload().default_locale, 'de')
 
+    def test_default_locale_removal_not_deleted(self):
+        names = {'en-US': None}
+        self.addon.update_names(names)
+        self.addon.save()
+        self.check_names(self.names)
+
 
 class TestAddonWatchDisabled(amo.tests.TestCase):
 

--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -38,6 +38,7 @@ from files.helpers import copyfileobj
 from files.models import File, Platform
 from lib.es.signals import reset, process
 from market.models import AddonPremium, Price, PriceCurrency
+from translations.models import Translation
 from versions.models import ApplicationsVersions, Version
 
 import mkt
@@ -435,6 +436,11 @@ class TestCase(RedisTest, test_utils.TestCase):
 
     def login(self, profile):
         assert self.client.login(username=profile.email, password='password')
+
+    def trans_eq(self, trans, locale, localized_string):
+        eq_(Translation.objects.get(id=trans.id,
+                                    locale=locale).localized_string,
+            localized_string)
 
 
 class AMOPaths(object):

--- a/apps/amo/utils.py
+++ b/apps/amo/utils.py
@@ -1068,6 +1068,9 @@ def find_language(locale):
     """
     Return a locale we support, or None.
     """
+    if not locale:
+        return None
+
     LANGS = settings.AMO_LANGUAGES + settings.HIDDEN_LANGUAGES
 
     if locale in LANGS:

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -463,12 +463,14 @@ class TestPublicise(amo.tests.TestCase):
         eq_(res.status_code, 302)
         eq_(self.get_webapp().status, amo.STATUS_PUBLIC_WAITING)
 
-    def test_publicise(self):
+    @mock.patch('mkt.webapps.models.Webapp.update_name_from_package_manifest')
+    def test_publicise(self, update):
         res = self.client.post(self.publicise_url)
         eq_(res.status_code, 302)
         eq_(self.get_webapp().status, amo.STATUS_PUBLIC)
         eq_(self.get_webapp().versions.latest().all_files[0].status,
             amo.STATUS_PUBLIC)
+        assert update.called
 
     def test_status(self):
         res = self.client.get(self.status_url)

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -182,6 +182,8 @@ def publicise(request, addon_id, addon):
         amo.log(amo.LOG.CHANGE_STATUS, addon.get_status_display(), addon)
         # Call update_version, so various other bits of data update.
         addon.update_version()
+        # Call to update names if they changed.
+        addon.update_name_from_package_manifest()
     return redirect(addon.get_dev_url('versions'))
 
 

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -170,6 +170,7 @@ class ReviewApp(ReviewBase):
                            highest_status=amo.STATUS_PUBLIC)
         # Call update_version, so various other bits of data update.
         self.addon.update_version()
+        self.addon.update_name_from_package_manifest()
         self.addon.sign_if_packaged(self.version.pk)
 
         self.log_action(amo.LOG.APPROVE_VERSION)

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -273,7 +273,7 @@ def app_review(request, addon):
         resp = _review(request, addon)
     except SigningError, exc:
         transaction.rollback()
-        messages.error(request, 'Signing Error: %s' % exc.message)
+        messages.error(request, 'Signing Error: %s' % exc)
         transaction.commit()
         return redirect(
             reverse('reviewers.apps.review', args=[addon.app_slug]))

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -1,0 +1,13 @@
+def get_locale_properties(manifest, property, default_locale=None):
+    locale_dict = {}
+    for locale in manifest.get('locales', {}):
+        if property in manifest['locales'][locale]:
+            locale_dict[locale] = manifest['locales'][locale][property]
+
+    # Add in the default locale name.
+    default = manifest.get('default_locale') or default_locale
+    root_property = manifest.get(property)
+    if default and root_property:
+        locale_dict[default] = root_property
+
+    return locale_dict


### PR DESCRIPTION
This will update the Marketplace name and translations (and possibly default_locale) when an updated version of a packaged app is approved by a reviewer or publicized by a dev.
