### PR TITLE
Fix weird unicode-related bug in tests

### DIFF
--- a/mkt/developers/tests/test_views_edit.py
+++ b/mkt/developers/tests/test_views_edit.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from itertools import repeat
 import json
 import os
@@ -520,7 +521,7 @@ class TestEditCountryLanguage(TestEdit):
         for c in countries.split(', '):
             clean_countries.append(strip_whitespace(c))
 
-        eq_(langs, u'English (US) (default), Deutsch, Espa\xc3\xb1ol')
+        eq_(langs, u'English (US) (default), Deutsch, Español')
         self.assertSetEqual(
             sorted(clean_countries),
             sorted([r.name.decode() for r in regions.ALL_REGIONS


### PR DESCRIPTION
This test has been failing for me for ages:
`AssertionError: u'English (US) (default), Deutsch, Espa\xf1ol' != u'English (US) (default), Deutsch, Espa\xc3\xb1ol'
`

This fixes it for me, but I'm not sure what was going on or why it wasn't failing for others.
