### PR TITLE
theme statistics (bug 565813)

### DIFF
--- a/apps/devhub/templates/devhub/addons/listing/item_actions_theme.html
+++ b/apps/devhub/templates/devhub/addons/listing/item_actions_theme.html
@@ -7,14 +7,21 @@
         {{ _('Edit Listing') }}</a>
     </li>
   {% endif %}
-  <li>
-    <a href="{{ addon.get_url_path() }}" class="tooltip"
-       title="{{ _("View this theme's public listing page.") }}">
-      {{ _('View Listing') }}</a>
-  </li>
+  {% if waffle.switch('theme-stats') %}
+    <li>
+      <a href="{{ addon.get_url_path() }}" class="tooltip"
+         title="{{ _("View this theme's public listing page.") }}">
+        {{ _('View Listing') }}</a>
+    </li>
+  {% endif %}
   <li>
     <a href="{{ url('devhub.feed', addon.slug) }}">
       {{ _('View Recent Changes') }}</a>
+  </li>
+  <li>
+    <a href="{{ url('stats.usage', addon.slug) }}" class="tooltip"
+       title="{{ _("View the popularity of this theme over time.") }}">
+      {{ _('View Statistics') }}</a>
   </li>
   {% if check_addon_ownership(request, addon) %}
     <li>

--- a/apps/devhub/templates/devhub/personas/edit.html
+++ b/apps/devhub/templates/devhub/personas/edit.html
@@ -56,6 +56,9 @@
         <p><a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a></p>
         <p><a href="{{ url('devhub.feed', addon.slug) }}">
           {{ _('View Recent Changes') }}</a></p>
+        {% if waffle.switch('theme-stats') %}
+          <p><a href="{{ url('stats.usage', addon.slug) }}">{{ _('View Statistics') }}</a></p>
+        {% endif %}
         {% if can_delete %}
           <a href="#" class="button scary delete-addon">{{ _('Delete Theme') }}</a>
           <div class="modal-delete modal hidden">

--- a/apps/stats/fixtures/stats/test_models.json
+++ b/apps/stats/fixtures/stats/test_models.json
@@ -60,6 +60,21 @@
         }
     },
     {
+        "pk": 6,
+        "model": "addons.addon",
+        "fields": {
+            "slug": "6",
+            "type": 9,
+            "status": 4,
+            "highest_status": 4,
+            "description": null,
+            "public_stats": true,
+            "modified": "2008-05-22 11:59:13",
+            "name": null,
+            "created": "2004-06-11 18:23:31"
+        }
+    },
+    {
         "pk": 1,
         "model": "stats.downloadcount",
         "fields": {
@@ -198,6 +213,33 @@
             "applications": "a:1:{s:38:\"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}\";a:1:{s:3:\"4.0\";i:1500;}}",
             "oses": "a:2:{s:5:\"Linux\";i:400;s:5:\"WINNT\";i:500;}",
             "locales": "a:2:{s:5:\"en-US\";i:300;s:2:\"el\";i:400;}",
+            "date": "2007-01-01"
+        }
+    },
+    {
+        "pk": 1,
+        "model": "stats.themeusercount",
+        "fields": {
+            "addon": 6,
+            "count": 1000,
+            "date": "2009-06-01"
+        }
+    },
+    {
+        "pk": 2,
+        "model": "stats.themeusercount",
+        "fields": {
+            "addon": 6,
+            "count": 1500,
+            "date": "2009-06-02"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "stats.themeusercount",
+        "fields": {
+            "addon": 6,
+            "count": 10,
             "date": "2007-01-01"
         }
     },

--- a/apps/stats/management/commands/index_stats.py
+++ b/apps/stats/management/commands/index_stats.py
@@ -8,9 +8,10 @@ from django.db.models import Max, Min
 from celery.task.sets import TaskSet
 
 from amo.utils import chunked
-from stats.models import CollectionCount, DownloadCount, UpdateCount
+from stats.models import (CollectionCount, DownloadCount, ThemeUserCount,
+                          UpdateCount)
 from stats.tasks import (index_collection_counts, index_download_counts,
-                         index_update_counts)
+                         index_theme_user_counts, index_update_counts)
 
 log = logging.getLogger('z.stats')
 
@@ -57,6 +58,8 @@ class Command(BaseCommand):
                 {'date': 'date'}),
             (DownloadCount.objects, index_download_counts,
                 {'date': 'date'}),
+            (ThemeUserCount.objects, index_theme_user_counts,
+                {'date': 'date'})
         ]
 
         if not addons:
@@ -111,7 +114,8 @@ def create_tasks(task, qs):
 
 def fixup():
     queries = [(UpdateCount, index_update_counts),
-               (DownloadCount, index_download_counts)]
+               (DownloadCount, index_download_counts),
+               (ThemeUserCount, index_theme_user_counts)]
 
     for model, task in queries:
         all_addons = model.objects.distinct().values_list('addon', flat=True)

--- a/apps/stats/models.py
+++ b/apps/stats/models.py
@@ -449,3 +449,13 @@ class ClientData(models.Model):
         db_table = 'client_data'
         unique_together = ('download_source', 'device_type', 'user_agent',
                            'is_chromeless', 'language', 'region')
+
+
+class ThemeUserCount(SearchMixin, models.Model):
+    """Theme active daily users."""
+    addon = models.ForeignKey('addons.Addon')
+    count = models.PositiveIntegerField()
+    date = models.DateField()
+
+    class Meta:
+        db_table = 'theme_user_counts'

--- a/apps/stats/search.py
+++ b/apps/stats/search.py
@@ -108,6 +108,13 @@ def extract_addon_collection(collection_count, addon_collections,
             })}
 
 
+def extract_theme_user_count(user_count):
+    return {'addon': user_count.addon_id,
+            'date': user_count.date,
+            'count': user_count.count,
+            'id': user_count.id}
+
+
 def get_all_app_versions():
     vals = AppVersion.objects.values_list('application', 'version')
     rv = collections.defaultdict(list)

--- a/apps/stats/templates/stats/addon_report_menu.html
+++ b/apps/stats/templates/stats/addon_report_menu.html
@@ -1,40 +1,44 @@
 <nav id="side-nav" class="report-menu">
   <ul>
-    <li data-report="overview" data-layout="overview">
-      <a href="{{ url('stats.overview', addon.slug) }}">{{ _('Overview') }}</a>
-    </li>
-    <li data-report="downloads">
-      <a href="{{ url('stats.downloads', addon.slug) }}">{{ _('Downloads') }}</a>
-    </li>
-    <ul>
-      <li data-report="sources">
-        <a href="{{ url('stats.sources', addon.slug) }}">{{ _('by Source') }}</a>
+    {% if not addon.is_persona() %}
+      <li data-report="overview" data-layout="overview">
+        <a href="{{ url('stats.overview', addon.slug) }}">{{ _('Overview') }}</a>
       </li>
-    </ul>
+      <li data-report="downloads">
+        <a href="{{ url('stats.downloads', addon.slug) }}">{{ _('Downloads') }}</a>
+      </li>
+      <ul>
+        <li data-report="sources">
+          <a href="{{ url('stats.sources', addon.slug) }}">{{ _('by Source') }}</a>
+        </li>
+      </ul>
+    {% endif %}
     <li data-report="usage">
       <a href="{{ url('stats.usage', addon.slug) }}">{{ _('Daily Users') }}</a>
     </li>
-    <ul>
-      <li data-report="versions">
-        <a href="{{ url('stats.versions', addon.slug) }}">{{ _('by Add-on Version') }}</a>
-      </li>
-      <li data-report="apps">
-        <a href="{{ url('stats.apps', addon.slug) }}">{{ _('by Application') }}</a>
-      </li>
-      <li data-report="locales">
-        <a href="{{ url('stats.locales', addon.slug) }}">{{ _('by Language') }}</a>
-      </li>
-      <li data-report="os">
-        <a href="{{ url('stats.os', addon.slug) }}">{{ _('by Platform') }}</a>
-      </li>
-      <li data-report="statuses">
-        <a href="{{ url('stats.statuses', addon.slug) }}">{{ _('by Add-on Status') }}</a>
-      </li>
-    </ul>
-    {% if has_privs %}
-      <li data-report="contributions">
-        <a href="{{ url('stats.contributions', addon.slug) }}">{{ _('Contributions') }}</a>
-      </li>
+    {% if not addon.is_persona() %}
+      <ul>
+        <li data-report="versions">
+          <a href="{{ url('stats.versions', addon.slug) }}">{{ _('by Add-on Version') }}</a>
+        </li>
+        <li data-report="apps">
+          <a href="{{ url('stats.apps', addon.slug) }}">{{ _('by Application') }}</a>
+        </li>
+        <li data-report="locales">
+          <a href="{{ url('stats.locales', addon.slug) }}">{{ _('by Language') }}</a>
+        </li>
+        <li data-report="os">
+          <a href="{{ url('stats.os', addon.slug) }}">{{ _('by Platform') }}</a>
+        </li>
+        <li data-report="statuses">
+          <a href="{{ url('stats.statuses', addon.slug) }}">{{ _('by Add-on Status') }}</a>
+        </li>
+      </ul>
+      {% if has_privs %}
+        <li data-report="contributions">
+          <a href="{{ url('stats.contributions', addon.slug) }}">{{ _('Contributions') }}</a>
+        </li>
+      {% endif %}
     {% endif %}
   </ul>
 </nav>

--- a/apps/stats/templates/stats/reports/usage.html
+++ b/apps/stats/templates/stats/reports/usage.html
@@ -7,13 +7,24 @@
 {% endblock %}
 
 {% block stats_note %}
-  {% trans %}
-    <h2>What are daily users?</h2>
-    <p>
-      Add-ons downloaded from this site check for updates once per day. The total
-      number of these update pings is known as Active Daily Users. Daily users can be
-      broken down by add-on version, operating system, add-on status, application,
-      and locale.
-    </p>
-  {% endtrans %}
+  {% if addon.is_persona() %}
+    {% trans %}
+      <h2>What are daily users?</h2>
+      <p>
+        Themes installed from this site check for updates once per day. The total
+        number of these update pings is known as Active Daily Users, or
+        the total number of people using your theme by day.
+      </p>
+    {% endtrans %}
+  {% else %}
+    {% trans %}
+      <h2>What are daily users?</h2>
+      <p>
+        Add-ons downloaded from this site check for updates once per day. The total
+        number of these update pings is known as Active Daily Users. Daily users can be
+        broken down by add-on version, operating system, add-on status, application,
+        and locale.
+      </p>
+    {% endtrans %}
+  {% endif %}
 {% endblock %}

--- a/apps/stats/views.py
+++ b/apps/stats/views.py
@@ -34,7 +34,8 @@ from amo.decorators import allow_cross_site_request, json_view, login_required
 from amo.urlresolvers import reverse
 from amo.utils import memoize
 
-from .models import CollectionCount, Contribution, DownloadCount, UpdateCount
+from .models import (CollectionCount, Contribution, DownloadCount,
+                     ThemeUserCount, UpdateCount)
 
 
 logger = logging.getLogger('z.apps.stats.views')
@@ -193,7 +194,9 @@ def usage_series(request, addon, group, start, end, format):
     date_range = check_series_params_or_404(group, start, end, format)
     check_stats_permission(request, addon)
 
-    series = get_series(UpdateCount, addon=addon.id, date__range=date_range)
+    series = get_series(
+        ThemeUserCount if addon.type == amo.ADDON_PERSONA else UpdateCount,
+        addon=addon.id, date__range=date_range)
 
     if format == 'csv':
         return render_csv(request, addon, series, ['date', 'count'])

--- a/docs/topics/install-zamboni/elasticsearch.rst
+++ b/docs/topics/install-zamboni/elasticsearch.rst
@@ -20,7 +20,13 @@ will show you the commands to launch. If you used aptitude, elasticsearch will
 come with an start-stop daemon in /etc/init.d as well as configuration files in
 /etc/elasticsearch.
 
+There is a ```config.yml``` in the ```scripts/elasticsearch/```
+directory. If you installed via brew, copy that file into
+```/usr/local/Cellar/elasticsearch/x.x.x/config/```. On Linux, the
+configuration directory is often ```/etc/elasticsearch/```.
+
 Mappings::
+
     ./manage.py shell_plus
     from stats.search import setup_indexes
     setup_indexes()

--- a/migrations/623-theme-user-count.sql
+++ b/migrations/623-theme-user-count.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `theme_user_counts` (
+    `id` integer AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    `addon_id` integer UNSIGNED NOT NULL,
+    `count` integer UNSIGNED NOT NULL,
+    `date` date NOT NULL
+);
+
+ALTER TABLE `theme_user_counts` ADD CONSTRAINT `addon_id_refs_id_ac19f783` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`);
+CREATE INDEX addon_date_idx ON theme_user_counts (addon_id, date);
+
+INSERT INTO waffle_switch_amo (name, active, created, modified, note) VALUES ('theme-stats', 0, NOW(), NOW(), 'Allow access to theme stat pages');

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -68,6 +68,7 @@ HOME=/tmp
 30 23 * * * %(z_cron)s index_latest_stats
 35 23 * * * %(z_cron)s index_latest_mkt_stats --settings=settings_local_mkt
 45 23 * * * %(z_cron)s update_addons_collections_downloads
+50 23 * * * %(z_cron)s update_daily_theme_user_counts
 
 # Once per week
 45 23 * * 4 %(z_cron)s unconfirmed


### PR DESCRIPTION
**Notes:**
- Daily cronjob saves Persona.popularity into stats.models.ThemeUserCount with addon/date/count.
- Adds an indexing task to index_stats to save the daily theme user counts into ElasticSearch.
- Creates a link to the statistics dashboard from the theme dashboard and theme edit page.
- Theme statistics dashboard only contains an active daily user chart (usage) with no breakdowns.

![Dashboard Screenshot](http://i.imgur.com/lfq3Ot2.png)
