### PR TITLE
Add a property for latest_version to provide a fallback (bug 899034)

### DIFF
--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -286,6 +286,14 @@ class TestAddonModels(amo.tests.TestCase):
         v2.save()
         eq_(a.latest_version.id, v1.id)  # Still should be f1
 
+    def test_latest_version_fallback(self):
+        a = Addon.objects.get(pk=3615)
+        version = a.latest_version
+
+        a._latest_version = None
+        eq_(a.latest_version, version)
+        eq_(a._latest_version, version)
+
     def test_current_beta_version(self):
         a = Addon.objects.get(pk=5299)
         eq_(a.current_beta_version.id, 50000)

--- a/apps/amo/fixtures/base/addon_3615.json
+++ b/apps/amo/fixtures/base/addon_3615.json
@@ -170,7 +170,7 @@
         "fields": {
             "slug": "a3615",
             "_current_version": 81551,
-            "latest_version": 81551,
+            "_latest_version": 81551,
             "dev_agreement": true,
             "eula": 42021,
             "last_updated": "2009-10-21 09:58:40",

--- a/mkt/site/fixtures/data/webapp_337141.json
+++ b/mkt/site/fixtures/data/webapp_337141.json
@@ -126,7 +126,7 @@
             "total_reviews": 0,
             "the_reason": null,
             "hotness": 0.0,
-            "latest_version": 1268829
+            "_latest_version": 1268829
         }
     },
     {

--- a/mkt/webapps/fixtures/webapps/337141-steamcube.json
+++ b/mkt/webapps/fixtures/webapps/337141-steamcube.json
@@ -123,7 +123,7 @@
             "total_reviews": 0,
             "the_reason": null,
             "hotness": 0.0,
-            "latest_version": 1268829
+            "_latest_version": 1268829
         }
     },
     {


### PR DESCRIPTION
Sometimes, latest_version isn't populated for non-incomplete apps, which breaks some reviewers tools pages. We need to investigate why, hopefully this should help us work around the bug in the meantime and find out which apps are affected (and then figure out why)
