### PR TITLE
Notify on region price change (bug 888023)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1163,6 +1163,9 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
         return not (self.is_premium() and self.premium and
                     self.premium.price)
 
+    def is_free_inapp(self):
+        return self.premium_type == amo.ADDON_FREE_INAPP
+
     def needs_payment(self):
         return (self.premium_type not in
                 (amo.ADDON_FREE, amo.ADDON_OTHER_INAPP))

--- a/mkt/developers/templates/developers/payments/includes/regions_inappropriate.html
+++ b/mkt/developers/templates/developers/payments/includes/regions_inappropriate.html
@@ -1,4 +1,4 @@
-<div class="island warning">
+<div class="island warning" id="regions-inappropriate">
   {% trans %}
     Your app will no longer be listed in certain regions because those
     regions do not support payments. We have transferred your region

--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -146,6 +146,13 @@
           {% include 'developers/payments/includes/regions_inappropriate.html' %}
         {% endif %}
 
+        <div class="island info hidden" id="regions-changed">
+          {%- trans %}
+            Based on your chosen price point the available regions have been updated.
+            Please check them prior to saving your changes.
+          {% endtrans -%}
+        </div>
+
         <section id="regions" class="island">
           <table>
             <tbody>
@@ -175,7 +182,7 @@
                 <td colspan="2" class="region-container">
                   <div id="region-list" class="checkbox-choices regions"
                        data-api-error-msg="{{ _('A server error occurred. Please try again later.') }}"
-                       data-disabled-regions="{{ region_form.disabled_regions|json }}"
+                       data-disabled-general-regions="{{ region_form.disabled_general_regions|json }}"
                        data-not-applicable-msg="{{ _('Not applicable') }}"
                        data-payment-methods="{{ payment_methods|json }}"
                        data-pricelist-api-url="{{ api_pricelist_url }}"
@@ -195,8 +202,9 @@
                           {% if value|int in mkt.regions.ALL_PAID_REGION_IDS %}
                           <tr>
                               <td>
-                                <label class="disabled">
-                                  <input type="checkbox" disabled
+                                <label {% if value in region_form.disabled_regions %} class="disabled"{% endif %}>
+                                  <input type="checkbox"
+                                         {% if value in region_form.disabled_regions %}disabled{% endif %}
                                          {% if value in region_form.initial.regions %}checked{% endif %}
                                          name="regions" value="{{ value }}">{{ text }}</label>
                               </td>

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -262,6 +262,16 @@ class TestPayments(amo.tests.TestCase):
         base.update(extension)
         return base
 
+    @mock.patch('mkt.developers.forms.ALL_PAID_REGION_IDS', new=[11])
+    def test_paid_app_has_correct_regions_when_loaded(self):
+        self.webapp.update(premium_type=amo.ADDON_PREMIUM)
+        price = Price.objects.get(pk=1)
+        res = self.client.post(
+            self.url, self.get_postdata({'allow_inapp': False,
+                                         'price': price.pk}), follow=True)
+        pqr = pq(res.content)
+        eq_(len(pqr('input[type=checkbox][value=11]:not(:disabled)')), 1)
+
     def test_free(self):
         res = self.client.post(
             self.url, self.get_postdata({'toggle-paid': 'free'}), follow=True)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -604,10 +604,10 @@ class Webapp(Addon):
         return sorted(list(set(all_ids) - set(excluded)))
 
     def get_possible_price_region_ids(self):
-        if self.premium:
+        if self.has_premium() and self.premium:
             ids = [p['region'] for p in self.premium.price.prices()]
-            return sorted(set(ids))
-        return set()
+            return sorted(ids)
+        return []
 
     def get_regions(self):
         """


### PR DESCRIPTION
This ended up being quite a rabbit hole.  I still need to add another message for paid -> free but that will be in a separate branch/bug.
- I've split out disabled regions a bit to aid seeing what regions are generally disabled (e.g. always) vs regions that are disabled based on the price (Having them combined made doing different things based on XHR when the prices changed a problem.
- If you change prices and the checkboxes that are disabled are different from when the page was loaded a notice is shown.
- I've cleaned up a few cases where we had sets unnecessarily.
