### PR TITLE
retroactively reward theme reviewer points for old theme revs (bug 909985)

### DIFF
--- a/migrations/654-award-theme-points.py
+++ b/migrations/654-award-theme-points.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import datetime
+
+from django.db.models import Q
+
+import amo
+from amo.utils import chunked
+from devhub.models import ActivityLog
+
+from mkt.reviewers.tasks import _batch_award_points
+import mkt.constants.reviewers as rvw
+
+
+def run():
+    """
+    Retroactively award theme reviewer points for all the theme
+    reviewers done since the Great Theme Migration to amo up to
+    when we started recording points.
+    """
+    start_date = datetime.date(2013, 8, 27)
+
+    # Get theme reviews that are approves and rejects from before we started
+    # awarding.
+    approve = '"action": %s' % rvw.ACTION_APPROVE
+    reject = '"action": %s' % rvw.ACTION_REJECT
+    al = ActivityLog.objects.filter(
+        Q(_details__contains=approve) | Q(_details__contains=reject),
+        action=amo.LOG.THEME_REVIEW.id, created__lte=start_date)
+
+    for chunk in chunked(al, 500):
+        # Review and thou shall receive.
+        _batch_award_points.delay(chunk)


### PR DESCRIPTION
We introduced theme review points for theme reviewers. But we only started awarding points for theme reviews after the 8.27.2013 push.

We have theme review logs since ~4.20.13, 8805 of them. This patch gives those theme reviewers their due and awards points for those 9000 reviews.

This is done through a migration. I tried to build it safe such that even if it is run multiple times, the DB state only changes on the first run (integrity). It also adds a note on the created ReviewerScore objects, marking them as manual and "RETROACTIVE".

![img](http://collegecandy.files.wordpress.com/2013/03/make-it-rain-guys.gif)
