### PR TITLE
Implement opensearch suggestions in the API (bug 898020)

### DIFF
--- a/mkt/api/serializers.py
+++ b/mkt/api/serializers.py
@@ -27,3 +27,21 @@ class Serializer(Serializer):
             return super(Serializer, self).deserialize(content, format)
         except JSONDecodeError, exc:
             raise DeserializationError(original=exc)
+
+
+class SuggestionsSerializer(Serializer):
+    formats = ['suggestions+json', 'json']
+    content_types = {
+        'suggestions+json': 'application/x-suggestions+json',
+        'json': 'application/json',
+    }
+
+    def serialize(self, bundle, format='application/json', options=None):
+        if options is None:
+            options = {}
+        if format == 'application/x-suggestions+json':
+            # Format application/x-suggestions+json just like regular json.
+            format = 'application/json'
+        return super(SuggestionsSerializer, self).serialize(bundle,
+                                                            format=format,
+                                                            options=options)

--- a/mkt/api/urls.py
+++ b/mkt/api/urls.py
@@ -11,7 +11,7 @@ from mkt.api.resources import (AppResource, CarrierResource, CategoryViewSet,
 from mkt.features.views import AppFeaturesList
 from mkt.stats.api import GlobalStatsResource
 from mkt.ratings.resources import RatingResource
-from mkt.search.api import SearchResource
+from mkt.search.api import SearchResource, SuggestionsResource
 
 
 api = Api(api_name='apps')
@@ -19,6 +19,7 @@ api.register(ValidationResource())
 api.register(AppResource())
 api.register(PreviewResource())
 api.register(SearchResource())
+api.register(SuggestionsResource())
 api.register(StatusResource())
 api.register(RatingResource())
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=898020

This is an experimental feature, we probably don't want to expose this in the docs till we are certain that this is the right format (*). This is designed to be used by gaia but also potentially for search suggestions in the marketplace itself if we want to re-enable this (see https://bugzilla.mozilla.org/show_bug.cgi?id=847625)

(*) In particular, we are extending the spec here with a 4th array containing icons. The spec has not changed in years, so it should not be a problem as long as every browsers ignore extra arrays they don't know about (they should)
