### PR TITLE
Fix tests broken by fixture changes in a5afb23

### DIFF
--- a/mkt/versions/tests/test_models.py
+++ b/mkt/versions/tests/test_models.py
@@ -19,11 +19,11 @@ class TestVersion(BaseUploadTest, amo.tests.TestCase):
 
     def test_developer_name(self):
         version = Version.objects.latest('id')
+        version.update(_developer_name='')
         eq_(version.developer_name, version.addon.authors.all()[0].name)
 
         version._developer_name = u'M€lâ'
         eq_(version.developer_name, u'M€lâ')
-
         eq_(Version(_developer_name=u'M€lâ').developer_name, u'M€lâ')
 
     @mock.patch('files.utils.parse_addon')

--- a/mkt/webapps/tests/test_tasks.py
+++ b/mkt/webapps/tests/test_tasks.py
@@ -607,6 +607,7 @@ class TestUpdateDeveloperName(amo.tests.TestCase):
         mock_parser.return_value = {
             'developer_name': u'New Dêv'
         }
+        self.app.current_version.update(_developer_name='')
         update_developer_name(ids=(self.app.pk,))
         version = self.app.current_version.reload()
         eq_(version._developer_name, u'New Dêv')
@@ -616,6 +617,7 @@ class TestUpdateDeveloperName(amo.tests.TestCase):
     @mock.patch('mkt.webapps.tasks._log')
     def test_update_developer_name_validation_error(self, _log, mock_parser):
         mock_parser.side_effect = ValidationError('dummy validation error')
+        self.app.current_version.update(_developer_name='')
         update_developer_name(ids=(self.app.pk,))
         assert _log.called_with(337141, u'Webapp manifest can not be parsed')
 


### PR DESCRIPTION
In a5afb23, the fixtures were changed and a non-empty _developer_name was added to the current version of the default test app. This breaks some tests, which are fixed by this PR (I believe it might be better to explicitly set in the test the values we are expecting when testing, but if you disagree, feel free to ignore this and fix the fixture instead)
