### PR TITLE
Bug 841856 add extension devs filter

### DIFF
--- a/apps/zadmin/forms.py
+++ b/apps/zadmin/forms.py
@@ -37,7 +37,8 @@ class DevMailerForm(happyforms.Form):
                 ('payments',
                  'Developers of non-deleted apps (not add-ons) with payments'),
                 ('desktop_apps',
-                 'Developers of non-deleted apps supported on desktop')]
+                 'Developers of non-deleted apps supported on desktop'),
+                ('all_extensions', 'All extension developers')]
     recipients = forms.ChoiceField(choices=_choices, required=True)
     subject = forms.CharField(widget=forms.TextInput(attrs=dict(size='100')),
                               required=True)

--- a/apps/zadmin/tests/test_views.py
+++ b/apps/zadmin/tests/test_views.py
@@ -1989,6 +1989,12 @@ class TestEmailDevs(amo.tests.TestCase):
         self.assertNoFormErrors(res)
         eq_(len(mail.outbox), 1)
 
+    def test_only_extensions(self):
+        self.addon.update(type=amo.ADDON_EXTENSION)
+        res = self.post(recipients='all_extensions')
+        self.assertNoFormErrors(res)
+        eq_(len(mail.outbox), 1)        
+
     def test_ignore_deleted_always(self):
         self.addon.update(status=amo.STATUS_DELETED)
         for name, label in DevMailerForm._choices:

--- a/apps/zadmin/views.py
+++ b/apps/zadmin/views.py
@@ -674,6 +674,8 @@ def email_devs(request):
                 addon__addondevicetype__device_type=amo.DEVICE_DESKTOP.id))
         elif data['recipients'] == 'sdk':
             qs = qs.exclude(addon__versions__files__jetpack_version=None)
+        elif data['recipients'] == 'all_extensions':
+            qs = qs.filter(addon__type=amo.ADDON_EXTENSION)
         else:
             raise NotImplementedError('If you want to support emailing other '
                                       'types of developers, do it here!')


### PR DESCRIPTION
This adds the ability to filter dev emails to extension authors only via the zadmin email form.
