### PR TITLE
store cats as slugs in ES to fix linux app installs (bug 876293)

### DIFF
--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -296,7 +296,7 @@ class TestAppCreateHandler(CreateHandler, AMOPaths):
         eq_(res.status_code, 200)
         data = json.loads(res.content)
         self.assertSetEqual(data['categories'],
-                            [c.pk for c in self.categories])
+                            [c.slug for c in self.categories])
         eq_(data['current_version'], app.current_version.version)
         self.assertSetEqual(data['device_types'],
                             [n.api_name for n in amo.DEVICE_TYPES.values()])

--- a/mkt/search/api.py
+++ b/mkt/search/api.py
@@ -152,9 +152,9 @@ class WithFeaturedResource(SearchResource):
     def alter_list_data_to_serialize(self, request, data):
         form_data = self.search_form(request)
         region = getattr(request, 'REGION', mkt.regions.WORLDWIDE)
-        cat_id = form_data.get('cat')
-        if cat_id:
-            cat_id = [cat_id]
+        cat_slug = form_data.get('cat')
+        if cat_slug:
+            cat_slug = [cat_slug]
 
         # Filter by device feature profile.
         profile = None
@@ -163,7 +163,7 @@ class WithFeaturedResource(SearchResource):
             if sig:
                 profile = FeatureProfile.from_signature(sig)
 
-        qs = Webapp.featured(cat=cat_id, region=region, profile=profile)
+        qs = Webapp.featured(cat=cat_slug, region=region, profile=profile)
 
         bundles = [self.build_bundle(obj=obj, request=request) for obj in qs]
         data['featured'] = [AppResource().full_dehydrate(bundle)

--- a/mkt/search/forms.py
+++ b/mkt/search/forms.py
@@ -126,9 +126,11 @@ class ApiSearchForm(forms.Form):
 
     def __init__(self, *args, **kw):
         super(ApiSearchForm, self).__init__(*args, **kw)
-        CATS = (Category.objects.filter(type=amo.ADDON_WEBAPP, weight__gte=0)
-                .values_list('id', flat=True))
-        self.fields['cat'].choices = [(pk, pk) for pk in CATS]
+
+        # Clients understand cats via slugs, Zamboni thinks of them via IDs.
+        self.fields['cat'].choices = (
+            Category.objects.filter(type=amo.ADDON_WEBAPP, weight__gte=0)
+            .values_list('slug', 'id'))
 
         self.initial.update({
             'type': 'app',
@@ -138,7 +140,7 @@ class ApiSearchForm(forms.Form):
 
     def clean_cat(self):
         if self.cleaned_data['cat']:
-            return self.cleaned_data['cat'].pk
+            return self.cleaned_data['cat'].slug
 
     def clean_type(self):
         return amo.MKT_ADDON_TYPES_API.get(self.cleaned_data['type'],

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -679,7 +679,7 @@ class Webapp(Addon):
             filters.update(filter_overrides)
 
         if cat:
-            filters.update(category=cat.id)
+            filters.update(category=cat.slug)
 
         srch = S(WebappIndexer).filter(**filters)
 
@@ -965,7 +965,10 @@ class WebappIndexer(MappingType, Indexable):
                     'author': {'type': 'string'},
                     'average_daily_users': {'type': 'long'},
                     'bayesian_rating': {'type': 'float'},
-                    'category': {'type': 'integer'},
+                    'category': {
+                        'type': 'string',
+                        'index': 'not_analyzed'
+                    },
                     'content_ratings': {
                         'type': 'object',
                         'dynamic': 'true',
@@ -1115,7 +1118,7 @@ class WebappIndexer(MappingType, Indexable):
         d['app_type'] = (amo.ADDON_WEBAPP_PACKAGED if obj.is_packaged else
                          amo.ADDON_WEBAPP_HOSTED)
         d['author'] = obj.developer_name
-        d['category'] = getattr(obj, 'category_ids', [])
+        d['category'] = list(obj.categories.values_list('slug', flat=True))
         d['content_ratings'] = content_ratings if content_ratings else None
         d['current_version'] = version.version if version else None
         d['default_locale'] = obj.default_locale

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -379,7 +379,7 @@ class TestWebapp(amo.tests.TestCase):
         # and only in US region.
         for abbr, region in mkt.regions.REGIONS_CHOICES:
             self.assertSetEqual(
-                [a.id for a in Webapp.featured(cat=[cat], region=region)],
+                [a.id for a in Webapp.featured(cat=[cat.slug], region=region)],
                 creatured_ids if abbr == 'us' else [])
 
     def test_featured_no_creatured(self):
@@ -1216,7 +1216,7 @@ class TestWebappIndexer(amo.tests.TestCase):
         AddonCategory.objects.create(addon=self.app, category=cat)
 
         obj, doc = self._get_doc()
-        eq_(doc['category'], [cat.id])
+        eq_(doc['category'], [cat.slug])
 
     def test_extract_device(self):
         device = DEVICE_TYPES.keys()[0]

--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -105,6 +105,14 @@ class TestAppToDict(amo.tests.TestCase):
                             res['versions'].keys())
         eq_(res['current_version'], v.version)
 
+    def test_categories(self):
+        cat1 = Category.objects.create(type=amo.ADDON_WEBAPP, slug='cat1')
+        cat2 = Category.objects.create(type=amo.ADDON_WEBAPP, slug='cat2')
+        AddonCategory.objects.create(addon=self.app, category=cat1)
+        AddonCategory.objects.create(addon=self.app, category=cat2)
+        res = app_to_dict(self.app)
+        self.assertSetEqual(res['categories'], ['cat1', 'cat2'])
+
 
 @override_settings(PURCHASE_ENABLED_REGIONS=[regions.US.id, regions.PL.id])
 class TestAppToDictPrices(amo.tests.TestCase):

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -64,7 +64,7 @@ def app_to_dict(app, region=None, profile=None, request=None):
     data = {
         'app_type': app.app_type,
         'author': app.developer_name,
-        'categories': list(app.categories.values_list('pk', flat=True)),
+        'categories': list(app.categories.values_list('slug', flat=True)),
         'content_ratings': dict([(cr.get_body().name, {
             'name': cr.get_rating().name,
             'description': unicode(cr.get_rating().description),

--- a/mkt/zadmin/models.py
+++ b/mkt/zadmin/models.py
@@ -89,11 +89,10 @@ class FeaturedAppQuerySet(models.query.QuerySet):
         return qs
 
     def featured_ids(self, cat=None, region=None, profile=None):
-
         carrier = get_carrier_id()
         cache_key = 'featured:%s:%s:%s:%s' % (
             region.id if region else 0,
-            ','.join(map(str, cat)) if cat else 0,
+            ','.join(cat) if cat else 0,
             profile.to_signature() if profile else 0,
             carrier if carrier else 0)
 
@@ -180,10 +179,10 @@ class FeaturedAppQuerySet(models.query.QuerySet):
     def for_category(self, cats):
         """
         Removes features in the queryset that are not in the passed
-        categories. The passed category is a list of category IDs.
+        categories. The passed category is a list of category slugs.
         """
         if cats:
-            return self.filter(category__in=cats)
+            return self.filter(category__slug__in=cats)
         return self.filter(category__isnull=True)
 
 

--- a/mkt/zadmin/tests/test_views.py
+++ b/mkt/zadmin/tests/test_views.py
@@ -94,9 +94,10 @@ class TestFeaturedApps(amo.tests.TestCase):
     fixtures = ['base/users']
 
     def setUp(self):
-        self.c1 = Category.objects.create(name='awesome',
+        self.c1 = Category.objects.create(name='awesome', slug='awesome',
                                           type=amo.ADDON_WEBAPP)
-        self.c2 = Category.objects.create(name='groovy', type=amo.ADDON_WEBAPP)
+        self.c2 = Category.objects.create(name='groovy', slug='groovy',
+                                          type=amo.ADDON_WEBAPP)
 
         self.a1 = Webapp.objects.create(status=amo.STATUS_PUBLIC,
                                         name='awesome app 1',
@@ -153,7 +154,7 @@ class TestFeaturedApps(amo.tests.TestCase):
                 'Unexpected status code for %s URL' % url)
 
     def test_get_featured_apps(self):
-        r = self.client.get(urlparams(self.url, category=self.c1.id))
+        r = self.client.get(urlparams(self.url, category=self.c1.slug))
         assert not r.content
 
         FeaturedApp.objects.create(app=self.a1, category=self.c1)
@@ -188,7 +189,7 @@ class TestFeaturedApps(amo.tests.TestCase):
                                           category=None).exists()
 
         self.client.post(self.url,
-                         {'category': self.c1.id,
+                         {'category': self.c1.slug,
                           'add': self.a1.id})
         assert FeaturedApp.objects.filter(app=self.a1,
                                           category=self.c1).exists()
@@ -205,7 +206,7 @@ class TestFeaturedApps(amo.tests.TestCase):
                                           category=self.c1).exists()
         FeaturedApp.objects.create(app=self.a1, category=None)
         self.client.post(self.url,
-                         {'category': self.c1.id,
+                         {'category': self.c1.slug,
                           'delete': self.a1.id})
         assert not FeaturedApp.objects.filter(app=self.a1,
                                               category=self.c1).exists()
@@ -282,9 +283,10 @@ class TestFeaturedApps(amo.tests.TestCase):
 class TestFeaturedAppQueryset(amo.tests.TestCase):
 
     def setUp(self):
-        self.c1 = Category.objects.create(name='awesome',
+        self.c1 = Category.objects.create(name='awesome', slug='awesome',
                                           type=amo.ADDON_WEBAPP)
-        self.c2 = Category.objects.create(name='groovy', type=amo.ADDON_WEBAPP)
+        self.c2 = Category.objects.create(name='groovy', slug='groovy',
+                                          type=amo.ADDON_WEBAPP)
 
         self.a1 = Webapp.objects.create(status=amo.STATUS_PUBLIC,
                                         name='awesome app 1',
@@ -345,8 +347,9 @@ class TestFeaturedAppQueryset(amo.tests.TestCase):
         return all(item in temp for item in x)
 
     def test_queryset_for_category(self):
-        self.assertQuerySetEqual(FeaturedApp.objects.for_category([self.c1]),
-                                 FeaturedApp.objects.filter(category=self.c1))
+        self.assertQuerySetEqual(
+            FeaturedApp.objects.for_category([self.c1.slug]),
+            FeaturedApp.objects.filter(category=self.c1))
 
     def test_queryset_for_no_category(self):
         FeaturedApp.objects.create(app=self.g1, category=None)
@@ -411,7 +414,7 @@ class TestFeaturedAppQueryset(amo.tests.TestCase):
         carrier = 'telerizon'
         either_cat = [self.c1, self.c2]
         assert self._is_overlap(
-            FeaturedApp.objects.for_category([self.c1]),
+            FeaturedApp.objects.for_category([self.c1.slug]),
             FeaturedApp.objects.featured(cat=[self.c1])
         ), 'Unexpected items in category %s' % self.c1
         assert self._is_overlap(
@@ -523,9 +526,9 @@ class TestFeaturedSuggestions(amo.tests.ESTestCase):
         super(TestFeaturedSuggestions, self).setUp()
         self.url = reverse('zadmin.featured_suggestions')
 
-        self.c1 = Category.objects.create(name='groovy',
+        self.c1 = Category.objects.create(name='groovy', slug='groovy',
             type=amo.ADDON_WEBAPP)
-        self.c2 = Category.objects.create(name='awesome',
+        self.c2 = Category.objects.create(name='awesome', slug='awesome',
             type=amo.ADDON_WEBAPP)
 
         self.w1 = Webapp.objects.create(status=amo.STATUS_PUBLIC,
@@ -568,9 +571,9 @@ class TestFeaturedSuggestions(amo.tests.ESTestCase):
 
     def test_with_category(self):
         self._login()
-        self.check_suggestions(self.url, 'q=app&category=%d' % self.c1.id,
+        self.check_suggestions(self.url, 'q=app&category=%s' % self.c1.slug,
                                apps=[self.w1])
-        self.check_suggestions(self.url, 'q=app&category=%d' % self.c2.id,
+        self.check_suggestions(self.url, 'q=app&category=%s' % self.c2.slug,
                                apps=[self.w2])
 
     def test_access(self):


### PR DESCRIPTION
Linux webapp installs on Marketplace were breaking because Firefox clients expected categories to be slugs (strings), not IDs (integers). Categories are passed into app installs for Linux to get them into proper system application categories. The categories' IDs have no meaning to clients outside of Zamboni.
1. Store categories into ElasticSearch by their slugs and not by their IDs. Done by changing the mapping.
2. When querying/filtering ES, query/filter with slug.
3. When dehydrating, cast categories as slugs.

This involves changing the API. The search API already can accept both IDs or slugs. The search form is changed to clean the category to its slug and ES queries also changed to use slugs.
