### PR TITLE
Fix charlimit field position in mobile reviews (bug 842546)

### DIFF
--- a/media/css/mkt/ratings.less
+++ b/media/css/mkt/ratings.less
@@ -169,7 +169,7 @@ section.replies .review.reply {
     }
     .charlimit {
         font-size: 12px;
-        margin: -9px 0 15px;
+        margin: 5px 0 15px;
         text-align: right;
         line-height: 12px;
     }


### PR DESCRIPTION
This moves the "Max 150 Characters" down off the textarea.

Doesn't look to clash with desktop styles afaict - the desktop version uses different markup.
