### PR TITLE
Let's talk about bots.

### DIFF
--- a/scripts/update/devbot.js
+++ b/scripts/update/devbot.js
@@ -1,0 +1,9 @@
+var fs = require('fs');
+var irc = require('irc');
+
+var client = new irc.Client('irc.mozilla.org', 'devbot', {channels: ['#amo-bots']});
+
+fs.readFile('./media/git-rev.txt', function(err, data) {
+    client.say('#amo-bots', 'dev is updated: ' + data);
+    client.disconnect();
+});

--- a/scripts/update/update.py
+++ b/scripts/update/update.py
@@ -89,6 +89,7 @@ def update_info(ctx, ref='origin/master'):
         ctx.local("git log -1")
         ctx.local("/bin/bash -c 'source /etc/bash_completion.d/git && __git_ps1'")
         ctx.local('git show -s {0} --pretty="format:%h" > media/git-rev.txt'.format(ref))
+        ctx.local('node scripts/update/devbot.js')  # Tell everyone that we're done.
 
 
 @task


### PR DESCRIPTION
This PR is not for merging. Let's talk about a bot.
- we don't know when -dev is up-to-date without polling git-rev.txt
- krupa is sad
- we <3 krupa

This would obviously require node and node-irc (`npm install irc`) on the server.

Not sure how we could block this from being a prod thing, but this would be infinitely useful for anyone working on the front-end.
