### PR TITLE
fix mkt statistics tests, refs #793032

### DIFF
--- a/mkt/stats/tests/test_views.py
+++ b/mkt/stats/tests/test_views.py
@@ -97,8 +97,8 @@ class StatsTest(amo.tests.ESTestCase):
 
 class TestStatsPermissions(StatsTest):
     """Tests to make sure all restricted data remains restricted."""
-    mock_es = True  # We're checking only headers, not content.
 
+    @amo.tests.mock_es  # We're checking only headers, not content.
     def _check_it(self, views, status):
         for view, kwargs in views:
             response = self.get_view_response(view, head=True, **kwargs)


### PR DESCRIPTION
This fixes all test failures in mkt.stats.tests.test_views (7 of them).
