### PR TITLE
report that browserid is disabled

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -407,6 +407,8 @@ def browserid_login(request, browserid_audience=None):
             auth.login(request, profile.user)
             profile.log_login_attempt(True)
             return http.HttpResponse(status=200)
+    else:
+        msg = 'browserid-login waffle switch is not enabled'
     return http.HttpResponse(msg, status=401)
 
 


### PR DESCRIPTION
This doesn't display to the user unless they are inspecting the response bodies. It would have saved me like 1.5 hours of my day if I knew that it was this waffle causing my issues.
