### PR TITLE
Support Server Name Indication (bug 875142)

### DIFF
--- a/docs/topics/install-zamboni/installation.rst
+++ b/docs/topics/install-zamboni/installation.rst
@@ -40,7 +40,7 @@ The following command will install the required development files on Ubuntu or,
 if you're running a recent version, you can `install them automatically
 <apt:python-dev,python-virtualenv,libxml2-dev,libxslt1-dev,libmysqlclient-dev,libmemcached-dev>`_::
 
-    sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev libmemcached-dev libssl-dev swig
+    sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev libmemcached-dev libssl-dev swig openssl
 
 On versions 12.04 and later, you will need to install a patched version of
 M2Crypto instead of the version from PyPI.::
@@ -298,8 +298,8 @@ Persona
 -------
 
 We use `Persona <https://login.persona.org/>`_ to log in and create accounts.
-In order for this to work you need to set ``SITE_URL`` and ``STATIC_URL`` in 
-your local settings file based on how you run your dev server. Here is an 
+In order for this to work you need to set ``SITE_URL`` and ``STATIC_URL`` in
+your local settings file based on how you run your dev server. Here is an
 example::
 
     SITE_URL = 'http://localhost:8000'

--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -8,5 +8,8 @@ PIL==1.1.7
 # Temporary.
 M2Crypto==0.20.2
 
+# This is required by the app validator.
+pyOpenSSL==0.13
+
 # For the addon validator, including C speedups.
 simplejson==2.3.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -58,11 +58,13 @@ mock==1.0.0
 monolith.client==0.6
 moz-addon-packager==1.0.1
 mozpay==2.0.0
+ndg-httpsclient==0.3.2
 nose==1.2.1
 newrelic==1.11.0.55
 oauth2==1.5.211
 oauthlib==0.4.0
 ordereddict==1.1
+pyasn1==0.1.7
 PyBrowserID==0.6
 pyelasticsearch==0.5
 pyes==0.16.0
@@ -77,7 +79,7 @@ rdflib==3.0.0
 recaptcha-client==1.0.5
 receipts==0.2.6
 redis==2.7.6
-requests==1.2.0
+requests==1.2.3
 schematic==0.2
 #signing_clients==0.1.7
 six==1.3.0
@@ -89,7 +91,7 @@ tastypie-services==0.2.2
 
 ## Not on pypi.
 -e git+https://github.com/mozilla/amo-validator.git@a07a4e89ed6c5390caa20b858f92eee6fc974e21#egg=amo-validator
--e git+https://github.com/mozilla/app-validator.git@cb339548dab7699ad5553778015352ba56f92180#egg=app-validator
+-e git+https://github.com/mozilla/app-validator.git@f604ed588d0fca628e3b7bdfb01bde6329e6cc10#egg=app-validator
 -e git+https://github.com/jsocol/commonware.git@27646ecaca40a89024cc581c3ecf5eb0fa87ee11#egg=commonware
 -e git+https://github.com/jbalogh/django-queryset-transform@a1ba6ae41bd86f5bb9ff66fb56614e0fafe6e022#egg=django-queryset-transform
 -e git+https://github.com/miracle2k/django-tables.git@546f339308103880c823b2056830fcdc9220edd0#egg=django-tables


### PR DESCRIPTION
This fixes certain hostname mismatches when validating apps.
See
https://github.com/kennethreitz/requests/commit/50e592209fe7a62556bf5a14339135e071e4017d#L1R55

Note that PyOpenSSL won't be available until bug 892654
but until then requests will silently ignore the ImportError.
