### PR TITLE
Show price/method data for all available payment regions (bug 884443)

### DIFF
--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -173,10 +173,11 @@
               </tr>
               <tr>
                 <td colspan="2" class="region-container">
-                  <div class="checkbox-choices regions"
+                  <div id="region-list" class="checkbox-choices regions"
                        data-api-error-msg="{{ _('A server error occurred. Please try again later.') }}"
                        data-disabled-regions="{{ region_form.disabled_regions|json }}"
                        data-free-with-inapp-id="{{ free_with_in_app_id }}"
+                       data-payment-methods="{{ payment_methods|json }}"
                        data-pricelist-api-url="{{ api_pricelist_url }}">
                     {{ region_form.regions.errors }}
                     <table>
@@ -185,6 +186,7 @@
                           <th><span class="region-heading">{{ _('Region') }}</span></th>
                           <th>{{ _('Retail price') }}
                             <span class="local-currency-heading">({{ _('local currency') }})</span></th>
+                          <th>{{ _('Billing method') }}</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -198,6 +200,7 @@
                                          name="regions" value="{{ value }}">{{ text }}</label>
                               </td>
                               <td><span class="local-retail"></span></td>
+                              <td><span class="local-method"></span></td>
                           </tr>
                           {% endif %}
                         {% endfor %}

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -12,6 +12,9 @@ import amo.tests
 from amo.urlresolvers import reverse
 from addons.models import (Addon, AddonCategory, AddonDeviceType, AddonUser,
                            Category)
+from constants.payments import (PAYMENT_METHOD_ALL,
+                                PAYMENT_METHOD_CARD,
+                                PAYMENT_METHOD_OPERATOR)
 from mkt.constants.payments import ACCESS_PURCHASE, ACCESS_SIMULATE
 from market.models import Price
 from users.models import UserProfile
@@ -293,13 +296,20 @@ class TestPayments(amo.tests.TestCase):
         eq_(len(pqr('#regions-island')), 0),
         eq_(len(pqr('#paid-regions-island')), 1),
 
-    def test_free_with_in_app_tier_id_in_context(self):
+    def test_free_with_in_app_tier_id_in_content(self):
         free_tier = Price.objects.create(price='0.00')
         self.webapp.update(premium_type=amo.ADDON_PREMIUM)
         res = self.client.get(self.url)
         pqr = pq(res.content)
         eq_(len(pqr('.regions[data-free-with-inapp-id]')), 1),
         eq_(int(pqr('.regions').attr('data-free-with-inapp-id')), free_tier.pk)
+
+    def test_pay_method_ids_in_context(self):
+        self.webapp.update(premium_type=amo.ADDON_PREMIUM)
+        res = self.client.get(self.url)
+        self.assertSetEqual(res.context['payment_methods'].keys(),
+                            [PAYMENT_METHOD_ALL, PAYMENT_METHOD_CARD,
+                             PAYMENT_METHOD_OPERATOR])
 
     def test_premium_in_app_passes(self):
         self.webapp.update(premium_type=amo.ADDON_FREE)

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -19,6 +19,9 @@ from access import acl
 from amo import messages
 from amo.decorators import json_view, login_required, post_required, write
 from amo.urlresolvers import reverse
+from constants.payments import (PAYMENT_METHOD_ALL,
+                                PAYMENT_METHOD_CARD,
+                                PAYMENT_METHOD_OPERATOR)
 from lib.crypto import generate_key
 from lib.pay_server import client
 
@@ -145,7 +148,12 @@ def payments(request, addon_id, addon, webapp=False):
              not waffle.switch_is_active('disabled-payments'),
          'api_pricelist_url':
              reverse('api_dispatch_list', kwargs={'resource_name': 'prices',
-                                                  'api_name': 'webpay'})})
+                                                  'api_name': 'webpay'}),
+         'payment_methods': {
+             PAYMENT_METHOD_ALL: _('All'),
+             PAYMENT_METHOD_CARD: _('Credit card'),
+             PAYMENT_METHOD_OPERATOR: _('Carrier'),
+         }})
 
 
 @login_required


### PR DESCRIPTION
This branch shows both the local currency and the billing method for available regions as returned by the api.

This changes local prices to always show along with the billing method as it's useful data for informing the user as to whether to check that region or not.

I used data sent from the view in a data attr as json - not having used that convention before I'd appreciate someone sanity checking that's all ok.

I've also switched away from changing the type of the radio button for free-in-app to get rid of a jqmigrate warning.
