### PR TITLE
Fix new app version and app validator upload forms (bug 888239)

### DIFF
--- a/mkt/developers/templates/developers/apps/status.html
+++ b/mkt/developers/templates/developers/apps/status.html
@@ -183,7 +183,7 @@
 
       <h2 id="upload-new-version">{{ _('Upload New Version') }}</h2>
       <div class="island">
-        <form method="post" id="create-addon" class="item">
+        <form method="post" id="upload-webapp" class="item">
           {{ csrf() }}
           <p>
           {% trans %}

--- a/mkt/developers/templates/developers/validate_addon.html
+++ b/mkt/developers/templates/developers/validate_addon.html
@@ -50,8 +50,10 @@
     </div>
 
     <div class="packaged tab">
-      <h2><a href="#">{{ _('Packaged') }}</a></h2>
-      <input type="file" id="upload-app" data-upload-url="{{ upload_packaged_url }}" />
+      <form id="upload-webapp">
+        <h2><a href="#">{{ _('Packaged') }}</a></h2>
+        <input type="file" id="upload-app" data-upload-url="{{ upload_packaged_url }}" />
+      </form>
     </div>
   </section>
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=888239

In 2a486af the upload button logic was changed to rely on a form with `id="upload-webapp"` but this didn't exist in the manage versions & status page, as well as the app validator page.
