### PR TITLE
For apps in PUBLIC_WAITING state, current_version should return PUBLIC version as well (bug 895432)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -587,8 +587,14 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
         if self.type == amo.ADDON_PERSONA:
             return
         try:
-            if self.status in (amo.STATUS_PUBLIC, amo.STATUS_PUBLIC_WAITING):
+            if self.status == amo.STATUS_PUBLIC:
                 status = [self.status]
+            elif self.status == amo.STATUS_PUBLIC_WAITING:
+                # For public_waiting apps, accept both public and
+                # public_waiting statuses, because the file status might be
+                # changed from PUBLIC_WAITING to PUBLIC just before the app's
+                # is.
+                status = amo.WEBAPPS_APPROVED_STATUSES
             elif self.status in (amo.STATUS_LITE,
                                  amo.STATUS_LITE_AND_NOMINATED):
                 status = [amo.STATUS_PUBLIC, amo.STATUS_LITE,

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -523,12 +523,32 @@ class TestPubliciseVersion(amo.tests.TestCase):
 
     @mock.patch('mkt.webapps.models.Webapp.update_supported_locales')
     @mock.patch('mkt.webapps.models.Webapp.update_name_from_package_manifest')
-    def test_publicise_version_cur_waiting(self, update_name, update_locales):
+    def test_publicise_version_cur_waiting_app_public(self, update_name,
+                                                      update_locales):
+        eq_(self.app.status, amo.STATUS_PUBLIC)
         File.objects.filter(version__addon=self.app).update(
             status=amo.STATUS_PUBLIC_WAITING)
+        eq_(self.app.current_version, self.app.latest_version)
         res = self.post()
         eq_(res.status_code, 302)
+        eq_(self.app.current_version, self.app.latest_version)
         eq_(self.get_version_status(), amo.STATUS_PUBLIC)
+        eq_(self.app.reload().status, amo.STATUS_PUBLIC)
+        assert update_name.called
+        assert update_locales.called
+
+    @mock.patch('mkt.webapps.models.Webapp.update_supported_locales')
+    @mock.patch('mkt.webapps.models.Webapp.update_name_from_package_manifest')
+    def test_publicise_version_cur_waiting(self, update_name, update_locales):
+        self.app.update(status=amo.STATUS_PUBLIC_WAITING)
+        File.objects.filter(version__addon=self.app).update(
+            status=amo.STATUS_PUBLIC_WAITING)
+        eq_(self.app.current_version, self.app.latest_version)
+        res = self.post()
+        eq_(res.status_code, 302)
+        eq_(self.app.current_version, self.app.latest_version)
+        eq_(self.get_version_status(), amo.STATUS_PUBLIC)
+        eq_(self.app.reload().status, amo.STATUS_PUBLIC)
         assert update_name.called
         assert update_locales.called
 

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -312,6 +312,14 @@ def version_publicise(request, addon_id, addon):
                 version)
         # Call update_version, so various other bits of data update.
         addon.update_version()
+
+        # If the version we are publishing is the current_version one, and the
+        # app was in waiting state as well, update the app status.
+        if (version == addon.current_version and
+                addon.status == amo.STATUS_PUBLIC_WAITING):
+            addon.update(status=amo.STATUS_PUBLIC)
+            amo.log(amo.LOG.CHANGE_STATUS, addon.get_status_display(), addon)
+
         # Call to update names and locales if changed.
         addon.update_name_from_package_manifest()
         addon.update_supported_locales()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=895432

The app is still in `STATUS_PUBLIC_WAITING` when we reach `get_version()`, but the File associated to the version has already been set to `STATUS_PUBLIC`. I dismissed this as an edge case when touching `get_version()` the other day but it turns out, it's easy to reproduce now that we can publish version independently.

Also, if the current_version of an app was published, publish that app as well if it was in WAITING state.
