### PR TITLE
fix rereview queue from breaking due to soft deleted addons (bug 876819)

### DIFF
--- a/apps/editors/models.py
+++ b/apps/editors/models.py
@@ -660,6 +660,20 @@ class RereviewQueue(amo.models.ModelBase):
             amo.log(event, addon, addon.current_version)
 
 
+class RereviewQueueThemeManager(amo.models.ManagerBase):
+
+    def __init__(self, include_deleted=False):
+        amo.models.ManagerBase.__init__(self)
+        self.include_deleted = include_deleted
+
+    def get_query_set(self):
+        qs = super(RereviewQueueThemeManager, self).get_query_set()
+        if self.include_deleted:
+            return qs
+        else:
+            return qs.exclude(theme__addon__status=amo.STATUS_DELETED)
+
+
 class RereviewQueueTheme(amo.models.ModelBase):
     theme = models.ForeignKey(Persona)
     header = models.CharField(max_length=72, blank=True, default='')
@@ -668,6 +682,9 @@ class RereviewQueueTheme(amo.models.ModelBase):
     # Holds whether this reuploaded theme is a duplicate.
     dupe_persona = models.ForeignKey(Persona, null=True,
                                      related_name='dupepersona')
+
+    objects = RereviewQueueThemeManager()
+    with_deleted = RereviewQueueThemeManager(include_deleted=True)
 
     class Meta:
         db_table = 'rereview_queue_theme'

--- a/mkt/reviewers/tests/test_views_themes.py
+++ b/mkt/reviewers/tests/test_views_themes.py
@@ -488,6 +488,54 @@ class TestThemeQueueRereview(ThemeReviewTestMixin, amo.tests.TestCase):
         self.login('senior_persona_reviewer@mozilla.com')
         eq_(self.client.get(self.queue_url).status_code, 200)
 
+    def test_soft_deleted_addon(self):
+        """
+        Test soft-deleted add-ons don't cause trouble like they did to me
+        for the last 6 months! #liberation
+        """
+        self.create_switch('soft_delete')
+
+        # Normal RQT object.
+        RereviewQueueTheme.objects.create(
+            theme=addon_factory(type=amo.ADDON_PERSONA).persona, header='',
+            footer='')
+
+        # Deleted add-on RQT object.
+        addon = addon_factory(type=amo.ADDON_PERSONA)
+        RereviewQueueTheme.objects.create(theme=addon.persona, header='',
+                                          footer='')
+        addon.delete()
+
+        self.login('senior_persona_reviewer@mozilla.com')
+        r = self.client.get(self.queue_url)
+        eq_(r.status_code, 200)
+        doc = pq(r.content)
+        eq_(doc('.theme').length, 1)
+        eq_(RereviewQueueTheme.with_deleted.count(), 2)
+
+    def test_hard_deleted_addon(self):
+        """
+        Test soft-deleted add-ons don't cause trouble like they did to me
+        for the last 6 months! #liberation
+        """
+        # Normal RQT object.
+        RereviewQueueTheme.objects.create(
+            theme=addon_factory(type=amo.ADDON_PERSONA).persona, header='',
+            footer='')
+
+        # Deleted add-on RQT object.
+        addon = addon_factory(type=amo.ADDON_PERSONA)
+        RereviewQueueTheme.objects.create(theme=addon.persona, header='',
+                                          footer='')
+        addon.delete()
+
+        self.login('senior_persona_reviewer@mozilla.com')
+        r = self.client.get(self.queue_url)
+        eq_(r.status_code, 200)
+        doc = pq(r.content)
+        eq_(doc('.theme').length, 1)
+        eq_(RereviewQueueTheme.with_deleted.count(), 1)
+
 
 class TestDeletedThemeLookup(amo.tests.TestCase):
     fixtures = fixture('group_admin', 'user_admin', 'user_admin_group',


### PR DESCRIPTION
Sitch
1. Theme is re-uploaded/updated.
2. addon.delete() (status => amo.STATUS_DELETED)
3. Theme tries to load in the theme queue.
4. RereviewQueueTheme object tries to access header/footer URLs.
5. Calling theme.addon raises Addon.DoesNotExist

Fix

RereviewQueueTheme manager that `excludes` soft-deleted add-ons.
