### PR TITLE
Use absolute path for nagios_check_packaged_app.zip

### DIFF
--- a/apps/amo/monitors.py
+++ b/apps/amo/monitors.py
@@ -241,7 +241,7 @@ def package_signer():
     destination = getattr(settings, 'SIGNED_APPS_SERVER', None)
     if not destination:
         return '', 'Signer is not configured.'
-    app_path = os.path.join(os.path.dirname(__file__),
+    app_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'nagios_check_packaged_app.zip')
     signed_path = tempfile.mktemp()
     try:


### PR DESCRIPTION
This fixes a issue we are having in our new environment where the the signer check tries to look for the nagios_check_packaged_app.zip at '/apps/amo/nagios_check_packaged_app.zip'
