### PR TITLE
When an app field is empty, don't hide all the translations (bug 888831)

### DIFF
--- a/apps/translations/helpers.py
+++ b/apps/translations/helpers.py
@@ -56,14 +56,14 @@ def l10n_menu(context, default_locale='en-us'):
 
 
 @jingo.register.filter
-def all_locales(addon, field_name, nl2br=False):
-    field = getattr(addon, field_name)
-    if not (addon and field):
+def all_locales(addon, field_name, nl2br=False, prettify_empty=False):
+    field = getattr(addon, field_name, None)
+    if not addon or field is None:
         return
     trans = field.__class__.objects.filter(id=field.id,
                                            localized_string__isnull=False)
     ctx = dict(addon=addon, field=field, field_name=field_name,
-               translations=trans, nl2br=nl2br)
+               translations=trans, nl2br=nl2br, prettify_empty=prettify_empty)
     t = jingo.env.get_template('translations/all-locales.html')
     return jinja2.Markup(t.render(ctx))
 

--- a/apps/translations/templates/translations/all-locales.html
+++ b/apps/translations/templates/translations/all-locales.html
@@ -1,10 +1,13 @@
 <div class="trans" data-name="{{ field_name }}">
   {% for trans in translations %}
-    {% if nl2br %}
+    {% if prettify_empty and not trans %}
+      {% set klass='empty' %}
+      {% set text=_('None') %}
+    {% elif nl2br %}
       {% set text=trans|nl2br %}
     {% else %}
       {% set text=trans %}
     {% endif %}
-    <span lang="{{ trans.locale|to_language }}">{{ text }}</span>
+    <span{% if klass %} class="{{ klass }}"{% endif %} lang="{{ trans.locale|to_language }}">{{ text }}</span>
   {% endfor %}
 </div>

--- a/apps/translations/tests/test_helpers.py
+++ b/apps/translations/tests/test_helpers.py
@@ -4,9 +4,14 @@ from django.utils import translation
 import jingo
 from mock import Mock
 from nose.tools import eq_
+from tower import strip_whitespace
 
+import amo
+import amo.tests
 from translations import helpers
-from translations.models import PurifiedTranslation
+from translations.fields import save_signal
+from translations.models import PurifiedTranslation, Translation
+from translations.tests.testapp.models import TranslatedModel
 
 
 def super():
@@ -79,3 +84,55 @@ def test_clean():
 def test_clean_in_template():
     s = '<a href="#woo">yeah</a>'
     eq_(jingo.env.from_string('{{ s|clean }}').render(s=s), s)
+
+
+class TestAllLocales(amo.tests.TestCase):
+    def test_all_locales_none(self):
+        addon = None
+        field_name = 'description'
+        eq_(helpers.all_locales(addon, field_name), None)
+
+        addon = Mock()
+        field_name = 'description'
+        del addon.description
+        eq_(helpers.all_locales(addon, field_name), None)
+
+    def test_all_locales(self):
+        obj = TranslatedModel()
+        obj.description = {
+            'en-US': 'There',
+            'es': 'Is No',
+            'fr': 'Spoon'
+        }
+        # Pretend the TranslateModel instance was saved to force Translation
+        # objects to be saved.
+        save_signal(sender=TranslatedModel, instance=obj)
+
+        result = helpers.all_locales(obj, 'description')
+        eq_(strip_whitespace(result),
+            u'<div class="trans" data-name="description"> '
+            u'<span lang="en-us">There</span> <span lang="es">Is No</span> '
+            u'<span lang="fr">Spoon</span> </div>')
+
+    def test_all_locales_empty(self):
+        obj = TranslatedModel()
+        obj.description = {
+            'en-US': 'There',
+            'es': 'Is No',
+            'fr': ''
+        }
+        # Pretend the TranslateModel instance was saved to force Translation
+        # objects to be saved.
+        save_signal(sender=TranslatedModel, instance=obj)
+
+        result = helpers.all_locales(obj, 'description')
+        eq_(strip_whitespace(result),
+            u'<div class="trans" data-name="description"> '
+            u'<span lang="en-us">There</span> <span lang="es">Is No</span> '
+            u'<span lang="fr"></span> </div>')
+
+        result = helpers.all_locales(obj, 'description', prettify_empty=True)
+        eq_(strip_whitespace(result),
+            u'<div class="trans" data-name="description"> '
+            u'<span lang="en-us">There</span> <span lang="es">Is No</span> '
+            u'<span class="empty" lang="fr">None</span> </div>')

--- a/mkt/developers/templates/developers/apps/edit/basic.html
+++ b/mkt/developers/templates/developers/apps/edit/basic.html
@@ -114,11 +114,9 @@
               {{ form.description.errors }}
               {{ some_html_tip() }}
             {% else %}
-              {% call empty_unless(addon.description) %}
-                <div id="addon-description" class="prose">
-                  {{ addon|all_locales('description', nl2br=True) }}
-                </div>
-              {% endcall %}
+              <div id="addon-description" class="prose">
+                {{ addon|all_locales('description', nl2br=True, prettify_empty=True) }}
+              </div>
             {% endif %}
           </td>
         </tr>

--- a/mkt/developers/templates/developers/apps/edit/details.html
+++ b/mkt/developers/templates/developers/apps/edit/details.html
@@ -1,4 +1,4 @@
-{% from 'developers/includes/macros.html' import empty_unless, required, some_html_tip, tip %}
+{% from 'developers/includes/macros.html' import required, some_html_tip, tip %}
 {% set req_if_edit = required() if editable %}
 <form id="details" method="post" action="{{ addon.get_dev_url('section', args=['details', 'edit']) }}">
   <h2>
@@ -45,9 +45,7 @@
               {{ form.homepage }}
               {{ form.homepage.errors }}
             {% else %}
-              {% call empty_unless(addon.homepage) %}
-                {{ addon|all_locales('homepage') }}
-              {% endcall %}
+              {{ addon|all_locales('homepage', prettify_empty=True) }}
             {% endif %}
           </td>
         </tr>
@@ -68,11 +66,9 @@
               {{ form.privacy_policy.errors }}
               {{ some_html_tip() }}
             {% else %}
-              {% call empty_unless(addon.privacy_policy) %}
-                <div id="addon-privacy-policy" class="prose">
-                  {{ addon|all_locales('privacy_policy', nl2br=True) }}
-                </div>
-              {% endcall %}
+              <div id="addon-privacy-policy" class="prose">
+                {{ addon|all_locales('privacy_policy', nl2br=True, prettify_empty=True) }}
+              </div>
             {% endif %}
           </td>
         </tr>

--- a/mkt/developers/templates/developers/apps/edit/support.html
+++ b/mkt/developers/templates/developers/apps/edit/support.html
@@ -1,4 +1,4 @@
-{% from 'developers/includes/macros.html' import empty_unless, required, tip %}
+{% from 'developers/includes/macros.html' import required, tip %}
 <form method="post" action="{{ addon.get_dev_url('section', args=['support', 'edit']) }}">
   <h2>
     {{ _('Support Information') }}
@@ -29,9 +29,7 @@
               {{ form.support_email }}
               {{ form.support_email.errors }}
             {% else %}
-              {% call empty_unless(addon.support_email) %}
-                {{ addon|all_locales('support_email') }}
-              {% endcall %}
+              {{ addon|all_locales('support_email', prettify_empty=True) }}
             {% endif %}
           </td>
         </tr>
@@ -60,9 +58,7 @@
               {{ form.support_url }}
               {{ form.support_url.errors }}
             {% else %}
-              {% call empty_unless(addon.support_url) %}
-                {{ addon|all_locales('support_url') }}
-              {% endcall %}
+              {{ addon|all_locales('support_url', prettify_empty=True) }}
             {% endif %}
           </td>
         </tr>

--- a/mkt/developers/templates/developers/apps/edit/technical.html
+++ b/mkt/developers/templates/developers/apps/edit/technical.html
@@ -1,4 +1,4 @@
-{% from 'developers/includes/macros.html' import empty_unless, flags, some_html_tip, tip %}
+{% from 'developers/includes/macros.html' import flags, some_html_tip, tip %}
 <form method="post"
       action="{{ addon.get_dev_url('section', args=['technical', 'edit']) }}">
   <h2>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=888831

When we had an empty translation for a field, whatever the reason, we replaced the whole field, including translations in other languages, by a span. It turns out it's a bad idea since it will hide other translations, even non-empty ones, causing a lot of confusion since the edit form itself displays correctly.
