### PR TITLE
allow replies to a note (bug 888707)

### DIFF
--- a/migrations/635-enable-reply-to-notes.sql
+++ b/migrations/635-enable-reply-to-notes.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `comm_thread_notes` ADD COLUMN `read_permission_public` bool NOT NULL;
+ALTER TABLE `comm_thread_notes` ADD COLUMN `read_permission_developer` bool NOT NULL;
+ALTER TABLE `comm_thread_notes` ADD COLUMN `read_permission_reviewer` bool NOT NULL;
+ALTER TABLE `comm_thread_notes` ADD COLUMN `read_permission_senior_reviewer` bool NOT NULL;
+ALTER TABLE `comm_thread_notes` ADD COLUMN `read_permission_staff` bool NOT NULL;
+ALTER TABLE `comm_thread_notes` ADD COLUMN `read_permission_mozilla_contact` bool NOT NULL;
+ALTER TABLE `comm_thread_notes` ADD COLUMN `reply_to_id` int(11) unsigned;
+ALTER TABLE `comm_thread_notes` ADD CONSTRAINT `reply_to_id_refs_id_df5d5709` FOREIGN KEY (`reply_to_id`) REFERENCES `comm_thread_notes` (`id`);
+
+CREATE INDEX `comm_thread_notes_dev_perm` ON `comm_thread_notes` (`read_permission_developer`);
+CREATE INDEX `comm_threads_dev_perm` ON `comm_threads` (`read_permission_developer`);

--- a/mkt/comm/urls.py
+++ b/mkt/comm/urls.py
@@ -2,13 +2,15 @@ from django.conf.urls import include, patterns, url
 
 from rest_framework.routers import DefaultRouter
 
-from mkt.comm.api import NoteViewSet, ThreadViewSet, post_email
+from mkt.comm.api import NoteViewSet, post_email, ReplyViewSet, ThreadViewSet
 
 
 api_thread = DefaultRouter()
 api_thread.register(r'thread', ThreadViewSet, base_name='comm-thread')
 api_thread.register(r'thread/(?P<thread_id>\d+)/note', NoteViewSet,
                     base_name='comm-note')
+api_thread.register(r'thread/(?P<thread_id>\d+)/note/(?P<note_id>\d+)/replies',
+                    ReplyViewSet, base_name='comm-note-replies')
 
 api_patterns = patterns('',
     url(r'^comm/', include(api_thread.urls)),


### PR DESCRIPTION
**Notes**
- adds permissions to `CommunicationThreadNote` model.
- adds an endpoint like `/comm/thread/1/note/2/replies/` (`GET` to list replies to a note, `POST` to add one)
- a note on creation derives its permissions from its parent thread. A reply to a note, derives its permissions from the parent note.
