### PR TITLE
Fixes in mkt.collections regarding automatic order

### DIFF
--- a/mkt/collections/models.py
+++ b/mkt/collections/models.py
@@ -22,7 +22,7 @@ class Collection(amo.models.ModelBase):
 
     def apps(self):
         """
-        Return a QuerySet containing all apps in this collection.
+        Return a list containing all apps in this collection.
         """
         return [a.app for a in self.collectionmembership_set.all()]
 
@@ -43,10 +43,9 @@ class Collection(amo.models.ModelBase):
         collection.
         """
         if not order:
-            qs = CollectionMembership.objects.filter(collection=self,
-                                                     app=app)
+            qs = CollectionMembership.objects.filter(collection=self)
             aggregate = qs.aggregate(Max('order'))['order__max']
-            order = aggregate + 1 if aggregate else 0
+            order = aggregate + 1 if aggregate else 1
         return CollectionMembership.objects.create(collection=self, app=app,
                                                    order=order)
 


### PR DESCRIPTION
The automatic order wasn't working, it was kept at 0 everytime, for 2 reasons:
1. The `app=app` in the `CollectionMembership.objects.filter()` call made the queryset always return `order__max: None`. Removing the `app=app` fixes this.
2. The `aggregate + 1 if aggregate else 0` was always returning 0 if only automatic order was used. Starting the automatic order at 1 fixes this.

I also simplified the tests and added one with automatic order only.
