### PR TITLE
Add missing directories to DOMAIN_METHODS for javascript (bug 844591)

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -474,9 +474,11 @@ DOMAIN_METHODS = {
         # crashes the extractor with bad unicode data.
         ('media/js/*.js', 'javascript'),
         ('media/js/amo2009/**.js', 'javascript'),
+        ('media/js/common/**.js', 'javascript'),
         ('media/js/impala/**.js', 'javascript'),
         ('media/js/zamboni/**.js', 'javascript'),
         ('media/js/mkt/**.js', 'javascript'),
+        ('media/js/devreg/**.js', 'javascript'),
     ],
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=844591

Extractor wasn't considering `media/js/devreg/` and `media/js/common` so if you had not run `compress_assets`, it would never pick up strings in those directories. The missing one mentioned in the bug was in `devreg/`.
