### PR TITLE
monolith total users chart (bug 843047)

### DIFF
--- a/apps/stats/tasks.py
+++ b/apps/stats/tasks.py
@@ -1,6 +1,7 @@
 import datetime
 import httplib2
 import itertools
+import json
 
 from django.conf import settings
 from django.db import connection, transaction
@@ -166,7 +167,8 @@ def update_global_totals(job, date, **kw):
     # monolith is only used for marketplace
     if job.startswith(('apps', 'mmo')):
         try:
-            MonolithRecord(recorded=date, key=job, value=num or 0,
+            value = json.dumps({'count': num or 0})
+            MonolithRecord(recorded=date, key=job, value=value,
                            user_hash='none').save()
         except Exception as e:
             log.critical("Update of monolith table failed: (%s): %s" % (p, e))

--- a/apps/stats/tests/test_cron.py
+++ b/apps/stats/tests/test_cron.py
@@ -38,6 +38,7 @@ class TestGlobalStats(amo.tests.TestCase):
 
         tasks.update_global_totals(job, date)
         self.assertTrue(record.called)
+        eq_(record.call_args[1]['value'], '{"count": 0}')
 
     @mock.patch('stats.tasks.MonolithRecord')
     def test_addon_total_downloads_doesnot_update_monolith(self, record):


### PR DESCRIPTION
Address bug 843047 - by storing a JSON mapping in the monolith_record table for global stats instead of just a plain int.
