### PR TITLE
Add the ability to send emails to devs of paid apps (bug 896034)

### DIFF
--- a/apps/zadmin/forms.py
+++ b/apps/zadmin/forms.py
@@ -36,6 +36,10 @@ class DevMailerForm(happyforms.Form):
                 ('apps', 'Developers of active apps (not add-ons)'),
                 ('payments',
                  'Developers of non-deleted apps (not add-ons) with payments'),
+                ('payments_region_enabled',
+                 'Developers of apps with payments and new region enabled'),
+                ('payments_region_disabled',
+                 'Developers of apps with payments and new region disabled'),
                 ('desktop_apps',
                  'Developers of non-deleted apps supported on desktop'),
                 ('all_extensions', 'All extension developers')]

--- a/apps/zadmin/tests/test_views.py
+++ b/apps/zadmin/tests/test_views.py
@@ -1921,7 +1921,6 @@ class TestEmailDevs(amo.tests.TestCase):
 
     def test_only_apps_with_payments(self):
         self.addon.update(type=amo.ADDON_WEBAPP,
-                          paypal_id='fliggy@fligtar.net',
                           premium_type=amo.ADDON_PREMIUM)
         res = self.post(recipients='payments')
         self.assertNoFormErrors(res)
@@ -1936,6 +1935,27 @@ class TestEmailDevs(amo.tests.TestCase):
         mail.outbox = []
         self.addon.update(status=amo.STATUS_DELETED)
         res = self.post(recipients='payments')
+        self.assertNoFormErrors(res)
+        eq_(len(mail.outbox), 0)
+
+    def test_only_apps_with_payments_and_new_regions(self):
+        self.addon.update(type=amo.ADDON_WEBAPP,
+                          premium_type=amo.ADDON_PREMIUM)
+        res = self.post(recipients='payments_region_enabled')
+        self.assertNoFormErrors(res)
+        eq_(len(mail.outbox), 0)
+        mail.outbox = []
+        res = self.post(recipients='payments_region_disabled')
+        self.assertNoFormErrors(res)
+        eq_(len(mail.outbox), 1)
+
+        mail.outbox = []
+        self.addon.update(enable_new_regions=True)
+        res = self.post(recipients='payments_region_enabled')
+        self.assertNoFormErrors(res)
+        eq_(len(mail.outbox), 1)
+        mail.outbox = []
+        res = self.post(recipients='payments_region_disabled')
         self.assertNoFormErrors(res)
         eq_(len(mail.outbox), 0)
 

--- a/apps/zadmin/views.py
+++ b/apps/zadmin/views.py
@@ -642,11 +642,16 @@ def email_devs(request):
 
         if data['recipients'] == 'eula':
             qs = qs.exclude(addon__eula=None)
-        elif data['recipients'] == 'payments':
+        elif data['recipients'] in ('payments',
+                                    'payments_region_enabled',
+                                    'payments_region_disabled'):
             qs = qs.filter(addon__type=amo.ADDON_WEBAPP)
-            qs = qs.exclude(addon__paypal_id=None)
             qs = qs.exclude(addon__premium_type__in=(amo.ADDON_FREE,
                                                      amo.ADDON_OTHER_INAPP))
+            if data['recipients'] == 'payments_region_enabled':
+                qs = qs.filter(addon__enable_new_regions=True)
+            elif data['recipients'] == 'payments_region_disabled':
+                qs = qs.filter(addon__enable_new_regions=False)
         elif data['recipients'] == 'apps':
             qs = qs.filter(addon__type=amo.ADDON_WEBAPP)
         elif data['recipients'] == 'desktop_apps':


### PR DESCRIPTION
… that checked the `enable_new_regions` checkbox or not.

Known limitation: you can't pass variables from the admin interface and thus the `region name` or `app name` can't be dynamically populated. On the other side, with the newly added `email_developers_about_new_paid_region` command it's maybe less relevant(?).

To remove that limitation, we need to create a new command that can't be handled via zamboni's admin.
