### PR TITLE
try to optimize edit theme form (bug 855619)

### DIFF
--- a/apps/translations/tests/test_util.py
+++ b/apps/translations/tests/test_util.py
@@ -1,6 +1,7 @@
 from nose.tools import eq_
 
-from translations.utils import truncate
+from translations.models import Translation
+from translations.utils import transfield_changed, truncate
 
 
 def test_truncate():
@@ -9,3 +10,30 @@ def test_truncate():
     eq_(truncate(s, 100), s)
     eq_(truncate(s, 6), '   <p>one</p><ol><li>two...</li></ol>')
     eq_(truncate(s, 11), '   <p>one</p><ol><li>two</li><li>three...</li></ol>')
+
+
+def test_transfield_changed():
+    initial = {
+        'some_field': 'some_val',
+        'name_en-us': Translation.objects.create(
+            id=500, locale='en-us', localized_string='test_name')
+    }
+    data = {'some_field': 'some_val',
+            'name': {'init': '', 'en-us': 'test_name'}}
+
+    # No change.
+    eq_(transfield_changed('name', initial, data), 0)
+
+    # Changed localization.
+    data['name']['en-us'] = 'test_name_changed'
+    eq_(transfield_changed('name', initial, data), 1)
+
+    # New localization.
+    data['name']['en-us'] = 'test_name'
+    data['name']['en-af'] = Translation.objects.create(
+        id=505, locale='en-af', localized_string='test_name_localized')
+    eq_(transfield_changed('name', initial, data), 1)
+
+    # Deleted localization.
+    del initial['name_en-us']
+    eq_(transfield_changed('name', initial, data), 1)

--- a/apps/translations/utils.py
+++ b/apps/translations/utils.py
@@ -60,3 +60,23 @@ def truncate(html, length, killwords=False, end='...'):
     else:
         short, _ = trim(tree, length, killwords, end)
         return jinja2.Markup(force_unicode(short.toxml()))
+
+
+def transfield_changed(field, initial, data):
+    """
+    For forms, compares initial data against cleaned_data for TransFields.
+    Returns True if data is the same. Returns False if data is different.
+
+    Arguments:
+    field -- name of the form field as-is.
+    initial -- data in the form of {'description_en-us': 'x',
+                                    'description_en-br': 'y'}
+    data -- cleaned data in the form of {'description': {'init': '',
+                                                         'en-us': 'x',
+                                                         'en-br': 'y'}
+    """
+    initial = [(k, v.localized_string) for k, v in initial.iteritems()
+               if '%s_' % field in k]
+    data = [('%s_%s' % (field, k), v) for k, v in data[field].iteritems()
+            if k != 'init']
+    return set(initial) != set(data)


### PR DESCRIPTION
Changes:
- Reduces one call to `get_tags` by storing it in the form init and updating it in the form save.
- Checks whether add-on properties (name, desc, slug) have been modified before saving the add-on.
- When checking whether `TransField`s have been modified, use utility function that compares TransField in initial data against cleaned data of the form.
