### PR TITLE
Don't use a string for the version id when signing in reviewer tools (bug 900028)

### DIFF
--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -2258,6 +2258,13 @@ class TestGetSigned(BasePackagedAppTest, amo.tests.TestCase):
         self.client.login(username='regular@mozilla.com', password='password')
         eq_(self.client.get(self.url).status_code, 403)
 
+    @mock.patch('lib.crypto.packaged.sign')
+    def test_reviewer_sign_arguments(self, sign_mock):
+        self.setup_files()
+        res = self.client.get(self.url)
+        eq_(res.status_code, 200)
+        sign_mock.assert_called_with(self.version.pk, reviewer=True)
+
     @mock.patch.object(packaged, 'sign', mock_sign)
     def test_reviewer(self):
         if not settings.XSENDFILE:

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -719,7 +719,7 @@ def app_abuse(request, addon):
 def get_signed_packaged(request, addon, version_id):
     version = get_object_or_404(addon.versions, pk=version_id)
     file = version.all_files[0]
-    path = addon.sign_if_packaged(version_id, reviewer=True)
+    path = addon.sign_if_packaged(version.pk, reviewer=True)
     if not path:
         raise http.Http404
     log.info('Returning signed package addon: %s, version: %s, path: %s' %


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=900028

I'm not familiar at all with the signing code, just noticed we were using the parameter from the URL directly, which is a string, instead of the field from the database, which is an int. So hopefully this change should fix the bug.
