### PR TITLE
manage my addons to manage my submissions, tabbed dev dashboard (bug 85512)

### DIFF
--- a/apps/addons/templates/addons/includes/dashboard_tabs.html
+++ b/apps/addons/templates/addons/includes/dashboard_tabs.html
@@ -1,0 +1,8 @@
+{% if addons or themes %}
+  <div class="submission-type-tabs">
+    <a href="{{ url('devhub.addons') }}"{% if addon_tab %} class="active"{% endif %}>
+      {{ _('My Add-ons') }}</a>
+    <a href="{{ url('devhub.themes') }}"{% if theme %} class="active"{% endif %}>
+      {{ _('My Themes') }}</a>
+  </div>
+{% endif %}

--- a/apps/amo/context_processors.py
+++ b/apps/amo/context_processors.py
@@ -85,7 +85,7 @@ def global_settings(request):
         })
 
         if request.amo_user.is_developer:
-            tools_links.append({'text': _('Manage My Add-ons'),
+            tools_links.append({'text': _('Manage My Submissions'),
                                 'href': reverse('devhub.addons')})
         tools_links.append({'text': _('Submit a New Add-on'),
                             'href': reverse('devhub.submit.1')})

--- a/apps/amo/tests/test_views.py
+++ b/apps/amo/tests/test_views.py
@@ -103,7 +103,7 @@ class TestCommon(amo.tests.TestCase):
 
         expected = [
             ('Tools', '#'),
-            ('Manage My Add-ons', reverse('devhub.addons')),
+            ('Manage My Submissions', reverse('devhub.addons')),
             ('Submit a New Add-on', reverse('devhub.submit.1')),
             ('Submit a New Theme', reverse('devhub.themes.submit')),
             ('Developer Hub', reverse('devhub.index')),
@@ -138,7 +138,7 @@ class TestCommon(amo.tests.TestCase):
 
         expected = [
             ('Tools', '#'),
-            ('Manage My Add-ons', reverse('devhub.addons')),
+            ('Manage My Submissions', reverse('devhub.addons')),
             ('Submit a New Add-on', reverse('devhub.submit.1')),
             ('Submit a New Theme', reverse('devhub.themes.submit')),
             ('Developer Hub', reverse('devhub.index')),
@@ -180,7 +180,7 @@ class TestCommon(amo.tests.TestCase):
 
         expected = [
             ('Tools', '#'),
-            ('Manage My Add-ons', reverse('devhub.addons')),
+            ('Manage My Submissions', reverse('devhub.addons')),
             ('Submit a New Add-on', reverse('devhub.submit.1')),
             ('Submit a New Theme', reverse('devhub.themes.submit')),
             ('Developer Hub', reverse('devhub.index')),

--- a/apps/devhub/helpers.py
+++ b/apps/devhub/helpers.py
@@ -69,7 +69,7 @@ def dev_breadcrumbs(context, addon=None, items=None, add_default=False,
         link = reverse('devhub.apps')
     else:
         crumbs = [(reverse('devhub.index'), _('Developer Hub'))]
-        title = _('My Add-ons')
+        title = _('My Submissions')
         link = reverse('devhub.addons')
 
     if not addon and not items:

--- a/apps/devhub/templates/devhub/addons/dashboard.html
+++ b/apps/devhub/templates/devhub/addons/dashboard.html
@@ -3,7 +3,7 @@
 {% if webapp %}
   {% set title = loc('Manage My Apps') %}
 {% else %}
-  {% set title = _('Manage My Add-ons') %}
+  {% set title = _('Manage My Submissions') %}
 {% endif %}
 
 {% block title %}{{ dev_page_title(title) }}{% endblock %}
@@ -13,7 +13,8 @@
     <header class="hero">
       {{ dev_breadcrumbs(impala=True) }}
       <h1>{{ title }}</h1>
-      {% if addons %}
+
+      {% if addons and addon_tab %}
         {% set cnt = addons.paginator.count %}
         {% if webapp %}
           {# L10n: {0} is an integer. #}
@@ -26,7 +27,7 @@
     </header>
   </section>
 
-{% if not addons and not themes %}
+{% if webapp %}
   <div class="island action-needed">
     <h2>{{ _('Welcome to the Developer Dashboard') }}</h2>
     {% if webapp %}
@@ -96,7 +97,8 @@
     {% endif %}
   </section>
 
-  {% if addons %}
+  {% if addon_tab %}
+    {% include "addons/includes/dashboard_tabs.html" %}
     <section class="dashboard primary" role="main">
       <div class="listing island hero c">
         {{ impala_addon_listing_header(request.get_full_path(), search_filter=filter) }}
@@ -108,15 +110,16 @@
     </section>
   {% endif %}
 
-  {% if waffle.flag('submit-personas') and themes %}
+  {% if waffle.flag('submit-personas') and themes and theme %}
     {# L10n: {0} is an integer. #}
     <section class="dashboard primary theme-dashboard">
       {% set cnt = themes.paginator.count %}
       <h2 class="theme-count">
         {{ ngettext('<b>{0}</b> theme', '<b>{0}</b> themes', cnt)|f(cnt|numberfmt)|safe }}
       </h2>
+      {% include "addons/includes/dashboard_tabs.html" %}
       <div class="listing island hero c">
-        {{ impala_addon_listing_header(request.get_full_path(), search_filter=theme_filter) }}
+        {{ impala_addon_listing_header(request.get_full_path(), search_filter=filter) }}
         <div class="items">
           {{ dev_addon_listing_items(themes.object_list) }}
         </div>

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -7,7 +7,6 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.core import mail
-from django.utils.http import urlencode
 from django.core.files.storage import default_storage as storage
 
 import jingo
@@ -141,12 +140,13 @@ class TestDashboard(HubTest):
         super(TestDashboard, self).setUp()
         self.url = reverse('devhub.addons')
         self.apps_url = reverse('devhub.apps')
+        self.themes_url = reverse('devhub.themes')
         eq_(self.client.get(self.url).status_code, 200)
 
     def test_addons_layout(self):
         doc = pq(self.client.get(self.url).content)
         eq_(doc('title').text(),
-            'Manage My Add-ons :: Developer Hub :: Add-ons for Firefox')
+            'Manage My Submissions :: Developer Hub :: Add-ons for Firefox')
         eq_(doc('#social-footer').length, 1)
         eq_(doc('#copyright').length, 1)
         eq_(doc('#footer-links .mobile-link').length, 0)
@@ -192,7 +192,7 @@ class TestDashboard(HubTest):
         for x in range(2):
             addon = addon_factory(type=amo.ADDON_PERSONA)
             AddonUser.objects.create(user=self.user_profile, addon=addon)
-        r = self.client.get(self.url)
+        r = self.client.get(self.themes_url)
         doc = pq(r.content)
         eq_(len(doc('.item .item-info')), 2)
 

--- a/apps/devhub/urls.py
+++ b/apps/devhub/urls.py
@@ -204,6 +204,8 @@ urlpatterns = decorate(write, patterns('',
     # Redirect to /addons/ at the base.
     url('^addon$', lambda r: redirect('devhub.addons', permanent=True)),
     url('^addons$', views.dashboard, name='devhub.addons'),
+    url('^themes$', views.dashboard, name='devhub.themes',
+        kwargs={'theme': True}),
     url('^apps$', use_apps(views.dashboard), name='devhub.apps'),
     url('^feed$', views.feed, name='devhub.feed_all'),
     # TODO: not necessary when devhub homepage is moved out of remora

--- a/media/css/devhub/dashboard.less
+++ b/media/css/devhub/dashboard.less
@@ -7,6 +7,26 @@
     }
 }
 
+.submission-type-tabs {
+    margin-bottom: 8px;
+    a {
+        background: #FCFDFE;
+        .gradient-two-color(#FCFDFE, #F4F8FC);
+        border: 1px solid @border-blue;
+        border-radius: 5px 5px 0 0;
+        .box-shadow(0 -2px 0 rgba(204, 223, 243, 0.3) inset, 0 0 1px rgba(0, 0, 0, 0.1));
+        padding: 8px 14px;
+    }
+    a.active {
+        color: @orange;
+        cursor: default;
+        font-weight: bold;
+        &:hover {
+            text-decoration: none;
+        }
+    }
+}
+
 .action-needed {
     p {
         color: @medium-gray;
@@ -72,5 +92,5 @@ h3 a.subscribe-feed {
 }
 
 h2.theme-count {
-    margin-bottom: 16px;
+    margin-bottom: 20px;
 }


### PR DESCRIPTION
On AMO, "Manage My Add-ons" has been changed to "Manage My Submissions" on navigation and dashboard.

Separate add-on and themes into tabs on dashboard.

![img](http://imgur.com/XySfOhg.jpg)
