### PR TITLE
Fix references to site/dev-agreement.html

### DIFF
--- a/mkt/developers/templates/developers/docs/policies-agreement.html
+++ b/mkt/developers/templates/developers/docs/policies-agreement.html
@@ -10,6 +10,6 @@
 {{ hub_breadcrumbs(items=[(None, _('Developer Agreement'))]) }}
 <h1>{{ _('Developer Agreement') }}</h1>
 <div class="primary prose" role="main">
-  {% include 'site/dev-agreement.html' %}
+  {{ dev_agreement() }}
 </div>
 {% endblock %}

--- a/mkt/submit/templates/submit/terms.html
+++ b/mkt/submit/templates/submit/terms.html
@@ -28,7 +28,7 @@
     </p>
     <div id="agreement-container">
       <div id="dev-agreement">
-        {% include 'site/dev-agreement.html' %}
+        {{ dev_agreement() }}
       </div>
     </div>
     <ol id="agreement-extra-links">


### PR DESCRIPTION
In eabd37b the template at mkt/site/templates/site/dev-agreement.html was removed in favour of a localised version.

However it's still referenced in mkt/submit/templates/submit/terms.html and  mkt/developers/templates/developers/docs/policies-agreement.html (not sure if the latter is even used).
