### PR TITLE
Make manifest_url not required for packaged apps in basic form (bug 800341)

### DIFF
--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -528,6 +528,10 @@ class AppFormBasic(addons.forms.AddonFormBase):
 
         super(AppFormBasic, self).__init__(*args, **kw)
 
+        if self.instance.is_packaged:
+            # Manifest URL field for packaged apps is empty.
+            self.fields['manifest_url'].required = False
+
     def _post_clean(self):
         # Switch slug to app_slug in cleaned_data and self._meta.fields so
         # we can update the app_slug field for webapps.

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -704,7 +704,11 @@ def addons_section(request, addon_id, addon, section, editable=False,
             all_forms = [form, previews, image_assets]
             if show_features:
                 all_forms.append(appfeatures_form)
+            if cat_form:
+                all_forms.append(cat_form)
             if all(not f or f.is_valid() for f in all_forms):
+                if cat_form:
+                    cat_form.save()
 
                 addon = form.save(addon)
 
@@ -730,12 +734,6 @@ def addons_section(request, addon_id, addon, section, editable=False,
                     amo.log(amo.LOG.EDIT_PROPERTIES, addon)
 
                 valid_slug = addon.app_slug
-            if cat_form:
-                if cat_form.is_valid():
-                    cat_form.save()
-                    addon.save()
-                else:
-                    editable = True
         else:
             form = models[section](instance=addon, request=request)
     else:


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=800341

Also make cat_form go with the rest of the form to prevent changes to be saved if a form is invalid (previously, since cat_form was valid and it saved the addon instance, invalid changes could be saved as long as the cat_form was valid)
