### PR TITLE
theme review queue search, add for rereview (bug 904820)

### DIFF
--- a/apps/addons/search.py
+++ b/apps/addons/search.py
@@ -70,6 +70,8 @@ def extract(addon):
             d['weekly_downloads'] = addon.persona.popularity
             # Boost on popularity.
             d['_boost'] = addon.persona.popularity ** .2
+            d['has_theme_rereview'] = (
+                addon.persona.rereviewqueuetheme_set.exists())
         except Persona.DoesNotExist:
             # The addon won't have a persona while it's being created.
             pass

--- a/mkt/reviewers/forms.py
+++ b/mkt/reviewers/forms.py
@@ -256,6 +256,7 @@ class ThemeSearchForm(forms.Form):
         required=False, label=_lazy(u'Search'),
         widget=forms.TextInput(attrs={'autocomplete': 'off',
                                       'placeholder': _lazy(u'Search')}))
+    queue_type = forms.CharField(required=False, widget=forms.HiddenInput())
 
 
 class ApiReviewersSearchForm(ApiSearchForm):

--- a/mkt/reviewers/templates/reviewers/includes/macros.html
+++ b/mkt/reviewers/templates/reviewers/includes/macros.html
@@ -30,10 +30,10 @@
   </form>
 {% endmacro %}
 
-{% macro tabnav(type, tab, tabs) %}
+{% macro tabnav(type, tab, tabs, no_search_toggle) %}
 {# type -- string (e.g. 'queue', 'log')
    tabs -- list of named_url/tab_code/tab_text tuples #}
-  <ul class="tabnav search-toggle">
+  <ul class="tabnav{{ ' search-toggle' if not no_search_toggle }}">
     {% for named_url, tab_code, text in tabs %}
       <li{% if tab == tab_code %} class="selected trigger-{{ type }}"{% endif %}>
         <a href="{{ url(named_url) }}">{{ text }}</a>

--- a/mkt/reviewers/templates/reviewers/themes/queue_list.html
+++ b/mkt/reviewers/templates/reviewers/themes/queue_list.html
@@ -10,21 +10,22 @@
        data-review-url="{{ url('reviewers.themes.single', '__slug__') }}">
     <form class="c">
       {{ search_form.q }}
+      <input type="hidden" name="queue_type" value="{{ 'rereview' if rereview else 'flagged' if flagged else '' }}">
       <button class="search button" type="submit"><span>{{ _('Search') }}</span></button>
-      <span class="clear-queue-search hidden"><a>{{ _('Clear Search') }}</a></span>
+      <a href="#" class="clear-queue-search hidden">{{ _('Clear Search') }}</a>
       {{ search_form.limit }}
     </form>
   </div>
 
   <div class="theme-list-hat">
-    {{ macros.tabnav('queues', tab, queue_tabnav_themes() ) }}
+    {{ macros.tabnav('queues', tab, queue_tabnav_themes(), true) }}
 
     <a class="button release-theme-lock" href="{{ url('reviewers.themes.release_locks') }}">
       <span>{{ _('Release My Theme Locks') }}</span>
     </a>
   </div>
 
-    <section id="queue-island" class="island search-toggle">
+  <section id="queue-island" class="island search-toggle">
     <h3 class="theme-queue-link c">
       <a href="{{ url('reviewers.themes.queue_themes') }}">
         {{ _('Interactive Theme Queue') }}

--- a/mkt/site/fixtures/data/user_senior_persona_reviewer.json
+++ b/mkt/site/fixtures/data/user_senior_persona_reviewer.json
@@ -55,7 +55,7 @@
         "pk": 50070,
         "model": "access.group",
         "fields": {
-            "rules": "SeniorPersonasTools:View",
+            "rules": "Personas:Review,SeniorPersonasTools:View",
             "notes": "",
             "modified": "2012-05-22 17:53:57",
             "name": "Senior Persona Reviewers",


### PR DESCRIPTION
Make theme searches not global:
- On pending queue, pending themes results only.
- On flagged queue, flagged themes results only.
- On rereview queue, rereview themes results only.

Add support for searching flagged/rereview theme queues.
