### PR TITLE
Inherit nomination when app is in PUBLIC_WAITING state as well (bug 894394)

### DIFF
--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -527,7 +527,8 @@ def inherit_nomination(sender, instance, **kw):
             instance.update(nomination=last_ver[0].nomination, _signal=False)
             log.debug('[Webapp:%s] Inheriting nomination from prior pending '
                       'version' % addon.id)
-        elif addon.status == amo.STATUS_PUBLIC and not instance.nomination:
+        elif (addon.status in amo.WEBAPPS_APPROVED_STATUSES and
+              not instance.nomination):
             log.debug('[Webapp:%s] Setting nomination date to now for new '
                       'version.' % addon.id)
             instance.update(nomination=datetime.datetime.now(), _signal=False)

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -445,7 +445,7 @@ def queue_updates(request):
         request,
         Webapp.uncached.exclude(id__in=excluded_ids).filter(id__in=addon_ids))
 
-    apps = [QueuedApp(app, app.all_versions[0].nomination)
+    apps = [QueuedApp(app, app.all_versions[0].nomination or app.created)
             for app in Webapp.version_and_file_transformer(qs)]
     apps = sorted(apps, key=lambda a: a.created)
     return _queue(request, apps, 'updates')

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -461,6 +461,16 @@ class TestWebapp(amo.tests.TestCase):
         v = Version.objects.create(addon=app, version='1.9')
         self.assertCloseToNow(v.nomination)
 
+    def test_nomination_public_waiting(self):
+        # New versions while public waiting get a new version nomination.
+        app = app_factory()
+        app.update(is_packaged=True, status=amo.STATUS_PUBLIC_WAITING)
+        old_ver = app.versions.latest()
+        old_ver.update(nomination=self.days_ago(1))
+        old_ver.all_files[0].update(status=amo.STATUS_PUBLIC_WAITING)
+        v = Version.objects.create(addon=app, version='1.9')
+        self.assertCloseToNow(v.nomination)
+
     def test_excluded_in(self):
         app1 = app_factory()
         region = mkt.regions.BR


### PR DESCRIPTION
Also, don't fail in the reviewer tools sort if the nomination date is null, just ignore it.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=894394
