### PR TITLE
Allow filtering on ids and on empty (null) values in Collections (bug 911382)

### DIFF
--- a/docs/api/topics/rocketfuel.rst
+++ b/docs/api/topics/rocketfuel.rst
@@ -35,6 +35,9 @@ Listing
     :param carrier: a carrier ID/slug.
     :type carrier: int|string
 
+    Filtering on null values is done by omiting the value for the corresponding
+    parameter in the query string.
+
 Create
 ------
 

--- a/mkt/collections/filters.py
+++ b/mkt/collections/filters.py
@@ -1,3 +1,5 @@
+from django import forms
+from django.core.validators import EMPTY_VALUES
 from django.db.models import Q
 
 from django_filters.filters import ChoiceFilter, ModelChoiceFilter
@@ -13,22 +15,23 @@ from mkt.collections.models import Collection
 class SlugChoiceFilter(ChoiceFilter):
     def __init__(self, *args, **kwargs):
         self.choices_dict = kwargs.pop('choices_dict')
-        kwargs['choices'] = self.choices_dict.items()
+        # Create a choice dynamically to allow None, slugs and ids.
+        slugs_choices = self.choices_dict.items()
+        ids_choices = [(v.id, v) for v in self.choices_dict.values()]
+        kwargs['choices'] = [(None, None)] + slugs_choices + ids_choices
+
         return super(SlugChoiceFilter, self).__init__(*args, **kwargs)
 
     def filter(self, qs, value):
-        if not value:
-            # Filters are called everytime, even when there was no data given,
-            # and we don't want to do the slug match and NULL values filtering
-            # in that case, so just use django-filter implementation if value
-            # is falsy.
-            return super(SlugChoiceFilter, self).filter(qs, value)
+        if value == '' or value is None:
+            return qs.filter(**{'%s__isnull' % self.name: True})
         else:
-            # We are passed a slug, get the id by looking at the choices dict,
-            # and use that when filtering the queryset.
-            value = self.choices_dict.get(value, None)
-            if value is not None:
-                value = value.id
+            if not value.isdigit():
+                # We are passed a slug, get the id by looking at the choices
+                # dict, and use that when filtering the queryset.
+                value = self.choices_dict.get(value, None)
+                if value is not None:
+                    value = value.id
 
             # Do the filtering, adding a OR to catch NULL values as well.
             return qs.filter(
@@ -39,6 +42,9 @@ class SlugChoiceFilter(ChoiceFilter):
 
 class SlugModelChoiceFilter(ModelChoiceFilter):
     field_class = SluggableModelChoiceField
+
+    def filter(self, qs, value):
+        return qs.filter(**{'%s__%s' % (self.name, self.lookup_type): value})
 
 
 class CollectionFilterSetWithFallback(FilterSet):
@@ -83,9 +89,63 @@ class CollectionFilterSetWithFallback(FilterSet):
         # Make self.data mutable for later.
         self.data = self.data.copy()
 
+    def get_queryset(self):
+        """
+        Return the queryset to use for the filterset.
+
+        Copied from django-filter qs property, modified to support filtering on
+        'empty' values, at the expense of multi-lookups like 'x < 4 and x > 2'.
+        """
+        valid = self.is_bound and self.form.is_valid()
+
+        if self.strict and self.is_bound and not valid:
+            return self.queryset.none()
+
+        # Start with all the results and filter from there.
+        qs = self.queryset.all()
+        for name, filter_ in self.filters.items():
+            if valid:
+                if name in self.form.data:
+                    value = self.form.cleaned_data[name]
+                else:
+                    continue
+            else:
+                raw_value = self.form[name].value()
+                try:
+                    value = self.form.fields[name].clean(raw_value)
+                except forms.ValidationError:
+                    if self.strict:
+                        return self.queryset.none()
+                    else:
+                        continue
+
+            # At this point we should have valid & clean data.
+            qs = filter_.filter(qs, value)
+
+        # Optional ordering.
+        if self._meta.order_by:
+            order_field = self.form.fields[self.order_by_field]
+            data = self.form[self.order_by_field].data
+            ordered = None
+            try:
+                ordered = order_field.clean(data)
+            except forms.ValidationError:
+                pass
+
+            if ordered in EMPTY_VALUES and self.strict:
+                ordered = self.form.fields[self.order_by_field].choices[0][0]
+
+            if ordered:
+                qs = qs.order_by(*self.get_order_by(ordered))
+
+        return qs
+
     @property
     def qs(self):
-        qs = super(CollectionFilterSetWithFallback, self).qs
+        if hasattr(self, '_qs'):
+            return self._qs
+
+        qs = self.get_queryset()
         # FIXME: being able to return self.form.errors would greatly help
         # debugging.
         next_fallback = self.next_fallback()
@@ -95,6 +155,7 @@ class CollectionFilterSetWithFallback(FilterSet):
             # should be possible to implement using <filtersetinstance>.data.
             self.data.pop(next_fallback)
             del self._form
-            del self._qs
             qs = self.qs
-        return qs
+
+        self._qs = qs
+        return self._qs

--- a/mkt/collections/tests/test_views.py
+++ b/mkt/collections/tests/test_views.py
@@ -168,6 +168,21 @@ class TestCollectionViewSet(TestCollectionViewSetMixin, RestOAuth):
         eq_(collections[1]['id'], self.collection3.id)
         eq_(collections[2]['id'], self.collection2.id)
 
+    def test_listing_filtering_region_id(self):
+        self.create_additional_data()
+        self.make_publisher()
+
+        self.collection.update(region=mkt.regions.PL.id)
+
+        res = self.client.get(self.list_url, {'region': mkt.regions.SPAIN.id})
+        eq_(res.status_code, 200)
+        data = json.loads(res.content)
+        collections = data['objects']
+        eq_(len(collections), 3)
+        eq_(collections[0]['id'], self.collection4.id)
+        eq_(collections[1]['id'], self.collection3.id)
+        eq_(collections[2]['id'], self.collection2.id)
+
     def test_listing_filtering_carrier(self):
         self.create_additional_data()
         self.make_publisher()
@@ -183,6 +198,44 @@ class TestCollectionViewSet(TestCollectionViewSetMixin, RestOAuth):
         # self.collection.carrier is None, so it will match too.
         eq_(collections[2]['id'], self.collection.id)
 
+    def test_listing_filtering_carrier_id(self):
+        self.create_additional_data()
+        self.make_publisher()
+
+        res = self.client.get(self.list_url,
+            {'carrier': mkt.carriers.TELEFONICA.id})
+        eq_(res.status_code, 200)
+        data = json.loads(res.content)
+        collections = data['objects']
+        eq_(len(collections), 3)
+        eq_(collections[0]['id'], self.collection4.id)
+        eq_(collections[1]['id'], self.collection3.id)
+        # self.collection.carrier is None, so it will match too.
+        eq_(collections[2]['id'], self.collection.id)
+
+    def test_listing_filtering_carrier_null(self):
+        self.create_additional_data()
+        self.make_publisher()
+
+        res = self.client.get(self.list_url, {'carrier': ''})
+        eq_(res.status_code, 200)
+        data = json.loads(res.content)
+        collections = data['objects']
+        eq_(len(collections), 1)
+        eq_(collections[0]['id'], self.collection.id)
+
+    def test_listing_filtering_region_null(self):
+        self.create_additional_data()
+        self.make_publisher()
+
+        res = self.client.get(self.list_url, {'region': ''})
+        eq_(res.status_code, 200)
+        data = json.loads(res.content)
+        collections = data['objects']
+        eq_(len(collections), 2)
+        eq_(collections[0]['id'], self.collection3.id)
+        eq_(collections[1]['id'], self.collection.id)
+
     def test_listing_filtering_category(self):
         self.create_additional_data()
         self.make_publisher()
@@ -193,6 +246,30 @@ class TestCollectionViewSet(TestCollectionViewSetMixin, RestOAuth):
         collections = data['objects']
         eq_(len(collections), 1)
         eq_(collections[0]['id'], self.collection4.id)
+
+    def test_listing_filtering_category_id(self):
+        self.create_additional_data()
+        self.make_publisher()
+
+        res = self.client.get(self.list_url, {'cat': self.category.id})
+        eq_(res.status_code, 200)
+        data = json.loads(res.content)
+        collections = data['objects']
+        eq_(len(collections), 1)
+        eq_(collections[0]['id'], self.collection4.id)
+
+    def test_listing_filtering_category_null(self):
+        self.create_additional_data()
+        self.make_publisher()
+
+        res = self.client.get(self.list_url, {'cat': ''})
+        eq_(res.status_code, 200)
+        data = json.loads(res.content)
+        collections = data['objects']
+        eq_(len(collections), 3)
+        eq_(collections[0]['id'], self.collection3.id)
+        eq_(collections[1]['id'], self.collection2.id)
+        eq_(collections[2]['id'], self.collection.id)
 
     def test_listing_filtering_category_region_carrier(self):
         self.create_additional_data()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=911382
https://bugzilla.mozilla.org/show_bug.cgi?id=911414

The empty/null part requires a custom implementation of FilterSet.qs, because out of the box django-filter doesn't allow this at all.
