### PR TITLE
quick fix for bug 846055

### DIFF
--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -48,6 +48,13 @@ def file_review_status(addon, file):
                               amo.STATUS_LITE_AND_NOMINATED,
                               amo.STATUS_PUBLIC]:
             return _(u'Pending Full Review')
+    if file.status in [amo.STATUS_DISABLED, amo.STATUS_REJECTED]:
+        if file.reviewed is not None:
+            return _(u'Rejected')
+        # Can't assume that if the reviewed date is missing its
+        # unreviewed.  Especially for versions.
+        else:
+            return _(u'Rejected or Unreviewed')
     return amo.STATUS_CHOICES[file.status]
 
 

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -82,7 +82,7 @@
       {% set version = pager.object_list[i-1] %}
       <tr class="listing-header">
         <th colspan="2">
-          {% trans version = version.version, created = version.created|datetime, version_status = version.status|join(','), developer_name = version.developer_name %}
+          {% trans version = version.version, created = version.created|datetime, version_status = file_review_status(product, version), developer_name = version.developer_name %}
           Version {{ version }} &middot; {{ developer_name }} &middot; {{ created }} <span class="light">&middot; {{ version_status }}</span>
           {% endtrans %}
         </th>


### PR DESCRIPTION
STATUS_REJECTED shouldn't actually happen for versions&files but I covering all bases.
file_review_status will work with version and well as file objects as they both contain the same status variable.
