### PR TITLE
lookup app summary packaged zip download links (bug 894110)

### DIFF
--- a/mkt/lookup/templates/lookup/app_summary.html
+++ b/mkt/lookup/templates/lookup/app_summary.html
@@ -107,7 +107,8 @@
               <td>{{ v.created|datetime }}</td>
               <td>{{ v.version }} ({{ v.id }})</td>
               {% with file = v.files.latest() %}
-                <td>{{ file.filename }} ({{ file.id }}, {{ file.size|filesizeformat }})</td>
+                <td><a href="{{ v.all_files[0].get_url_path('') }}" class="download">
+                  {{ file.filename }} ({{ file.id }}, {{ file.size|filesizeformat }})</a></td>
                 <td>{{ amo.STATUS_CHOICES[file.status] }}</td>
               {% endwith %}
             </tr>

--- a/mkt/lookup/tests/test_views.py
+++ b/mkt/lookup/tests/test_views.py
@@ -639,8 +639,14 @@ class TestAppSummary(AppSummaryTest):
 
     def test_version_history_packaged(self):
         self.app.update(is_packaged=True)
+        self.version = self.app.current_version
+        self.file = self.version.all_files[0]
+        self.file.update(filename='mozball.zip')
+
         res = self.summary()
         eq_(pq(res.content)('section.version-history').length, 1)
+        assert 'mozball.zip' in pq(res.content)(
+            'section.version-history a.download').attr('href')
 
     def test_edit_link_staff(self):
         res = self.summary()


### PR DESCRIPTION
Down at the bottom of the App Summary page (eg. https://marketplace.firefox.com/lookup/app/418364/summary ) there is a Version History section with a bunch of files in it.  All the file names should be links to download the packaged apps.  All of those versions are accessible from the status & versions page (eg. https://marketplace.firefox.com/developers/app/here-maps-packaged/status ).
