### PR TITLE
Only owner can change app pay-account (bug 840188)

### DIFF
--- a/media/js/devreg/payments-manage.js
+++ b/media/js/devreg/payments-manage.js
@@ -2,8 +2,9 @@ define('payments-manage', ['payments'], function(payments) {
     'use strict';
 
     function refreshAccountForm(data) {
-        var $accountListForm = $('#bango-account-list');
-        $accountListForm.load($accountListForm.data('url'));
+        var $accountListForm = $('#my-accounts-list');
+        var $accountListContainer = $('#bango-account-list');
+        $accountListForm.load($accountListContainer.data('url'));
     }
 
     function newBangoPaymentAccount(e) {

--- a/media/js/devreg/payments.js
+++ b/media/js/devreg/payments.js
@@ -247,8 +247,11 @@ define('payments', [], function() {
             $free_island.toggle(tab.id == 'free-tab-header');
         });
 
-        $priceSelect.on('change', updatePrices);
-        updatePrices.call($priceSelect[0], false);
+        // Only update if we can edit. If the user can't edit all fields will be disabled.
+        if (!z.body.hasClass('no-edit')) {
+            $priceSelect.on('change', updatePrices);
+            updatePrices.call($priceSelect[0], false);
+        }
     }
 
     return {

--- a/mkt/developers/templates/developers/payments/includes/bango_accounts_form.html
+++ b/mkt/developers/templates/developers/payments/includes/bango_accounts_form.html
@@ -1,5 +1,5 @@
 {% if bango_account_list_form.fields['accounts'].queryset.exists() %}
   {{ bango_account_list_form.accounts }}
 {% else %}
-  {{ _("You don't have any payment accounts set up.") }}
+  <p class="no-accounts">{{ _("You don't have any payment accounts set up.") }}</p>
 {% endif %}

--- a/mkt/developers/templates/developers/payments/includes/bango_accounts_list.html
+++ b/mkt/developers/templates/developers/payments/includes/bango_accounts_list.html
@@ -1,0 +1,10 @@
+{% if bango_account_list_form.current_payment_account %}
+  <p class="current-account">{{ bango_account_list_form.current_payment_account }}</p>
+  <p class="hint">
+    {% trans %}The current payment account was associated with the app by an app owner.{% endtrans %}
+  </p>
+{% endif %}
+
+<div id="my-accounts-list">
+  {% include 'developers/payments/includes/bango_accounts_form.html' %}
+</div>

--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -122,11 +122,13 @@
                 <td>
                   <div id="bango-account-list" data-url="{{ url('mkt.developers.bango.payment_accounts_form') }}">
                     {{ bango_account_list_form.errors }}
-                    {% include 'developers/payments/includes/bango_accounts_form.html' %}
+                    {% include 'developers/payments/includes/bango_accounts_list.html' %}
                   </div>
-                  <a href="#" class="payment-account-actions" data-action="add">
-                    {{- _('Add or manage payment accounts') -}}
-                  </a>
+                  {% if can_edit and bango_account_list_form.is_owner %}
+                    <a href="#" class="payment-account-actions" data-action="add">
+                      {{- _('Add or manage payment accounts') -}}
+                    </a>
+                  {% endif %}
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
This branch changes payment accounts so that only an app owner can change the payment account.

If a payment account is set by an owner and an non-owner looks at the page then the account name is displayed outside of the select - this makes it clearer that the account set is not part of the user's list of accounts.

I've also fixed a small issue where the js to disable the form fields was being overridden by the price selection js. 
