### PR TITLE
add view manifest for packaged apps on lookup (bug 852691)

### DIFF
--- a/media/css/devreg/manifest.styl
+++ b/media/css/devreg/manifest.styl
@@ -1,0 +1,65 @@
+@import 'lib';
+
+
+#manifest-headers,
+#manifest-permissions {
+    background-color: $faint-gray;
+    border: $dark-gray 2px solid;
+    padding: 5px 10px;
+}
+
+#manifest-headers,
+#manifest-permissions,
+#manifest-contents {
+    border-box();
+    clear: both;
+    color: $dark-gray;
+    font: 12px/14px $mono-stack;
+    list-style: none;
+    margin: 15px 0;
+    overflow-x: auto;
+    white-space: pre;
+    width: 100%;
+}
+
+#manifest-contents {
+    background-color: #def;
+    border: darken(#def, 75%) 2px solid;
+    // Using counters so we can style the line numbers.
+    counter-reset: item;
+    li {
+        counter-increment: item;
+        padding: 5px 10px;
+        &:before {
+            background-color: $faint-gray;
+            display: inline-block;
+            color: $note-gray;
+            content: counter(item);
+            margin: -5px 10px -5px -10px;
+            padding: 5px;
+            text-align: right;
+            width: 3ex;
+        }
+        &:nth-child(2n + 1) {
+            background: lighten(#def, 4%);
+        }
+    }
+}
+
+iframe#manifest-contents {
+    min-height: 250px;
+}
+
+#view-manifest {
+    &:hover, b {
+        color: #036;
+    }
+    b {
+        &:before {
+            content: "(";
+        }
+        &:after {
+            content: ")";
+        }
+    }
+}

--- a/media/css/devreg/reviewers.styl
+++ b/media/css/devreg/reviewers.styl
@@ -1122,20 +1122,6 @@ span.currently_viewing_warning {
     }
 }
 
-#view-manifest {
-    &:hover, b {
-        color: #036;
-    }
-    b {
-        &:before {
-            content: "(";
-        }
-        &:after {
-            content: ")";
-        }
-    }
-}
-
 #leaderboard {
     td.name {
         width: 70%;
@@ -1172,55 +1158,6 @@ span.currently_viewing_warning {
             padding: 0 5px;
         }
     }
-}
-
-#manifest-headers,
-#manifest-permissions,
-#manifest-contents {
-    border-box();
-    color: $dark-gray;
-    clear: both;
-    font: 12px/14px $mono-stack;
-    list-style: none;
-    margin: 15px 0;
-    overflow-x: auto;
-    white-space: pre;
-    width: 100%;
-}
-
-#manifest-headers,
-#manifest-permissions {
-    background-color: $faint-gray;
-    border: $dark-gray 2px solid;
-    padding: 5px 10px;
-}
-
-#manifest-contents {
-    background-color: #def;
-    border: darken(#def, 75%) 2px solid;
-    // Using counters so we can style the line numbers.
-    counter-reset: item;
-    li {
-        counter-increment: item;
-        padding: 5px 10px;
-        &:before {
-            background-color: $faint-gray;
-            display: inline-block;
-            color: $note-gray;
-            content: counter(item);
-            margin: -5px 10px -5px -10px;
-            padding: 5px;
-            text-align: right;
-            width: 3ex;
-        }
-        &:nth-child(2n + 1) {
-            background: lighten(#def, 4%);
-        }
-    }
-}
-
-iframe#manifest-contents {
-    min-height: 250px;
 }
 
 // Addresses issue with drop-downs menus vs. active queue tab.

--- a/media/js/mkt/lookup-tool.js
+++ b/media/js/mkt/lookup-tool.js
@@ -1,3 +1,6 @@
+require(['prefetchManifest']);
+
+
 (function() {
     $('#account-search').searchSuggestions($('#account-search-suggestions'),
                                            processResults);

--- a/media/js/mkt/manifest.js
+++ b/media/js/mkt/manifest.js
@@ -1,0 +1,76 @@
+define('prefetchManifest', [], function() {
+    var $viewManifest = $('#view-manifest'),
+        $manifest = $('#manifest-contents');
+
+    if (!$viewManifest.length) {
+        return;
+    }
+
+    // Prefetch manifest.
+    $.getJSON($viewManifest.data('url'), function(data) {
+        var manifestContents = data;
+
+        // Show manifest.
+        $viewManifest.click(_pd(function() {
+            var $this = $viewManifest,
+                $manifest = $('#manifest-headers, #manifest-contents, #manifest-permissions');
+            if ($manifest.length) {
+                $manifest.toggle();
+            } else {
+                if (!manifestContents.success) {
+                    // If requests couldn't fetch the manifest, let Firefox render it.
+                    $('<iframe>', {'id': 'manifest-contents',
+                                   'src': 'view-source:' + $this.data('manifest')}).insertAfter($this);
+                } else {
+                    var contents = '',
+                        headers = '';
+
+                    _.each(manifestContents.content.split('\n'), function(v, k) {
+                        if (v) {
+                            contents += format('<li>{0}</li>', v);
+                        }
+                    });
+                    $('<ol>', {'id': 'manifest-contents',
+                               'html': contents}).insertAfter($this);
+
+                    if (manifestContents.headers) {
+                        _.each(manifestContents.headers, function(v, k) {
+                            headers += format('<li><b>{0}:</b> {1}</li>', k, v);
+                        });
+                        $('<ol>', {'id': 'manifest-headers',
+                                   'html': headers}).insertAfter($this);
+                    }
+
+                    if (manifestContents.permissions) {
+                        var permissions = format(
+                            '<h4>{0}</h4><dl>', gettext('Requested Permissions:'));
+                        permissions += _.map(
+                            manifestContents.permissions,
+                            function(details, permission) {
+                                var type;
+                                if (details.type) {
+                                    switch (details.type) {
+                                        case 'cert':
+                                            type = gettext('Certified');
+                                            break;
+                                        case 'priv':
+                                            type = gettext('Privileged');
+                                            break;
+                                        case 'web':
+                                            type = gettext('Unprivileged');
+                                    }
+                                }
+                                return format(
+                                    '<dt>{0}</dt><dd>{1}, {2}</dd>',
+                                    permission, type,
+                                    details.description || gettext('No reason given'));
+                            }
+                        ).join('');
+                        $('<div>', {'id': 'manifest-permissions',
+                                    'html': permissions}).insertAfter($this);
+                    }
+                }
+            }
+        }));
+    });
+});

--- a/media/js/mkt/reviewers.js
+++ b/media/js/mkt/reviewers.js
@@ -1,3 +1,6 @@
+require(['prefetchManifest']);
+
+
 (function() {
     if (z.capabilities.mobile) {
         z.body.addClass('mobile');
@@ -8,8 +11,6 @@
     if (z.capabilities.desktop) {
         z.body.addClass('desktop');
     }
-
-    initPrefetchManifest();
 
      // Reviewer tool search.
     initAdvancedMobileSearch();
@@ -222,83 +223,5 @@ function syncPrettyMobileForm() {
             valStrs.length ? valStrs.join() :
             $('.multi-val', $valSelectField).length ? gettext('Any') :
                                                       firstPrettyVal);
-    });
-}
-
-
-function initPrefetchManifest() {
-   var $viewManifest = $('#view-manifest'),
-       $manifest = $('#manifest-contents');
-
-    if (!$viewManifest.length) {
-        return;
-    }
-
-    // Prefetch manifest.
-    $.getJSON($viewManifest.data('url'), function(data) {
-        var manifestContents = data;
-
-        // Show manifest.
-        $viewManifest.click(_pd(function() {
-            var $this = $viewManifest,
-                $manifest = $('#manifest-headers, #manifest-contents, #manifest-permissions');
-            if ($manifest.length) {
-                $manifest.toggle();
-            } else {
-                if (!manifestContents.success) {
-                    // If requests couldn't fetch the manifest, let Firefox render it.
-                    $('<iframe>', {'id': 'manifest-contents',
-                                   'src': 'view-source:' + $this.data('manifest')}).insertAfter($this);
-                } else {
-                    var contents = '',
-                        headers = '';
-
-                    _.each(manifestContents.content.split('\n'), function(v, k) {
-                        if (v) {
-                            contents += format('<li>{0}</li>', v);
-                        }
-                    });
-                    $('<ol>', {'id': 'manifest-contents',
-                               'html': contents}).insertAfter($this);
-
-                    if (manifestContents.headers) {
-                        _.each(manifestContents.headers, function(v, k) {
-                            headers += format('<li><b>{0}:</b> {1}</li>', k, v);
-                        });
-                        $('<ol>', {'id': 'manifest-headers',
-                                   'html': headers}).insertAfter($this);
-                    }
-
-                    if (manifestContents.permissions) {
-                        var permissions = format(
-                            '<h4>{0}</h4><dl>', gettext('Requested Permissions:'));
-                        permissions += _.map(
-                            manifestContents.permissions,
-                            function(details, permission) {
-                                var type;
-                                if (details.type) {
-                                    switch (details.type) {
-                                        case 'cert':
-                                            type = gettext('Certified');
-                                            break;
-                                        case 'priv':
-                                            type = gettext('Privileged');
-                                            break;
-                                        case 'web':
-                                            type = gettext('Unprivileged');
-                                    }
-                                }
-                                return format(
-                                    '<dt>{0}</dt><dd>{1}, {2}</dd>',
-                                    permission, type,
-                                    details.description || gettext('No reason given'));
-                            }
-                        ).join('');
-                        $('<div>', {'id': 'manifest-permissions',
-                                    'html': permissions}).insertAfter($this);
-                    }
-                }
-            }
-        }));
     });
 }

--- a/mkt/asset_bundles.py
+++ b/mkt/asset_bundles.py
@@ -75,6 +75,7 @@ CSS = {
         'css/devreg/consumer-buttons.styl',
         'css/devreg/ratings.styl',
         'css/devreg/data-grid.styl',
+        'css/devreg/manifest.styl',
         'css/devreg/reviewers.styl',
         'css/devreg/themes_review.styl',
         'css/devreg/legacy-paginator.styl',
@@ -124,6 +125,7 @@ CSS = {
         'css/devreg/stats.styl',
     ),
     'mkt/lookup': (
+        'css/devreg/manifest.styl',
         'css/devreg/lookup-tool.styl',
         'css/devreg/activity.styl',
     ),
@@ -274,6 +276,7 @@ JS = {
         'js/mkt/payments.js',
         'js/mkt/install.js',
         'js/mkt/buttons.js',
+        'js/mkt/manifest.js',
         'js/mkt/reviewers.js',
         'js/devreg/expandable.js',
         'js/devreg/mobile_review_actions.js',
@@ -308,6 +311,7 @@ JS = {
         'js/common/keys.js',
         'js/impala/ajaxcache.js',
         'js/impala/suggestions.js',
+        'js/mkt/manifest.js',
         'js/mkt/lookup-tool.js',
     ),
     'mkt/ecosystem': (

--- a/mkt/lookup/templates/lookup/app_summary.html
+++ b/mkt/lookup/templates/lookup/app_summary.html
@@ -29,7 +29,16 @@
           {% endif %}
         </dd>
         <dt>{{ _('Manifest') }}</dt>
-        <dd><a target="_blank" href="{{ app.manifest_url }}">{{ app.manifest_url }}</a></dd>
+        <dd>
+          {% if app.is_packaged %}
+            {{ _('Packaged') }}
+          {% else %}
+            <a target="_blank" href="{{ app.manifest_url }}">{{ app.manifest_url }}</a>
+          {% endif %}
+            <a href="#" id="view-manifest" data-manifest="{{ app.manifest_url }}"
+               data-url="{{ url('reviewers.apps.review.manifest', app.app_slug) }}">
+              <b>{{ _('View') }}</b></a>
+        </dd>
         <dt>{{ _('Type') }}</dt>
         <dd>
           {{ amo.ADDON_TYPE[app.type] }};

--- a/mkt/reviewers/templates/reviewers/includes/details.html
+++ b/mkt/reviewers/templates/reviewers/includes/details.html
@@ -23,9 +23,14 @@
     </dd>
     <dt>{{ _('Manifest URL') }}</dt>
     <dd>
+      {% if product.is_packaged %}
+        {{ _('Packaged') }}
+      {% else %}
+        <a target="_blank" href="{{ product.manifest_url }}">{{ product.manifest_url }}</a>
+      {% endif %}
       <a href="#" id="view-manifest" data-manifest="{{ product.manifest_url }}"
          data-url="{{ url('reviewers.apps.review.manifest', product.app_slug) }}">
-        {{ product.manifest_url }} <b>{{ _('View') }}</b></a>
+        <b>{{ _('View') }}</b></a>
     </dd>
     {% if product.app_domain %}
     <dt>{{ _('App domain') }}</dt>


### PR DESCRIPTION
On the app summary page from the lookup tool, you can now view manifests for packaged apps in the same way they are viewed from the app review page.

Patch is mostly abstracting code and media from `reviewers` and including it in `lookup`. Some formatting improvements on the view link.
