### PR TITLE
Use addon data to check if default_locale was set in from_upload (bug 891376)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -462,7 +462,7 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
                          addon.default_locale in (
                              settings.AMO_LANGUAGES +
                              settings.HIDDEN_LANGUAGES) and
-                         addon.default_locale != settings.LANGUAGE_CODE)
+                         data.get('default_locale') == addon.default_locale)
         if not locale_is_set:
             addon.default_locale = to_language(translation.get_language())
         if addon.is_webapp():

--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -1760,11 +1760,11 @@ class TestAddonFromUpload(UploadTest):
         eq_(addon.default_locale, 'en-US')
 
     def test_browsing_locale_does_not_override(self):
-        translation.activate('gb')
-        # Upload app with en-US as default.
-        upload = self.get_upload(abspath=self.manifest('mozball.webapp'))
-        addon = Addon.from_upload(upload, [self.platform])
-        eq_(addon.default_locale, 'en-US')  # not gb
+        with translation.override('fr'):
+            # Upload app with en-US as default.
+            upload = self.get_upload(abspath=self.manifest('mozball.webapp'))
+            addon = Addon.from_upload(upload, [self.platform])
+            eq_(addon.default_locale, 'en-US')  # not fr
 
     @raises(forms.ValidationError)
     def test_malformed_locales(self):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=891376

This should fix one of the scenarios where we end up with a nameless app, because the default_locale was wrong. Also fix existing test: it was relying on 'gb', but it's not a valid locale.
