### PR TITLE
Add downloads count and creation date to the app API results (bug 867839)

### DIFF
--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -143,6 +143,7 @@ class TestESAppToDict(amo.tests.ESTestCase):
         expected = {
             'absolute_url': 'http://testserver/app/something-something/',
             'app_type': 'hosted',
+            'created': '2011-10-18T16:28:24',
             'current_version': {
                 'release_notes': None,
                 'version': '1.0',
@@ -172,12 +173,20 @@ class TestESAppToDict(amo.tests.ESTestCase):
                 'developed': False,
                 'installed': False,
                 'purchased': False,
-            }
+            },
+            'weekly_downloads': None,
         }
 
         for k, v in res.items():
             if k in expected:
                 eq_(expected[k], v, u'Unexpected value for field: %s' % k)
+
+    def test_show_downloads_count(self):
+        """Show weekly_downloads in results if app stats are public"""
+        self.app.update(public_stats=True)
+        self.refresh('webapp')
+        res = es_app_to_dict(self.get_obj())
+        eq_(res['weekly_downloads'], 9999)
 
     def test_icons(self):
         """


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=867839
