### PR TITLE
Don't allow worldwide/other region when disabled (bug 897511)

### DIFF
--- a/apps/market/fixtures/market/prices.json
+++ b/apps/market/fixtures/market/prices.json
@@ -91,7 +91,7 @@
       "currency": "USD",
       "tier": 2,
       "provider": 1,
-      "region": 1,
+      "region": 2,
       "price": "1.99",
       "modified": "2011-08-15 16:15:23",
       "created": "2011-08-15 16:15:23"
@@ -104,7 +104,7 @@
       "currency": "USD",
       "tier": 1,
       "provider": 1,
-      "region": 1,
+      "region": 2,
       "price": "0.99",
       "modified": "2011-08-15 16:15:23",
       "created": "2011-08-15 16:15:23"

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -841,6 +841,13 @@ class RegionForm(forms.Form):
 
         return data
 
+    def clean_other_regions(self):
+        data = self.cleaned_data['other_regions']
+        if data and mkt.regions.WORLDWIDE.id in self.disabled_regions:
+            raise forms.ValidationError(
+                _('Other regions is currently disabled.'))
+        return data
+
     def save(self):
         # Don't save regions if we are toggling.
         if self.is_toggling():

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -480,6 +480,20 @@ class TestRegionForm(amo.tests.WebappTestCase):
         form.save()
         eq_(self.app.get_region_ids(True), mkt.regions.ALL_REGION_IDS)
 
+    def test_exclude_worldwide_if_disabled(self):
+        self.app.update(premium_type=amo.ADDON_PREMIUM)
+        form = forms.RegionForm(data={'regions': mkt.regions.REGION_IDS,
+                                      'other_regions': True}, **self.kwargs)
+        form.price_region_ids = mkt.regions.REGION_IDS
+        form.disabled_regions = [mkt.regions.WORLDWIDE.id]
+        assert not form.is_valid()
+
+        form = forms.RegionForm(data={'regions': mkt.regions.REGION_IDS,
+                                      'other_regions': True}, **self.kwargs)
+        form.price_region_ids = mkt.regions.REGION_IDS
+        form.disabled_regions = []
+        assert form.is_valid()
+
 
 class TestNewManifestForm(amo.tests.TestCase):
 

--- a/mkt/site/fixtures/data/prices.json
+++ b/mkt/site/fixtures/data/prices.json
@@ -22,6 +22,17 @@
     }
   },
   {
+    "pk": 3,
+    "model": "market.price",
+    "fields": {
+      "active": true,
+      "price": "2.99",
+      "name": "3",
+      "modified": "2011-08-10 04:21:42",
+      "created": "2011-08-10 04:21:42"
+    }
+  },
+  {
     "pk": 1,
     "model": "market.pricecurrency",
     "fields": {
@@ -84,5 +95,19 @@
       "modified": "2011-08-15 16:15:23",
       "created": "2011-08-15 16:15:23"
     }
+  },
+  {
+    "pk": 6,
+    "model": "market.pricecurrency",
+    "fields": {
+      "currency": "USD",
+      "tier": 3,
+      "provider": 1,
+      "region": 10,
+      "price": "2.99",
+      "modified": "2011-08-15 16:15:23",
+      "created": "2011-08-15 16:15:23"
+    }
   }
+
 ]


### PR DESCRIPTION
This branch adds validation to other_regions so it gets made invalid when it's disabled. I've also updated the tests that were affected by tighter control over the regions - some of them were passing just because the other_region counted as a region submission.

I updated some of the fixtures too because having region 1 as a price region is a bit weird (1 is worldwide).
