### PR TITLE
Declare access for Bango product keys (bug 837169)

### DIFF
--- a/migrations/545-delete-old-inapp-keys.sql
+++ b/migrations/545-delete-old-inapp-keys.sql
@@ -1,0 +1,2 @@
+# These keys were just for testing so we can delete them.
+delete from user_inapp_keys where created < '2013-04-01 00:00:00';

--- a/mkt/constants/payments.py
+++ b/mkt/constants/payments.py
@@ -9,3 +9,7 @@ REFUND_STATUSES = {
     COMPLETED: _('Completed'),
     FAILED: _('Failed'),
 }
+
+# SellerProduct access types.
+ACCESS_PURCHASE = 1
+ACCESS_SIMULATE = 2

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -12,6 +12,7 @@ import amo.tests
 from amo.urlresolvers import reverse
 from addons.models import (Addon, AddonCategory, AddonDeviceType, AddonUser,
                            Category)
+from mkt.constants.payments import ACCESS_PURCHASE, ACCESS_SIMULATE
 from market.models import Price
 from users.models import UserProfile
 
@@ -176,6 +177,8 @@ class TestInappKeys(InappKeysTest):
         key = UserInappKey.objects.get()
         eq_(key.solitude_seller.resource_uri, self.seller_uri)
         eq_(key.seller_product_pk, self.product_pk)
+        m = solitude.api.generic.product.post.mock_calls
+        eq_(m[0][2]['data']['access'], ACCESS_SIMULATE)
 
     def test_reset(self, solitude):
         self.setup_solitude(solitude)
@@ -336,6 +339,8 @@ class TestPayments(amo.tests.TestCase):
 
         kw = api.bango.product.post.call_args[1]['data']
         ok_(kw['secret'], kw)
+        kw = api.generic.product.post.call_args[1]['data']
+        eq_(kw['access'], ACCESS_PURCHASE)
 
 
 class TestRegions(amo.tests.TestCase):


### PR DESCRIPTION
Keys created during bank account setup can be
purchased. Keys created for dev testing can only
be simulated.
