### PR TITLE
This will probably make ES tests a lot happier.

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -693,6 +693,7 @@ class ESTestCase(TestCase):
     def refresh(cls, index='default', timesleep=0):
         process.send(None)
         cls.es.refresh(settings.ES_INDEXES[index], timesleep=timesleep)
+        cls.es.health(wait_for_status='yellow')
 
     @classmethod
     def reindex(cls, model):


### PR DESCRIPTION
After refreshing indexes, wait for ES to claim it is ready to go again (yellow means there is a set of all data in some indexes, though not fully redundant yet.)
