### PR TITLE
Make features profile changes trigger re-review (bug 862449)

### DIFF
--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -626,6 +626,14 @@ class REVIEW_FEATURES_OVERRIDE(_LOG):
     review_queue = True
 
 
+class REREVIEW_FEATURES_CHANGED(_LOG):
+    id = 123
+    format = _(u'{addon} minimum requirements manually changed.')
+    short = _(u'Requirements Changed')
+    keep = True
+    review_queue = True
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -1047,6 +1047,9 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         eq_(app.status, amo.STATUS_PUBLIC_WAITING)
         self._check_log(amo.LOG.REVIEW_FEATURES_OVERRIDE)
 
+        # A reviewer changing features shouldn't generate a re-review.
+        eq_(RereviewQueue.objects.count(), 0)
+
     def test_pending_to_reject_w_requirements_overrides(self):
         # Rejecting an app doesn't let you override features requirements.
         self.create_switch(name='buchets')

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -247,7 +247,7 @@ def _review(request, addon, version):
                 if addon.make_public == amo.PUBLIC_IMMEDIATELY:
                     addon.update(make_public=amo.PUBLIC_WAIT)
 
-                appfeatures_form.save()
+                appfeatures_form.save(mark_for_rereview=False)
 
                 # Log that the reviewer changed the minimum requirements.
                 added_features = new_features - old_features

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1411,8 +1411,11 @@ class AppFeaturesBase(amo.models.ModelBase):
     def to_dict(self):
         return dict((f, getattr(self, f)) for f in self._fields())
 
+    def to_keys(self):
+        return [k for k, v in self.to_dict().iteritems() if v]
+
     def to_list(self):
-        features = [k for k, v in self.to_dict().iteritems() if v]
+        features = self.to_keys()
         feature_names = [FEATURES_DICT[f[4:].upper()] for f in features]
         return sorted(feature_names)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=862449

Note: this PR depends on #810, because I didn't want feature profile changes caused by reviewers to trigger re-reviews. Since #810 is not merged yet, there is an extra commit you shouldn't consider when reviewing, I'll rebase everything when this is done. At the moment, the only relevant commit for this pull request is 0fcd3db.

(Alternatively wait till we merge #810 before reviewing this)
