### PR TITLE
Toggle id_packaged checkbox in a consistent way in submit page (bug 891890)

### DIFF
--- a/media/js/common/upload-packaged-app.js
+++ b/media/js/common/upload-packaged-app.js
@@ -213,7 +213,7 @@
                 }};
 
                 $('#id_upload').val(results.upload);
-                $('#id_packaged').attr('checked', true);
+                $('#id_packaged').prop('checked', true);
                 upload_progress_inside.animate({'width': '100%'}, animateArgs);
             });
 

--- a/media/js/devreg/devhub.js
+++ b/media/js/devreg/devhub.js
@@ -224,7 +224,7 @@ $(document).ready(function() {
         function check_webapp_validation(results) {
             var $upload_field = $('#upload-webapp-url');
             $('#id_upload').val(results.upload);
-            $('#id_packaged').val('');
+            $('#id_packaged').prop('checked', false);
             if(results.error) {
                 $upload_field.trigger("upload_finished", [false, results, results.error]);
             } else if(!results.validation) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=891890 (Uploading a packaged app after having entered an hosted app URL creates an hybrid monster)

The python code behind trusts 'packaged' in post data to be consistent with the upload it's receiving, so the only fault seems to be lying in the client-side code.
