### PR TITLE
bug 840763 - update zamboni-altdev configuration for heka 0.1.1

### DIFF
--- a/sites/altdev/settings_base.py
+++ b/sites/altdev/settings_base.py
@@ -209,15 +209,5 @@ XSENDFILE_HEADER  = 'X-Accel-Redirect'
 
 GEOIP_NOOP = 0
 
-METLOG_CONF = {
-    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {})},
-    'sender': {
-        'class': 'metlog.senders.UdpSender',
-        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
-        'port': private.METLOG_CONF_SENDER_PORT,
-    },
-}
-
-USE_METLOG_FOR_CEF = True
 
 ALLOW_SELF_REVIEWS = True

--- a/sites/altdev/settings_mkt.py
+++ b/sites/altdev/settings_mkt.py
@@ -51,6 +51,9 @@ SYSLOG_TAG = "http_app_addons_marketplacealtdev"
 SYSLOG_TAG2 = "http_app_addons_marketplacealtdev_timer"
 SYSLOG_CSP = "http_app_addons_marketplacealtdev_csp"
 
+# The django statsd client to use, see django-statsd for more.
+STATSD_CLIENT = 'django_statsd.clients.moz_metlog'
+
 STATSD_PREFIX = 'marketplace-altdev'
 
 ## Celery
@@ -127,6 +130,18 @@ BLUEVIA_SECRET = private_mkt.BLUEVIA_SECRET
 SIGNING_SERVER = private_mkt.SIGNING_SERVER
 SIGNING_SERVER_ACTIVE = True
 
-METLOG_CONF['logger'] = 'addons-marketplace-altdev'
-METLOG_CONF['plugins']['raven'] = ('metlog_raven.raven_plugin:config_plugin', {'dsn': private_mkt.SENTRY_DSN})
+METLOG_CONF = {
+    'plugins': {'cef': ('metlog_cef.cef_plugin:config_plugin', {}),
+                'raven': (
+                    'metlog_raven.raven_plugin:config_plugin', {'dsn': SENTRY_DSN}),
+        },
+    'sender': {
+        'class': 'metlog.senders.UdpSender',
+        'host': splitstrip(private.METLOG_CONF_SENDER_HOST),
+        'port': private.METLOG_CONF_SENDER_PORT,
+    },
+    'logger': 'addons-marketplace-altdev',
+}
 METLOG = client_from_dict_config(METLOG_CONF)
+USE_METLOG_FOR_CEF = True
+USE_METLOG_FOR_TASTYPIE = True


### PR DESCRIPTION
- merged the METLOG_CONF from altdev/settings_base and
  altdev/settings_mkt into one dictionary in altdev/settings_mkt
- added an overloaded STATSD_CLIENT definition in altdev/settings_mkt
  to use the metlog transport in django-statsd
