### PR TITLE
bug 907569 - Link to Communication Dashboard from the menu

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -681,9 +681,13 @@ def collection_factory(**kw):
     return c
 
 
-def req_factory_factory(url, user=None):
+def req_factory_factory(url, user=None, data=None, follow=True):
     """Creates a request factory, logged in with the user."""
-    req = RequestFactory().get(url)
+    req = None
+    if data:
+        req = RequestFactory().post(url, data, follow=follow)
+    else:
+        req = RequestFactory().get(url, follow=follow)
     if user:
         req.amo_user = user
         req.user = user.user

--- a/media/css/devreg/status.styl
+++ b/media/css/devreg/status.styl
@@ -138,3 +138,7 @@
         white-space: nowrap;
     }
 }
+
+#page table.comm-threads {
+    margin-bottom: 6px;
+}

--- a/mkt/developers/templates/developers/apps/status.html
+++ b/mkt/developers/templates/developers/apps/status.html
@@ -109,6 +109,51 @@
       {% endif %}
     </div>
 
+    <div class="island c">
+      <h2>{{ _('Communication Dashboard') }}</h2>
+      <p>
+        {% trans %}
+          When Marketplace app reviewers wish to communicate with you about
+          your app, you can respond and reply back through communication
+          threads.
+        {% endtrans %}
+      </p>
+      {# L10n: {0} is app name. #}
+      <h3>{{ _('Communication Threads for {0}')|f(addon.name) }}</h3>
+      {% if comm_threads %}
+        <table id="version-list" class="comm-threads">
+          <thead>
+            <tr>
+              <th></th>
+              <th>{{ _('Status') }}</th>
+              <th>{{ _('Comment Count') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for thread in comm_threads %}
+              {% set thread_url = url('commonplace.commbadge') + 'thread/' ~ thread.thread.id %}
+              <tr>
+                <td><h4><a href="{{ thread_url }}">{{ thread.thread.version }}</a></h4></td>
+                <td>
+                  {% set addon = thread.thread.addon %}
+                  {% set version = thread.thread.version %}
+                  {% if addon.disabled_by_user %}
+                    <span class="{{ mkt_file_status_class(addon, version) }}"><b>{{ _('Disabled') }}</b></span>
+                  {% else %}
+                    <span class="{{ mkt_file_status_class(addon, version) }}"><b>{{ version.status|join(', ') }}</b></span>
+                  {% endif %}
+                </td>
+                <td>{{ thread.note_count }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="no-results">{{ _('No threads have been created yet.') }}</p>
+      {% endif %}
+      <h3><a href="{{ url('commonplace.commbadge') }}">{{ _('View Your Communication Dashboard') }}</a></h3>
+    </div>
+
     {% if check_addon_ownership(request, addon, dev=True) %}
       {% set is_disabled = addon.disabled_by_user and addon.status != amo.STATUS_DISABLED %}
       <div class="island c">

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -43,6 +43,7 @@ from users.views import _login
 from versions.models import Version
 
 from mkt.api.models import Access, generate
+from mkt.comm.api import CommunicationNote, CommunicationThread
 from mkt.constants import APP_IMAGE_SIZES
 from mkt.developers.decorators import dev_required
 from mkt.developers.forms import (APIConsumerForm, AppFormBasic,
@@ -266,6 +267,12 @@ def status(request, addon_id, addon, webapp=False):
             entry = None
         # This contains the rejection reason and timestamp.
         ctx['rejection'] = entry and entry.activity_log
+
+    # Link to Commbadge threads.
+    ctx['comm_threads'] = [{
+        'thread': thread,
+        'note_count': CommunicationNote.objects.filter(thread=thread).count()
+    } for thread in CommunicationThread.objects.filter(addon=addon)]
 
     return jingo.render(request, 'developers/apps/status.html', ctx)
 

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -235,7 +235,6 @@ class ReviewBase(object):
     def request_information(self):
         """Send a request for information to the authors."""
         emails = list(self.addon.authors.values_list('email', flat=True))
-        cc_email = self.addon.mozilla_contact or None
         self.log_action(amo.LOG.REQUEST_INFORMATION)
         self.version.update(has_info_request=True)
         log.info(u'Sending request for information for %s to %s' %
@@ -247,7 +246,6 @@ class ReviewBase(object):
 
         subject = u'Submission Update: %s' % data['name']
         self.notify_email('info', subject)
-
 
     def send_escalate_mail(self):
         self.log_action(amo.LOG.ESCALATE_MANUAL)
@@ -404,8 +402,6 @@ class ReviewApp(ReviewBase):
             EscalationQueue.objects.filter(addon=self.addon).delete()
         if self.in_rereview:
             RereviewQueue.objects.filter(addon=self.addon).delete()
-        emails = list(self.addon.authors.values_list('email', flat=True))
-        cc_email = self.addon.mozilla_contact or None
         self.create_comm_thread(action='disable')
         subject = u'App disabled by reviewer: %s' % self.addon.name
         self.notify_email('disabled', subject)


### PR DESCRIPTION
@brampitoyo @cvan

**Notes:**
- Under Manage Status and Versions page, under the Status sub-section.
- Per version, links to Commbadge threads.
## Screenshot

![screen shot 2013-08-27 at 6 04 15 pm](https://f.cloud.github.com/assets/674727/1039306/3c3a3a54-0f7f-11e3-8196-150244e05ebc.png)

![screen shot 2013-08-27 at 2 37 17 pm](https://f.cloud.github.com/assets/674727/1038278/01e8d2d4-0f61-11e3-9610-e09594002e98.png)
