### PR TITLE
Don't consider deleted versions in reviewers updates chart (bug 900897)

### DIFF
--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -146,6 +146,16 @@ class TestReviewersHome(AppReviewerTest, AccessMixin):
         rq = RereviewQueue.objects.create(addon=rereviewed)
         rq.update(created=self.days_ago(5))
 
+        # Add an app with latest update deleted. It shouldn't affect anything.
+        app = app_factory(name='Great White Shark',
+                          status=amo.STATUS_PUBLIC,
+                          version_kw={'version': '1.0'},
+                          is_packaged=True)
+        v = version_factory(addon=app,
+                        version='2.1',
+                        file_kw={'status': amo.STATUS_PENDING})
+        v.update(deleted=True)
+
     def test_stats_waiting(self):
         self.apps[0].update(created=self.days_ago(1))
         self.apps[1].update(created=self.days_ago(5))

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -159,6 +159,7 @@ def _progress():
                                version__addon__disabled_by_user=False,
                                version__addon__is_packaged=True,
                                version__addon__status__in=public_statuses,
+                               version__deleted=False,
                                status=amo.STATUS_PENDING)
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=900897
