### PR TITLE
In translated forms, pass default_locale to fields and widgets (bug 894563)

### DIFF
--- a/apps/translations/forms.py
+++ b/apps/translations/forms.py
@@ -27,11 +27,16 @@ class TranslationFormMixin(object):
     def __init__(self, *args, **kw):
         super(TranslationFormMixin, self).__init__(*args, **kw)
         self.error_class = self.error_class_
+        self.set_default_locale()
 
-    def full_clean(self):
+    def set_default_locale(self):
         locale = to_language(default_locale(self.instance))
         for field in self.fields.values():
             field.default_locale = locale
+            field.widget.default_locale = locale
+
+    def full_clean(self):
+        self.set_default_locale()
         return super(TranslationFormMixin, self).full_clean()
 
     def error_class_(self, *a, **k):

--- a/apps/translations/tests/test_forms.py
+++ b/apps/translations/tests/test_forms.py
@@ -1,0 +1,24 @@
+from pyquery import PyQuery as pq
+from nose.tools import eq_
+
+from django.forms import ModelForm
+
+import amo.tests
+from translations import forms, fields
+from translations.tests.testapp.models import TranslatedModel
+
+
+class TestForm(forms.TranslationFormMixin, ModelForm):
+    name = fields.TransField()
+
+
+class TestTranslationFormMixin(amo.tests.TestCase):
+
+    def test_default_locale(self):
+        obj = TranslatedModel()
+        obj.get_fallback = lambda: 'pl'
+
+        f = TestForm(instance=obj)
+        eq_(f.fields['name'].default_locale, 'pl')
+        eq_(f.fields['name'].widget.default_locale, 'pl')
+        eq_(pq(f.as_p())('input:not([lang=init])').attr('lang'), 'pl')

--- a/apps/translations/tests/test_widgets.py
+++ b/apps/translations/tests/test_widgets.py
@@ -1,4 +1,4 @@
-from  pyquery import PyQuery as pq
+from pyquery import PyQuery as pq
 from nose.tools import eq_
 
 import amo.tests
@@ -16,3 +16,12 @@ class TestWidget(amo.tests.TestCase):
         link.clean()
         widget = w.render('name', link)
         eq_(pq(widget).html(), '<b>yum yum</b>')
+
+    def test_default_locale(self):
+        w = widgets.TransTextarea()
+        result = w.render('name', '')
+        eq_(pq(result)('textarea:not([lang=init])').attr('lang'), 'en-us')
+
+        w.default_locale = 'pl'
+        result = w.render('name', '')
+        eq_(pq(result)('textarea:not([lang=init])').attr('lang'), 'pl')

--- a/apps/translations/widgets.py
+++ b/apps/translations/widgets.py
@@ -52,9 +52,11 @@ class TransMulti(forms.widgets.MultiWidget):
         if value:
             self.widgets = [self.widget() for _ in value]
         else:
-            # Give an empty widget in the current locale.
+            # Give an empty widget in the default locale.
+            default_locale = getattr(self, 'default_locale',
+                                     translation.get_language())
             self.widgets = [self.widget()]
-            value = [Translation(locale=translation.get_language())]
+            value = [Translation(locale=default_locale)]
         return super(TransMulti, self).render(name, value, attrs)
 
     def decompress(self, value):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=894563

Before this patch, when creating input/textarea widgets for empty values, we used the current language. At creation time the user can't see or edit fields in this locale if it's not the same as the app's, so this created an empty Translation for those fields.

With this, we now use the app default_locale, avoiding creation of empty Translations when submitting, since the user will be editing fields in that locale.
