### PR TITLE
Make signature block unmissable

### DIFF
--- a/mkt/reviewers/templates/reviewers/emails/decisions/includes/questions.txt
+++ b/mkt/reviewers/templates/reviewers/emails/decisions/includes/questions.txt
@@ -1,3 +1,5 @@
-If you have any questions about this review, please reply to this email or join #app-reviewers on irc.mozilla.org. For general developer support, please contact {{ MKT_SUPPORT_EMAIL }}.
+**********************************************************************
+If you have any questions about this review, please reply to this email or join #app-reviewers on irc.mozilla.org. 
 
 {% include 'reviewers/emails/decisions/includes/commbadge.txt' %}
+**********************************************************************


### PR DESCRIPTION
Added some asterisks and took out the redundant MKT_SUPPORT_EMAIL to make it shorter.
