### PR TITLE
Version uploaded while another version is PUBLIC_WAITING goes to wrong queue (bug 868526)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -587,7 +587,7 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
         if self.type == amo.ADDON_PERSONA:
             return
         try:
-            if self.status == amo.STATUS_PUBLIC:
+            if self.status in (amo.STATUS_PUBLIC, amo.STATUS_PUBLIC_WAITING):
                 status = [self.status]
             elif self.status in (amo.STATUS_LITE,
                                  amo.STATUS_LITE_AND_NOMINATED):

--- a/apps/addons/tests/test_views.py
+++ b/apps/addons/tests/test_views.py
@@ -1091,6 +1091,7 @@ class TestStatus(amo.tests.TestCase):
     def setUp(self):
         self.addon = Addon.objects.get(id=3615)
         self.version = self.addon.current_version
+        self.file = self.version.all_files[0]
         assert self.addon.status == amo.STATUS_PUBLIC
         self.url = self.addon.get_url_path()
 
@@ -1158,6 +1159,20 @@ class TestStatus(amo.tests.TestCase):
     def test_public_new_public_version(self):
         v = self.new_version(amo.STATUS_PUBLIC)
         eq_(self.addon.get_version(), v)
+
+    def test_public_waiting_new_unreviewed_version(self):
+        self.file.update(status=amo.STATUS_PUBLIC_WAITING)
+        self.addon.update(status=amo.STATUS_PUBLIC_WAITING)
+        new_version = self.new_version(amo.STATUS_UNREVIEWED)
+        assert self.version != new_version
+        eq_(self.addon.get_version(), self.version)
+        eq_(self.addon.latest_version, new_version)
+
+    def test_public_new_public_waiting_version(self):
+        new_version = self.new_version(amo.STATUS_PUBLIC_WAITING)
+        assert self.version != new_version
+        eq_(self.addon.get_version(), self.version)
+        eq_(self.addon.latest_version, new_version)
 
     def test_public_new_unreviewed_version(self):
         self.new_version(amo.STATUS_UNREVIEWED)

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -82,6 +82,7 @@ def home(request):
 
 def queue_counts(request):
     excluded_ids = EscalationQueue.uncached.values_list('addon', flat=True)
+    public_statuses = amo.WEBAPPS_APPROVED_STATUSES
 
     counts = {
         'pending': Webapp.uncached
@@ -101,7 +102,7 @@ def queue_counts(request):
                        .filter(version__addon__type=amo.ADDON_WEBAPP,
                                version__addon__disabled_by_user=False,
                                version__addon__is_packaged=True,
-                               version__addon__status=amo.STATUS_PUBLIC,
+                               version__addon__status__in=public_statuses,
                                version__deleted=False,
                                status=amo.STATUS_PENDING)
                        .count(),
@@ -431,9 +432,10 @@ def queue_escalated(request):
 @permission_required('Apps', 'Review')
 def queue_updates(request):
     excluded_ids = EscalationQueue.uncached.values_list('addon', flat=True)
+    pub_statuses = amo.WEBAPPS_APPROVED_STATUSES
     addon_ids = (File.objects.filter(status=amo.STATUS_PENDING,
                                      version__addon__is_packaged=True,
-                                     version__addon__status=amo.STATUS_PUBLIC,
+                                     version__addon__status__in=pub_statuses,
                                      version__addon__type=amo.ADDON_WEBAPP,
                                      version__addon__disabled_by_user=False,
                                      version__deleted=False)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -465,8 +465,10 @@ class Webapp(Addon):
 
         # If there are no public versions and at least one pending, set status
         # to pending.
+        public_statuses = amo.WEBAPPS_APPROVED_STATUSES
         has_public = (
-            self.versions.filter(files__status=amo.STATUS_PUBLIC).exists())
+            self.versions.filter(files__status__in=public_statuses).exists()
+        )
         has_pending = (
             self.versions.filter(files__status=amo.STATUS_PENDING).exists())
         if not has_public and has_pending:

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -1025,6 +1025,14 @@ class TestUpdateStatus(amo.tests.TestCase):
         app.update_status()
         eq_(app.status, amo.STATUS_PUBLIC)
 
+    def test_was_public_waiting_then_new_version(self):
+        app = amo.tests.app_factory(status=amo.STATUS_PUBLIC_WAITING)
+        File.objects.filter(version__addon=app).update(status=app.status)
+        amo.tests.version_factory(addon=app,
+                                  file_kw=dict(status=amo.STATUS_PENDING))
+        app.update_status()
+        eq_(app.status, amo.STATUS_PUBLIC_WAITING)
+
     def test_blocklisted(self):
         app = amo.tests.app_factory(status=amo.STATUS_BLOCKED)
         app.current_version.delete()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=868526

If an app is in PUBLIC_WAITING state, then:
- Addon.get_version() should return the current PUBLIC_WAITING version
- Webapp.update_status() shouldn't erase PUBLIC_WAITING when there is a new version
- When new versions are uploaded for that app, it should go in the update queue
