### PR TITLE
Return a different status code for "already purchased" (bug 891000)

### DIFF
--- a/apps/addons/decorators.py
+++ b/apps/addons/decorators.py
@@ -6,8 +6,8 @@ from django.shortcuts import get_object_or_404
 
 import waffle
 
-from addons.models import Addon
 import commonware.log
+from addons.models import Addon
 
 log = commonware.log.getLogger('mkt.purchase')
 
@@ -85,17 +85,6 @@ def has_purchased_or_refunded(f):
         if addon.is_premium() and not (addon.has_purchased(request.amo_user) or
                                        addon.is_refunded(request.amo_user)):
             log.info('Not purchased or refunded: %d' % addon.pk)
-            raise PermissionDenied
-        return f(request, addon, *args, **kw)
-    return wrapper
-
-
-def has_not_purchased(f):
-    """ The opposite of has_purchased. """
-    @functools.wraps(f)
-    def wrapper(request, addon, *args, **kw):
-        if addon.is_premium() and addon.has_purchased(request.amo_user):
-            log.info('Already purchased: %d' % addon.pk)
             raise PermissionDenied
         return f(request, addon, *args, **kw)
     return wrapper

--- a/apps/addons/tests/test_decorators.py
+++ b/apps/addons/tests/test_decorators.py
@@ -6,8 +6,8 @@ from nose.tools import eq_
 from test_utils import RequestFactory
 
 import amo.tests
-from addons.models import Addon
 from addons import decorators as dec
+from addons.models import Addon
 
 
 class TestAddonView(amo.tests.TestCase):
@@ -124,18 +124,5 @@ class TestPremiumDecorators(amo.tests.TestCase):
         view = dec.has_purchased(self.func)
         self.addon.is_premium.return_value = True
         self.addon.has_purchased.return_value = False
-        with self.assertRaises(PermissionDenied):
-            view(self.request, self.addon)
-
-    def test_has_not_purchased(self):
-        view = dec.has_not_purchased(self.func)
-        self.addon.is_premium.return_value = True
-        self.addon.has_purchased.return_value = False
-        eq_(view(self.request, self.addon), True)
-
-    def test_has_not_purchased_failure(self):
-        view = dec.has_not_purchased(self.func)
-        self.addon.is_premium.return_value = True
-        self.addon.has_purchased.return_value = True
         with self.assertRaises(PermissionDenied):
             view(self.request, self.addon)

--- a/docs/api/topics/payment.rst
+++ b/docs/api/topics/payment.rst
@@ -289,8 +289,8 @@ Produces the JWT that is passed to `navigator.mozPay`_.
 
     :status 201: successfully completed.
     :status 401: not authenticated.
-    :status 403: app cannot be purchased. This could be because the app has
-        already been purchased.
+    :status 403: app cannot be purchased.
+    :status 409: app already purchased.
 
 .. _payment-status-label:
 

--- a/mkt/api/base.py
+++ b/mkt/api/base.py
@@ -12,19 +12,20 @@ from django.http import HttpResponseNotFound
 
 import commonware.log
 from rest_framework.routers import Route, SimpleRouter
-from rest_framework.relations import HyperlinkedRelatedField, SlugRelatedField
+from rest_framework.relations import HyperlinkedRelatedField
 from rest_framework.viewsets import GenericViewSet
 from tastypie import fields, http
 from tastypie.bundle import Bundle
 from tastypie.exceptions import (ImmediateHttpResponse, NotFound,
                                  UnsupportedFormat)
 from tastypie.fields import ToOneField
+from tastypie.http import HttpConflict
 from tastypie.resources import ModelResource, Resource
 
 from access import acl
 from translations.fields import PurifiedField, TranslatedField
 
-from .exceptions import DeserializationError
+from .exceptions import AlreadyPurchased, DeserializationError
 from .http import HttpTooManyRequests
 from .serializers import Serializer
 
@@ -119,6 +120,9 @@ class Marketplace(object):
         except PermissionDenied:
             # Reraise PermissionDenied as 403, otherwise you get 500.
             raise http_error(http.HttpForbidden, 'Permission denied.')
+
+        except AlreadyPurchased:
+            raise http_error(HttpConflict, 'Already purchased app.')
 
     def non_form_errors(self, error_list):
         """

--- a/mkt/api/exceptions.py
+++ b/mkt/api/exceptions.py
@@ -4,3 +4,7 @@ from tastypie.exceptions import TastypieError
 class DeserializationError(TastypieError):
     def __init__(self, original=None):
         self.original = original
+
+
+class AlreadyPurchased(Exception):
+    pass

--- a/mkt/purchase/tests/test_webpay.py
+++ b/mkt/purchase/tests/test_webpay.py
@@ -17,6 +17,8 @@ import amo
 from amo.helpers import absolutify
 from amo.tests import TestCase
 from amo.urlresolvers import reverse
+from market.models import AddonPurchase
+from mkt.api.exceptions import AlreadyPurchased
 from stats.models import Contribution
 
 from utils import PurchaseTest
@@ -103,6 +105,14 @@ class TestPurchase(PurchaseTest):
         data = self.get(reverse('webpay.pay_status',
                                 args=[self.addon.app_slug, uuid_]))
         eq_(data['status'], 'incomplete')
+
+    def test_status_for_already_purchased(self):
+        AddonPurchase.objects.create(addon=self.addon,
+                                     user=self.user,
+                                     type=amo.CONTRIB_PURCHASE)
+
+        with self.assertRaises(AlreadyPurchased):
+            self.client.post(self.prepare_pay)
 
     def test_pay_status_for_unknown_contrib(self):
         data = self.get(reverse('webpay.pay_status',

--- a/mkt/webpay/tests/test_resources.py
+++ b/mkt/webpay/tests/test_resources.py
@@ -52,8 +52,11 @@ class TestPrepare(PurchaseTest, BaseOAuth):
     @patch('mkt.webapps.models.Webapp.has_purchased')
     def test_already_purchased(self, has_purchased):
         has_purchased.return_value = True
+        self.setup_base()
+        self.setup_package()
         res = self.client.post(self.list_url, data=json.dumps({'app': 337141}))
-        eq_(res.status_code, 403)
+        eq_(res.status_code, 409)
+        eq_(res.content, '{"reason": "Already purchased app."}')
 
     def _post(self):
         return self.client.post(self.list_url,


### PR DESCRIPTION
Not sure of the name and position of the new middleware.
