### PR TITLE
Move group management to CLI. Bug 844415

### DIFF
--- a/apps/access/models.py
+++ b/apps/access/models.py
@@ -2,8 +2,11 @@ from django.db import models
 from django import dispatch
 from django.db.models import signals
 
+import commonware.log
+
 import amo.models
 
+log = commonware.log.getLogger('z.users')
 
 class Group(amo.models.ModelBase):
 
@@ -36,6 +39,7 @@ def groupuser_post_save(sender, instance, **kw):
         instance.user.groups.filter(rules='*:*').count()):
         instance.user.user.is_superuser = instance.user.user.is_staff = True
         instance.user.user.save()
+    log.info("Added %s to %s\n" % (instance.user, instance.group))
 
 
 @dispatch.receiver(signals.post_delete, sender=GroupUser,
@@ -45,3 +49,4 @@ def groupuser_post_delete(sender, instance, **kw):
         not instance.user.groups.filter(rules='*:*').count()):
         instance.user.user.is_superuser = instance.user.user.is_staff = False
         instance.user.user.save()
+    log.info("Removed %s from %s\n" % (instance.user, instance.group))

--- a/mkt/zadmin/management/commands/addusertogroup.py
+++ b/mkt/zadmin/management/commands/addusertogroup.py
@@ -1,0 +1,40 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError
+
+import commonware.log
+
+from access.models import Group, GroupUser
+from users.models import UserProfile
+
+class Command(BaseCommand):
+    help = ("Add a new user to a group. Syntax: \n"
+            "    ./manage.py addusertogroup <userid> <groupid>")
+
+    log = commonware.log.getLogger('z.users')
+
+    def handle(self, *args, **options):
+
+        try:
+
+            user = UserProfile.objects.get(pk=args[0])
+            group = Group.objects.get(pk=args[1])
+
+            GroupUser.objects.create(user=user, group=group)
+
+            # This may double log due to the GroupUser callback. I don't mind.
+            msg = "Adding %s to %s\n" % (user, group)
+            self.log.info(msg)
+            self.stdout.write(msg)
+            # Surprised to see group changing is not a part of CEF logging
+            # requirements...
+
+        except IndexError:
+            raise CommandError(self.help)
+        except ValueError:
+            raise CommandError("Use user and group IDs (those are numbers)")
+        except IntegrityError, e:
+            raise CommandError("User is already in that group? %s" % e)
+        except Group.DoesNotExist:
+            raise CommandError("Group (%s) does not exist." % args[1])
+        except UserProfile.DoesNotExist:
+            raise CommandError("User (%s) does not exist." % args[0])

--- a/mkt/zadmin/management/commands/removeuserfromgroup.py
+++ b/mkt/zadmin/management/commands/removeuserfromgroup.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError
+
+import commonware.log
+
+from access.models import Group, GroupUser
+from users.models import UserProfile
+
+class Command(BaseCommand):
+    help = ("Remove a user from a group. Syntax: \n"
+            "    ./manage.py removeuserfromgroup <userid> <groupid>")
+
+    log = commonware.log.getLogger('z.users')
+
+    def handle(self, *args, **options):
+
+        try:
+
+            user = UserProfile.objects.get(pk=args[0])
+            group = Group.objects.get(pk=args[1])
+
+            # Doesn't actually check if the user was in the group or not
+            GroupUser.objects.filter(user=user, group=group).delete()
+
+            # This may double log due to the GroupUser callback. I don't mind.
+            msg = "Removing %s from %s\n" % (user, group)
+            self.log.info(msg)
+            self.stdout.write(msg)
+            # Surprised to see group changing is not a part of CEF logging
+            # requirements...
+
+        except IndexError:
+            raise CommandError(self.help)
+        except ValueError:
+            raise CommandError("Use user and group IDs (those are numbers)")
+        except Group.DoesNotExist:
+            raise CommandError("Group (%s) does not exist." % args[1])
+        except UserProfile.DoesNotExist:
+            raise CommandError("User (%s) does not exist." % args[0])


### PR DESCRIPTION
This is just a chunk of bug 844415 but that bug is arguably too big anyway.  This moves adding and removing users+groups to the CLI. I started writing unit tests for this, but we're talking about a single .create() or .delete() which is all a part of the ORM anyway.  In a world where we wait 20 minutes for tests to finish this feels like one of those times when tests are unnecessary.  Your call.

r? @muffinresearch at least since he owns the bug, but anyone is welcome.
