### PR TITLE
fix missing themes (bug 901604)

### DIFF
--- a/apps/addons/management/commands/fix_missing_theme_versions.py
+++ b/apps/addons/management/commands/fix_missing_theme_versions.py
@@ -1,0 +1,25 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+import amo
+from addons.models import Addon
+from versions.models import Version
+
+
+log = logging.getLogger('z.addons')
+
+
+class Command(BaseCommand):
+    help = 'Creates current_version\'s for themes that are missing them.'
+
+    def handle(self, *args, **options):
+        for addon in Addon.objects.filter(type=amo.ADDON_PERSONA,
+                                          _current_version__isnull=True):
+            if addon._latest_version:
+                addon.update(_current_version=addon._latest_version,
+                             _signal=False)
+            else:
+                version = Version.objects.create(addon=addon, version='0')
+                addon.update(_current_version=version, _signal=False)
+            log.info('Fixed missing current version for add-on %s' % addon.id)


### PR DESCRIPTION
Somewhat of a shotgun approach.
1. Script to creates missing versions for themes that currently already have had their versions deleted. 
2. Patches addon.update_version to have a special case for themes. Hopefully this prevents future occurrences; it's a shot, why versions went missing is unclear.
3. Don't 404 when a theme is missing _current_version
