### PR TITLE
fix for bug 834593 Dividers on search pages do not match mocks

### DIFF
--- a/media/css/mkt/desktop.less
+++ b/media/css/mkt/desktop.less
@@ -202,6 +202,11 @@ body {
     border: 1px solid rgba(0,0,0,.04);
 }
 
+.container.listing {
+    // Fix: 834593
+    background-color: rgba(255,255,255,.25);
+}
+
 .container {
     &.product-details,
     &.results,


### PR DESCRIPTION
This changes the colour of the background to allow the divider to look correct. The color was based on the color used in the app page which looks to be closer to the mock.

Note: afaics this should only affect search results and installed apps list + there's a my-submissions list on the account  page too but that doesn't appear locally for me (despite having an app submitted). Was trying to check on dev too but app submissions are broken relating to the JQuery upgrade.
