### PR TITLE
Fix review moderation queue when disabled reviews are on a page.

### DIFF
--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -421,8 +421,13 @@ def queue_moderated(request):
                                         queryset=page.object_list,
                                         request=request)
 
-    if reviews_formset.is_valid():
-        reviews_formset.save()
+    if request.method == 'POST':
+        if reviews_formset.is_valid():
+            reviews_formset.save()
+        else:
+            amo.messages.error(
+                request, ' '.join(e.as_text() or _('An unknown error occurred')
+                                  for e in reviews_formset.errors))
         return redirect(reverse('editors.queue_moderated'))
 
     return jingo.render(request, 'editors/queue.html',

--- a/media/js/zamboni/reviews.js
+++ b/media/js/zamboni/reviews.js
@@ -107,5 +107,5 @@ $(document).ready(function() {
 
     $("select[name='rating']").ratingwidget();
 
-    $('.review-flagged.disabled input').attr('disabled', true);
+    $('.review-flagged.disabled input:not([type=hidden])').attr('disabled', true);
 });


### PR DESCRIPTION
Review queue moderation is failing when disabled reviews are on a page, since the `disabled` attribute on the ID inputs are causing the formset to fail validation.
