### PR TITLE
Upgrade django-rest-framework to fix ChoiceField empty values issue (bug 910381)

### DIFF
--- a/mkt/api/base.py
+++ b/mkt/api/base.py
@@ -511,7 +511,8 @@ class SlugRouter(SimpleRouter):
         return ret
 
     def create_url(self, prefix, viewset, basename, route, mapping, lookup=''):
-        regex = route.url.format(prefix=prefix, lookup=lookup)
+        regex = route.url.format(prefix=prefix, lookup=lookup,
+                                 trailing_slash=self.trailing_slash)
         view = viewset.as_view(mapping, **route.initkwargs)
         name = route.name.format(basename=basename)
         return url(regex, view, name=name)

--- a/mkt/collections/tests/test_serializers.py
+++ b/mkt/collections/tests/test_serializers.py
@@ -94,6 +94,19 @@ class TestCollectionSerializer(CollectionDataMixin, amo.tests.TestCase):
         eq_(serializer.errors, {})
         ok_(serializer.is_valid())
 
+    def test_empty_choice_deserialization(self):
+        # Build data from existing object.
+        data = self.serializer.to_native(self.collection)
+        data.pop('id')
+        # Emulate empty values passed via POST.
+        data.update(carrier='', region='')
+
+        instance = self.serializer.from_native(data, None)
+        eq_(self.serializer.errors, {})
+        ok_(self.serializer.is_valid())
+        eq_(instance.region, None)
+        eq_(instance.carrier, None)
+
     def test_to_native_with_apps(self):
         apps = [amo.tests.app_factory() for n in xrange(1, 5)]
         data = self.test_to_native(apps=apps)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -33,7 +33,6 @@ django-quieter-formset==0.3
 django-raven-metlog==0.2
 django-ratelimit==0.1
 django-recaptcha-mozilla==0.0.1
-djangorestframework==2.3.5
 #django-session-csrf==0.6
 django-statsd-mozilla==0.3.8.6
 django-storages==1.1.8
@@ -91,6 +90,9 @@ SQLAlchemy==0.7.5
 statsd==1.0.0
 suds==0.3.9
 tastypie-services==0.2.2
+
+# Waiting for a release with that commit
+-e git+https://github.com/tomchristie/django-rest-framework.git@cf2033f8bf013039d906a3fe5390ca6940503626#egg=rest_framework
 
 ## Not on pypi.
 -e git+https://github.com/mozilla/amo-validator.git@21078009567fb581e462d4b48a819594f17c5f6f#egg=amo-validator


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=910381

My patch fixing this was accepted upstream but we can't really wait for a new release and this is tricky to deal with in our own code.
