### PR TITLE
Enable all available region checkboxes on tier change (bug 884815)

### DIFF
--- a/media/js/devreg/payments.js
+++ b/media/js/devreg/payments.js
@@ -103,10 +103,11 @@ define('payments', [], function() {
                     }
                     // Enable checkboxes for those that we have price info for.
                     $chkbox.prop('disabled', false)
+                           .prop('checked', true)
                            .parent('label').removeClass('disabled')
                            .closest('tr').find('.local-retail')
                            .text(price.price +' '+ price.currency)
-                           .toggle($chkbox.prop('checked'));
+                           .show();
                     seen.push($chkbox[0]);
                 }
                 // Disable everything else.


### PR DESCRIPTION
When changing price tiers enable all the available regions by default. 
