### PR TITLE
Show N/A for free with in-app (bug 887922)

### DIFF
--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -177,6 +177,7 @@
                        data-api-error-msg="{{ _('A server error occurred. Please try again later.') }}"
                        data-disabled-regions="{{ region_form.disabled_regions|json }}"
                        data-free-with-inapp-id="{{ free_with_in_app_id }}"
+                       data-not-applicable-msg="{{ _('Not applicable') }}"
                        data-payment-methods="{{ payment_methods|json }}"
                        data-pricelist-api-url="{{ api_pricelist_url }}">
                     {{ region_form.regions.errors }}

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -301,8 +301,15 @@ class TestPayments(amo.tests.TestCase):
         self.webapp.update(premium_type=amo.ADDON_PREMIUM)
         res = self.client.get(self.url)
         pqr = pq(res.content)
-        eq_(len(pqr('.regions[data-free-with-inapp-id]')), 1)
-        eq_(int(pqr('.regions').attr('data-free-with-inapp-id')), free_tier.pk)
+        eq_(len(pqr('#region-list[data-free-with-inapp-id]')), 1)
+        eq_(int(pqr('#region-list').attr(
+            'data-free-with-inapp-id')), free_tier.pk)
+
+    def test_not_applicable_data_attr_in_content(self):
+        self.webapp.update(premium_type=amo.ADDON_PREMIUM)
+        res = self.client.get(self.url)
+        pqr = pq(res.content)
+        eq_(len(pqr('#region-list[data-not-applicable-msg]')), 1)
 
     def test_pay_method_ids_in_context(self):
         self.webapp.update(premium_type=amo.ADDON_PREMIUM)


### PR DESCRIPTION
This branch displays 'N/A' for apps that are free with in-app payments instead of the 'All' billing method.

Also this refactors a little how the selectedPrice value is handled so we don't potentially hit bugs in the future. I've gone back to parseInt because using the + operator in front of a string works in most cases except the following:

``` javascript
var foo = '';
var bar = +foo; // bar is 0
var baz = parseInt(foo, 10); // baz is NaN
```

This is important when we need to know about the empty string value.  So I've updated all the handling of that value so it's clearer and selectedPrice is explicitly false when set as an empty string rather than trying to rely on the falsey value in if statements.
