### PR TITLE
Allow worldwide region for paid apps WiP (bug 883933)

### DIFF
--- a/media/js/devreg/payments.js
+++ b/media/js/devreg/payments.js
@@ -109,8 +109,13 @@ define('payments', [], function() {
         // Handle the 'Please select a price' case.
         if (selectedPrice === false) {
             $regions.find('input[type=checkbox]').each(disableCheckbox);
+            $('#id_other_regions').prop('disabled', true)
+                                  .next('label').addClass('disabled');
             currentPrice = selectedPrice;
             return;
+        } else {
+            $('#id_other_regions').prop('disabled', false)
+                                  .next('label').removeClass('disabled');
         }
 
         // If free with in-app is selected, check "Yes" then make the 'No' radio

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -526,6 +526,21 @@ class TestRegions(amo.tests.TestCase):
         eq_(td.find('div[data-disabled]').attr('data-disabled'), '[]')
         eq_(td.find('.note.disabled-regions').length, 0)
 
+    def test_world_wide_region_id_is_checked(self):
+        self.make_premium(self.webapp)
+        price = Price.objects.filter()[0]
+        res = self.client.post(
+            self.url, data={
+                'price': price.pk,
+                'free_platforms': ['free-%s' % dt.class_name for dt in
+                                   self.webapp.device_types],
+                'paid_platforms': ['paid-%s' % dt.class_name for dt in
+                                   self.webapp.device_types],
+                'other_regions': 'on'
+            }, follow=True)
+        pqr = pq(res.content)
+        eq_(pqr('#id_other_regions').attr('checked'), 'checked')
+
 
 class PaymentsBase(amo.tests.TestCase):
     fixtures = fixture('user_editor', 'user_999')


### PR DESCRIPTION
This turns on the worldwide checkbox in the devhub for paid apps.

It doesn't deal with any functionality wrt to dealing with the worldwide region being enabled and adding a new region - we'll need to tackle that separately - there's already a bug to work out what is needed which is here: https://bugzilla.mozilla.org/show_bug.cgi?id=882798
