### PR TITLE
fix alignment of rating error message (bug 842294)

### DIFF
--- a/media/css/mkt/desktop-ratings.less
+++ b/media/css/mkt/desktop-ratings.less
@@ -28,6 +28,9 @@
             padding-top: 5px;
         }
     }
+    .req-error {
+        margin-top: 0;
+    }
     // hmm
     .simple-field.rating {
         .border-radius(0);


### PR DESCRIPTION
Fix for rating error message being out of alignment with the char count.
