### PR TITLE
create API endpoint for posting `comm` emails (bug 896044)

### DIFF
--- a/apps/comm/tasks.py
+++ b/apps/comm/tasks.py
@@ -8,7 +8,7 @@ log = logging.getLogger('z.task')
 
 
 @task
-def consume_email(email_text):
+def consume_email(email_text, **kwargs):
     """Parse emails and save notes."""
     res = save_from_email_reply(email_text)
     if not res:

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1564,3 +1564,7 @@ API_THROTTLE = True
 
 # Cache timeout on the /search/featured API.
 CACHE_SEARCH_FEATURED_API_TIMEOUT = 60 * 60  # 1 hour.
+
+# Whitelist IP addresses of the allowed clients that can post email
+# through the API.
+WHITELISTED_CLIENTS_EMAIL_API = []

--- a/mkt/comm/api.py
+++ b/mkt/comm/api.py
@@ -1,8 +1,10 @@
+from django.conf import settings
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import PermissionDenied, ParseError
 from rest_framework.fields import CharField
 from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import (CreateModelMixin, DestroyModelMixin,
@@ -14,11 +16,13 @@ from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from addons.models import Addon
 from users.models import UserProfile
 from comm.models import CommunicationNote, CommunicationThread
+from comm.tasks import consume_email
 from comm.utils import ThreadObjectPermission
 from mkt.api.authentication import (RestOAuthAuthentication,
                                     RestSharedSecretAuthentication)
 from mkt.api.base import CORSViewSet
 from mkt.webpay.forms import PrepareForm
+from rest_framework.response import Response
 
 
 class AuthorSerializer(ModelSerializer):
@@ -190,3 +194,21 @@ class NoteViewSet(ListModelMixin, CreateModelMixin, RetrieveModelMixin,
 
         return super(NoteViewSet, self).get_serializer(data=data_dict,
             files=files, instance=instance, many=many, partial=partial)
+
+
+class EmailCreationPermission(object):
+    def has_permission(self, request, view):
+        remote_ip = request.META.get('REMOTE_ADDR')
+        return remote_ip and (
+            remote_ip in settings.WHITELISTED_CLIENTS_EMAIL_API)
+
+
+@api_view(['POST'])
+@permission_classes((EmailCreationPermission,))
+def post_email(request):
+    email_body = request.POST.get('email_body')
+    if not email_body:
+        raise ParseError(detail='Invalid or no email body supplied.')
+
+    consume_email.apply_async((email_body,))
+    return Response(status=201)

--- a/mkt/comm/urls.py
+++ b/mkt/comm/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, patterns, url
 
 from rest_framework.routers import DefaultRouter
 
-from mkt.comm.api import NoteViewSet, ThreadViewSet
+from mkt.comm.api import NoteViewSet, ThreadViewSet, post_email
 
 
 api_thread = DefaultRouter()
@@ -11,5 +11,6 @@ api_thread.register(r'thread/(?P<thread_id>\d+)/note', NoteViewSet,
                     base_name='comm-note')
 
 api_patterns = patterns('',
-    url(r'^comm/', include(api_thread.urls))
+    url(r'^comm/', include(api_thread.urls)),
+    url(r'^comm/email/', post_email, name='post-email-api')
 )


### PR DESCRIPTION
Referencing https://github.com/mozilla/zamboni/pull/900 because it contains `comm.tasks.consume_email`
