### PR TITLE
Fix app details editing for rejected/disabled hosted apps (bug 895752)

### DIFF
--- a/mkt/submit/forms.py
+++ b/mkt/submit/forms.py
@@ -463,11 +463,13 @@ class AppFeaturesForm(happyforms.ModelForm):
 
     def save(self, *args, **kwargs):
         mark_for_rereview = kwargs.pop('mark_for_rereview', True)
+        addon = self.instance.version.addon
         rval = super(AppFeaturesForm, self).save(*args, **kwargs)
         if (self.instance and mark_for_rereview and
+                addon.status in amo.WEBAPPS_APPROVED_STATUSES and
                 sorted(self.instance.to_keys()) != self.initial_features):
             added_features, removed_features = self._changed_features()
-            mark_for_rereview_features_change(self.instance.version.addon,
+            mark_for_rereview_features_change(addon,
                                               added_features,
                                               removed_features)
         return rval


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=895752

Also let developers edit features of rejected apps, and don't mark the app for re-review if features changed in that
case. Oh, and stopped instanciating the appfeatures form where it wasn't needed, such as in edit basic details view.
