### PR TITLE
Use current, not latest version when updating name from manifest (bug 893821)

### DIFF
--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -833,7 +833,7 @@ class Webapp(Addon):
         if not self.is_packaged:
             return None
 
-        file_ = self.versions.latest().all_files[0]
+        file_ = self.current_version.all_files[0]
         mf = self.get_manifest_json(file_)
 
         # Get names in "locales" as {locale: name}.

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -547,6 +547,24 @@ class TestPackagedAppManifestUpdates(amo.tests.TestCase):
         self.webapp.update_supported_locales()
         eq_(self.webapp.current_version.supported_locales, 'de,es')
 
+    def test_update_name_from_package_manifest_version(self):
+        evil_manifest = {
+            'name': u'Evil App Name'
+        }
+        good_manifest = {
+            'name': u'Good App Name',
+        }
+        latest_version = version_factory(addon=self.webapp, version='2.3',
+            file_kw=dict(status=amo.STATUS_DISABLED))
+        current_version = self.webapp.current_version
+        AppManifest.objects.create(version=current_version,
+                                   manifest=json.dumps(good_manifest))
+        AppManifest.objects.create(version=latest_version,
+                                   manifest=json.dumps(evil_manifest))
+
+        self.webapp.update_name_from_package_manifest()
+        eq_(self.webapp.name, u'Good App Name')
+
 
 class TestWebappVersion(amo.tests.TestCase):
     fixtures = ['base/platforms']


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=893821
