### PR TITLE
Make collection ordering start at 0 instead of 1

### DIFF
--- a/mkt/collections/models.py
+++ b/mkt/collections/models.py
@@ -34,7 +34,7 @@ class Collection(amo.models.ModelBase):
         if not order:
             qs = CollectionMembership.objects.filter(collection=self)
             aggregate = qs.aggregate(Max('order'))['order__max']
-            order = aggregate + 1 if aggregate else 1
+            order = aggregate + 1 if aggregate is not None else 0
         return CollectionMembership.objects.create(collection=self, app=app,
                                                    order=order)
 

--- a/mkt/collections/tests/test_models.py
+++ b/mkt/collections/tests/test_models.py
@@ -42,7 +42,7 @@ class TestCollection(amo.tests.TestCase):
         self.add_apps()
         self.assertSetEqual(self.collection.apps(), self.apps)
         eq_(list(CollectionMembership.objects.values_list('order', flat=True)),
-            [1, 2, 3, 4])
+            [0, 1, 2, 3])
 
     def test_mixed_ordering(self):
         extra_app = amo.tests.app_factory()


### PR DESCRIPTION
Changed my mind on this and I think it's better to start at 0 (in which case we need to differentiate between no-members-in-collection and max-order-is-0-because-there-is-only-one-member). 
