### PR TITLE
Accept and return slugs for category/region/carrier in collections API (bug 912279)

### DIFF
--- a/mkt/collections/serializers.py
+++ b/mkt/collections/serializers.py
@@ -4,16 +4,20 @@ import uuid
 
 from rest_framework import serializers
 from rest_framework.fields import get_component
+from rest_framework.compat import smart_text
+from rest_framework.reverse import reverse
 from tastypie.bundle import Bundle
 from tower import ugettext_lazy as _
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files.base import File
 from django.core.files.storage import default_storage as storage
 
-from rest_framework.reverse import reverse
 
+import amo
+import mkt
+from addons.models import Category
 from mkt.api.fields import TranslationSerializerField
 from mkt.api.resources import AppResource
 from mkt.constants.features import FeatureProfile
@@ -33,7 +37,6 @@ class CollectionMembershipField(serializers.RelatedField):
     def to_native(self, value):
         bundle = Bundle(obj=value.app)
         return AppResource().full_dehydrate(bundle).data
-
 
     def field_to_native(self, obj, field_name):
         value = get_component(obj, self.source)
@@ -68,6 +71,57 @@ class HyperlinkedRelatedOrNullField(serializers.HyperlinkedRelatedField):
             return None
 
 
+class SlugChoiceField(serializers.ChoiceField):
+    """
+    Companion to SlugChoiceFilter, this field accepts an id or a slug when
+    de-serializing, but always return a slug for serializing.
+
+    Like SlugChoiceFilter, it needs to be initialized with a choices_dict
+    mapping the slugs to objects with id and slug properties. This will be used
+    to overwrite the choices in the underlying code.
+    """
+    def __init__(self, *args, **kwargs):
+        # Create a choice dynamically to allow None, slugs and ids. Also store
+        # choices_dict and ids_choices_dict to re-use them later in to_native()
+        # and from_native().
+        self.choices_dict = kwargs.pop('choices_dict')
+        slugs_choices = self.choices_dict.items()
+        ids_choices = [(v.id, v) for v in self.choices_dict.values()]
+        self.ids_choices_dict = dict(ids_choices)
+        kwargs['choices'] = slugs_choices + ids_choices
+        return super(SlugChoiceField, self).__init__(*args, **kwargs)
+
+    def to_native(self, value):
+        if value:
+            choice = self.ids_choices_dict.get(value, None)
+            if choice is not None:
+                value = choice.slug
+        return super(SlugChoiceField, self).to_native(value)
+
+    def from_native(self, value):
+        if isinstance(value, basestring):
+            choice = self.choices_dict.get(value, None)
+            if choice is not None:
+                value = choice.id
+        return super(SlugChoiceField, self).from_native(value)
+
+
+class SlugModelChoiceField(serializers.PrimaryKeyRelatedField):
+    def field_to_native(self, obj, field_name):
+        attr = self.source or field_name
+        value = getattr(obj, attr)
+        return getattr(value, 'slug', None)
+
+    def from_native(self, data):
+        if isinstance(data, basestring):
+            try:
+                data = self.queryset.only('pk').get(slug=data).pk
+            except ObjectDoesNotExist:
+                msg = self.error_messages['does_not_exist'] % smart_text(data)
+                raise ValidationError(msg)
+        return super(SlugModelChoiceField, self).from_native(data)
+
+
 class CollectionSerializer(serializers.ModelSerializer):
     name = TranslationSerializerField()
     description = TranslationSerializerField()
@@ -79,6 +133,12 @@ class CollectionSerializer(serializers.ModelSerializer):
         source='*',
         view_name='collection-image-detail',
         predicate=lambda o: os.path.exists(o.image_path()))
+    carrier = SlugChoiceField(required=False,
+        choices_dict=mkt.carriers.CARRIER_MAP)
+    region = SlugChoiceField(required=False,
+        choices_dict=mkt.regions.REGIONS_DICT)
+    category = SlugModelChoiceField(required=False,
+        queryset=Category.objects.filter(type=amo.ADDON_WEBAPP))
 
     class Meta:
         fields = ('apps', 'author', 'background_color', 'carrier', 'category',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=912279

Probably best to review #1082 with it, even though the 2 should work separately : this one is for accepting slugs and ids when serializing and de-serializing, and the other one is for accepting slugs and ids when filtering.
