### PR TITLE
allow marking notes/thread as read (bug 897265)

### DIFF
--- a/apps/comm/models.py
+++ b/apps/comm/models.py
@@ -61,7 +61,7 @@ class CommunicationNote(CommunicationPermissionModel):
         self.thread.save()
 
 
-class CommunicationNoteRead(amo.models.ModelBase):
+class CommunicationNoteRead(models.Model):
     user = models.ForeignKey('users.UserProfile')
     note = models.ForeignKey(CommunicationNote)
 

--- a/apps/comm/tasks.py
+++ b/apps/comm/tasks.py
@@ -1,7 +1,8 @@
 import logging
 from celeryutils import task
 
-from comm.utils import save_from_email_reply
+from comm.utils import filter_notes_by_read_status, save_from_email_reply
+from comm.models import CommunicationNoteRead
 
 
 log = logging.getLogger('z.task')
@@ -13,3 +14,15 @@ def consume_email(email_text, **kwargs):
     res = save_from_email_reply(email_text)
     if not res:
         log.error('Failed to save email.')
+
+
+@task
+def mark_thread_read(thread, user, **kwargs):
+    """This marks each unread note in a thread as read - in bulk."""
+    object_list = []
+    unread_notes = filter_notes_by_read_status(thread.notes, user, False)
+
+    for note in unread_notes:
+        object_list.append(CommunicationNoteRead(note=note, user=user))
+
+    CommunicationNoteRead.objects.bulk_create(object_list)

--- a/apps/comm/utils.py
+++ b/apps/comm/utils.py
@@ -139,4 +139,4 @@ def filter_notes_by_read_status(queryset, profile, read_status=True):
         return queryset.filter(pk__in=notes) if notes else queryset.none()
     else:
         # Exclude read notes if they exist.
-        return queryset.exclude(pk__in=notes) if notes else queryset
+        return queryset.exclude(pk__in=notes) if notes else queryset.all()

--- a/docs/api/topics/comm.rst
+++ b/docs/api/topics/comm.rst
@@ -95,6 +95,25 @@ Thread
     :param recent_notes: contain 5 recently created notes.
     :type recent_notes: array
 
+.. _note-patch-label:
+
+.. http:patch:: /api/v1/comm/thread/(int:thread_id)/
+
+    .. note:: Requires authentication.
+
+    This endpoint can be used to mark all notes in a thread as read.
+
+    **Request**
+
+    :param is_read: set it to `true` to mark the note as read.
+    :type param: boolean
+
+    **Response**
+
+    :status code: 204 Thread is marked as read.
+    :status code: 403 There is an attempt to modify other fields or not allowed to access the object.
+    :status code: 400 Thread object not found.
+
 .. _thread-post-label:
 
 .. http:post:: /api/v1/comm/thread/
@@ -211,6 +230,25 @@ Note
         6 - Reviewer Comment
 
         7 - Resubmission
+
+.. _note-patch-label:
+
+.. http:patch:: /api/v1/comm/thread/(int:thread_id)/note/(int:id)/
+
+    .. note:: Requires authentication.
+
+    This endpoint can be used to mark an unread note as read.
+
+    **Request**
+
+    :param is_read: set it to `true` to mark the note as read.
+    :type param: boolean
+
+    **Response**
+
+    :status code: 204 Note marked as read.
+    :status code: 403 There is an attempt to modify other fields or not allowed to access the object.
+    :status code: 400 Note object not found.
 
 .. _note-post-label:
 


### PR DESCRIPTION
Allow marking the notes and threads as read.

This adds a PATCH method to `/comm/thread/(thread_id)` and `/comm/thread/(thread_id)/note/(note_id)` endpoints to mark a thread or note respectively as read.

Also, some refactoring in `mkt/comm/api.py`.
