### PR TITLE
Always update app status when uploading a new version (bug 895882)

### DIFF
--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -218,6 +218,9 @@ def status(request, addon_id, addon, webapp=False):
             ver = Version.from_upload(upload_form.cleaned_data['upload'],
                                       addon, [amo.PLATFORM_ALL])
 
+            # Update addon status now that the new version was saved.
+            addon.update_status()
+
             res = run_validator(ver.all_files[0].file_path)
             validation_result = json.loads(res)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=895882

This is the second attempt at fixing this bug, this time the call is done in the view handling new versions for minimal external impact, so it should be safer. 
