### PR TITLE
Make premium apps get their flag in reviewer searches as well (bug 907697)

### DIFF
--- a/media/js/mkt/reviewers.js
+++ b/media/js/mkt/reviewers.js
@@ -108,6 +108,9 @@ function buildAppResultRow(app, review_url, statuses) {
             flags.push({suffix: 'editor', title: gettext('Contains Editor Comment')});
         }
     }
+    if (app.premium_type == 'premium-inapp' || app.premium_type == 'premium') {
+        flags.push({suffix: 'premium', title: gettext('Premium App')});
+    }
     if (app.is_escalated) {
         flags.push({suffix: 'escalated', title: gettext('Escalated')});
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=907697

The flag was present in the queue which is pure django, but search needs this bit of JavaScript to have it.
