### PR TITLE
Update *_version silently when deleting an Addon

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -430,6 +430,11 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
                 models.signals.pre_delete.send(sender=Addon, instance=self)
                 self.status = amo.STATUS_DELETED
                 self.slug = self.app_slug = self.app_domain = None
+                if not self._current_version:
+                    # If we didn't have a _current_version, set it before
+                    # saving with the new status to prevent infinite loop
+                    # of doom. Don't let it send signals for the same reason.
+                    self.update_version(_signal=False)
                 self.save()
                 models.signals.post_delete.send(sender=Addon, instance=self)
             else:

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -95,6 +95,14 @@ class TestWebapp(amo.tests.TestCase):
         for attr in ('slug', 'app_slug', 'app_domain'):
             eq_(getattr(post_mortem[0], attr), None)
 
+    def test_soft_deleted_no_current_version(self):
+        waffle.models.Switch.objects.create(name='soft_delete', active=True)
+        webapp = amo.tests.app_factory()
+        webapp._current_version = None
+        webapp.save()
+        webapp.delete()
+        eq_(webapp.current_version, webapp.latest_version)
+
     def test_soft_deleted_valid(self):
         w = Webapp.objects.create(status=amo.STATUS_PUBLIC)
         Webapp.objects.create(status=amo.STATUS_DELETED)


### PR DESCRIPTION
This prevents infinite recursion problems because of bug 896782, trying to re-index a deleted model needs the current_version, which can itself trigger more save()s if we didn't have a current_version set. This can happen for rejected apps for instance.

I'm not 100% convinced this is the right solution. If anyone has a better idea I'm all ears.
