### PR TITLE
Link to API reference page on MDN rather than landing page. Fix bug 835574.

### DIFF
--- a/mkt/ecosystem/templates/ecosystem/base.html
+++ b/mkt/ecosystem/templates/ecosystem/base.html
@@ -10,7 +10,7 @@
 
 {% block account_links %}
   <div class="devhub-links {{ 'logged' if logged }}">
-    <a href="//developer.mozilla.org/apps">
+    <a href="//developer.mozilla.org/Apps/Reference">
       {{- _('API Reference') -}}
     </a>
     <a href="{{ url('ecosystem.support') }}">{{ _('Support') }}</a>


### PR DESCRIPTION
@cvan, can you take a look? This is an important link fix. Can we cherry pick it and push it to prod today?

Thanks a lot.
