### PR TITLE
Replace all '.uncached' calls by '.objects.no_cache()' (bug 913010)

### DIFF
--- a/apps/addons/forms.py
+++ b/apps/addons/forms.py
@@ -614,7 +614,7 @@ class EditThemeForm(AddonFormBase):
 
         super(AddonFormBase, self).__init__(*args, **kw)
 
-        addon = Addon.uncached.get(id=self.instance.id)
+        addon = Addon.objects.no_cache().get(id=self.instance.id)
         persona = addon.persona
 
         # Do not simply append validators, as validators will persist between

--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1305,31 +1305,31 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
         """
         status_change = Max('versions__files__datestatuschanged')
         public = (
-            Addon.uncached.filter(status=amo.STATUS_PUBLIC,
+            Addon.objects.no_cache().filter(status=amo.STATUS_PUBLIC,
                                   versions__files__status=amo.STATUS_PUBLIC)
             .exclude(type__in=(amo.ADDON_PERSONA, amo.ADDON_WEBAPP))
             .values('id').annotate(last_updated=status_change))
 
-        lite = (Addon.uncached.filter(status__in=amo.LISTED_STATUSES,
+        lite = (Addon.objects.no_cache().filter(status__in=amo.LISTED_STATUSES,
                                       versions__files__status=amo.STATUS_LITE)
                 .exclude(type=amo.ADDON_WEBAPP)
                 .values('id').annotate(last_updated=status_change))
 
         stati = amo.LISTED_STATUSES + (amo.STATUS_PUBLIC,)
-        exp = (Addon.uncached.exclude(status__in=stati)
+        exp = (Addon.objects.no_cache().exclude(status__in=stati)
                .filter(versions__files__status__in=amo.VALID_STATUSES)
                .exclude(type=amo.ADDON_WEBAPP)
                .values('id')
                .annotate(last_updated=Max('versions__files__created')))
 
-        listed = (Addon.uncached.filter(status=amo.STATUS_LISTED)
+        listed = (Addon.objects.no_cache().filter(status=amo.STATUS_LISTED)
                   .values('id')
                   .annotate(last_updated=Max('versions__created')))
 
-        personas = (Addon.uncached.filter(type=amo.ADDON_PERSONA)
+        personas = (Addon.objects.no_cache().filter(type=amo.ADDON_PERSONA)
                     .extra(select={'last_updated': 'created'}))
         webapps = (
-            Addon.uncached.filter(type=amo.ADDON_WEBAPP,
+            Addon.objects.no_cache().filter(type=amo.ADDON_WEBAPP,
                                   status=amo.STATUS_PUBLIC,
                                   versions__files__status=amo.STATUS_PUBLIC)
                           .values('id')
@@ -2046,7 +2046,7 @@ class Category(amo.models.OnChangeMixin, amo.models.ModelBase):
 
     @staticmethod
     def transformer(addons):
-        qs = (Category.uncached.filter(addons__in=addons)
+        qs = (Category.objects.no_cache().filter(addons__in=addons)
               .extra(select={'addon_id': 'addons_categories.addon_id'}))
         cats = dict((addon_id, list(cs))
                     for addon_id, cs in sorted_groupby(qs, 'addon_id'))

--- a/apps/addons/tasks.py
+++ b/apps/addons/tasks.py
@@ -71,7 +71,7 @@ def update_appsupport(ids):
                   (addon_id, app_id, min, max, created, modified)
                 VALUES %s"""
 
-    addons = Addon.uncached.filter(id__in=ids).no_transforms()
+    addons = Addon.objects.no_cache().filter(id__in=ids).no_transforms()
     apps = []
     for addon in addons:
         for app, appver in addon.compatible_apps.items():

--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -154,7 +154,6 @@ class TestAddonManager(amo.tests.TestCase):
         addon.update(_current_version=None, _signal=False)
         eq_(Addon.objects.valid_and_disabled_and_pending().count(), before + 1)
 
-
     def test_top_free_public(self):
         addons = list(Addon.objects.listed(amo.FIREFOX))
         eq_(list(Addon.objects.top_free(amo.FIREFOX)),
@@ -316,7 +315,7 @@ class TestAddonModels(amo.tests.TestCase):
         av = addon.current_version.apps.all()[0]
 
         v = Version.objects.create(addon=addon, version='99')
-        f = File.objects.create(status=status, version=v)
+        File.objects.create(status=status, version=v)
 
         ApplicationsVersions.objects.create(application_id=amo.FIREFOX.id,
                                             version=v, min=av.min, max=av.max)
@@ -1907,7 +1906,8 @@ class TestUpdateNames(amo.tests.TestCase):
         self.addon.save()
 
     def get_name(self, app, locale='en-US'):
-        return Translation.uncached.get(id=app.name_id, locale=locale)
+        return Translation.objects.no_cache().get(id=app.name_id,
+                                                  locale=locale)
 
     def check_names(self, names):
         """`names` in {locale: name} format."""

--- a/apps/amo/models.py
+++ b/apps/amo/models.py
@@ -108,6 +108,7 @@ class RawQuerySet(models.query.RawQuerySet):
 class CachingRawQuerySet(RawQuerySet, caching.base.CachingRawQuerySet):
     """A RawQuerySet with __len__ and caching."""
 
+
 # Make TransformQuerySet one of CachingQuerySet's parents so that we can do
 # transforms on objects and then get them cached.
 CachingQuerySet = caching.base.CachingQuerySet
@@ -341,7 +342,6 @@ class ModelBase(SearchMixin, caching.base.CachingMixin, models.Model):
     modified = models.DateTimeField(auto_now=True)
 
     objects = ManagerBase()
-    uncached = UncachedManagerBase()
 
     class Meta:
         abstract = True

--- a/apps/api/handlers.py
+++ b/apps/api/handlers.py
@@ -189,7 +189,7 @@ class AppsHandler(AddonsHandler):
 
             # We must reget the object here since the above has
             # saved changes to the object.
-            upload = FileUpload.uncached.get(pk=upload.pk)
+            upload = FileUpload.objects.get(pk=upload.pk)
             # Check it validated correctly.
             if settings.VALIDATE_ADDONS:
                 validation = json.loads(upload.validation)

--- a/apps/bandwagon/tests/test_views.py
+++ b/apps/bandwagon/tests/test_views.py
@@ -263,7 +263,7 @@ class TestVotes(amo.tests.TestCase):
         self.assertRedirects(r, self.c_url)
 
     def check(self, upvotes=0, downvotes=0):
-        c = Collection.uncached.get(slug='slug', author=9945)
+        c = Collection.objects.no_cache().get(slug='slug', author=9945)
         eq_(c.upvotes, upvotes)
         eq_(c.downvotes, downvotes)
         eq_(CollectionVote.objects.filter(user=4043307, vote=1).count(),
@@ -616,7 +616,7 @@ class TestCRUD(amo.tests.TestCase):
 
     def test_edit_no_contrib_tab(self):
         self.create_collection()
-        c = Collection.uncached.get(slug=self.slug)
+        c = Collection.objects.no_cache().get(slug=self.slug)
         url = c.edit_url()
 
         c.update(type=amo.COLLECTION_FAVORITES)

--- a/apps/bandwagon/views.py
+++ b/apps/bandwagon/views.py
@@ -424,7 +424,7 @@ def edit(request, collection, username, slug):
     else:
         form = forms.CollectionForm(instance=collection)
 
-    qs = (CollectionAddon.uncached.using('default')
+    qs = (CollectionAddon.objects.no_cache().using('default')
           .filter(collection=collection))
     meta = dict((c.addon_id, c) for c in qs)
     addons = collection.addons.no_cache().all()
@@ -559,7 +559,7 @@ def watch(request, username, slug):
     """
     collection = get_collection(request, username, slug)
     d = dict(user=request.amo_user, collection=collection)
-    qs = CollectionWatcher.uncached.using('default').filter(**d)
+    qs = CollectionWatcher.objects.no_cache().using('default').filter(**d)
     watching = not qs  # Flip the bool since we're about to change it.
     if qs:
         qs.delete()

--- a/apps/blocklist/views.py
+++ b/apps/blocklist/views.py
@@ -80,7 +80,7 @@ for m in (BlocklistItem, BlocklistPlugin, BlocklistGfx, BlocklistApp,
 def get_items(apiver, app, appver=None):
     # Collapse multiple blocklist items (different version ranges) into one
     # item and collapse each item's apps.
-    addons = (BlocklistItem.uncached
+    addons = (BlocklistItem.objects.no_cache()
               .select_related('details')
               .filter(Q(app__guid__isnull=True) | Q(app__guid=app))
               .order_by('-modified')
@@ -106,7 +106,7 @@ def get_items(apiver, app, appver=None):
 def get_plugins(apiver, app, appver=None):
     # API versions < 3 ignore targetApplication entries for plugins so only
     # block the plugin if the appver is within the block range.
-    plugins = (BlocklistPlugin.uncached.select_related('details')
+    plugins = (BlocklistPlugin.objects.no_cache().select_related('details')
                .filter(Q(app__isnull=True) | Q(app__guid=app) |
                        Q(app__guid__isnull=True))
                .extra(select={'app_guid': 'blapps.guid',

--- a/apps/devhub/management/commands/search_platforms.py
+++ b/apps/devhub/management/commands/search_platforms.py
@@ -34,7 +34,7 @@ def change():
     k = 0
     print 'Changing %s files' % len(files)
     for chunk in chunked(files, 100):
-        for file in File.uncached.filter(pk__in=chunk):
+        for file in File.objects.no_cache().filter(pk__in=chunk):
             file.platform_id = amo.PLATFORM_ALL.id
             if not file.datestatuschanged:
                 file.datestatuschanged = datetime.now()
@@ -50,7 +50,7 @@ def report():
                            .filter(addon__type=amo.ADDON_SEARCH)
                            .filter(files_count__gt=1))
     for chunk in chunked(versions, 100):
-        for version in Version.uncached.filter(pk__in=chunk):
+        for version in Version.objects.no_cache().filter(pk__in=chunk):
             print 'Addon: %s, %s' % (version.addon.pk,
                                      version.addon.name)
             print 'Version: %s - %s files' % (version.pk,

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -696,7 +696,7 @@ class TestDisablePayments(amo.tests.TestCase):
         r = self.client.post(self.disable_url)
         eq_(r.status_code, 302)
         assert(r['Location'].endswith(self.pay_url))
-        eq_(Addon.uncached.get(id=3615).wants_contributions, False)
+        eq_(Addon.objects.no_cache().get(id=3615).wants_contributions, False)
 
 
 class TestPaymentsProfile(amo.tests.TestCase):

--- a/apps/devhub/tests/test_views_versions.py
+++ b/apps/devhub/tests/test_views_versions.py
@@ -658,8 +658,8 @@ class TestPlatformSearch(TestVersionEdit):
                            approvalnotes='yy')
         response = self.client.post(self.url, dd)
         eq_(response.status_code, 302)
-        uncached = Version.uncached.get(id=42352).files.all()[0]
-        eq_(amo.PLATFORM_ALL.id, uncached.platform.id)
+        version = Version.objects.no_cache().get(id=42352).files.all()[0]
+        eq_(amo.PLATFORM_ALL.id, version.platform.id)
 
 
 class TestVersionEditCompat(TestVersionEdit):

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -813,7 +813,7 @@ def standalone_upload(request):
 @login_required
 @json_view
 def standalone_upload_detail(request, uuid):
-    upload = get_object_or_404(FileUpload.uncached, uuid=uuid)
+    upload = get_object_or_404(FileUpload, uuid=uuid)
     url = reverse('devhub.standalone_upload_detail', args=[uuid])
     return upload_validation_context(request, upload, url=url)
 
@@ -827,7 +827,7 @@ def upload_for_addon(request, addon_id, addon):
 @dev_required
 @json_view
 def upload_detail_for_addon(request, addon_id, addon, uuid):
-    upload = get_object_or_404(FileUpload.uncached, uuid=uuid)
+    upload = get_object_or_404(FileUpload, uuid=uuid)
     return json_upload_detail(request, upload, addon_slug=addon.slug)
 
 
@@ -1068,7 +1068,7 @@ def upload_validation_context(request, upload, addon_slug=None, addon=None,
 
 @login_required
 def upload_detail(request, uuid, format='html'):
-    upload = get_object_or_404(FileUpload.uncached, uuid=uuid)
+    upload = get_object_or_404(FileUpload, uuid=uuid)
 
     if format == 'json' or request.is_ajax():
         return json_upload_detail(request, upload)

--- a/apps/discovery/tests/test_views.py
+++ b/apps/discovery/tests/test_views.py
@@ -196,7 +196,7 @@ class TestModuleAdmin(amo.tests.TestCase):
             eq_(set(modules), set(registry.keys()))
 
         app = Application.objects.create()
-        qs = DiscoveryModule.uncached.filter(app=app)
+        qs = DiscoveryModule.objects.no_cache().filter(app=app)
         eq_(qs.count(), 0)
 
         # All our modules get added.

--- a/apps/discovery/views.py
+++ b/apps/discovery/views.py
@@ -149,9 +149,10 @@ def api_view(request, platform, version, list_type, api_version=1.5,
 def module_admin(request):
     APP = request.APP
     # Custom sorting to drop ordering=NULL objects to the bottom.
-    qs = DiscoveryModule.uncached.raw("""
-        SELECT * from discovery_modules WHERE app_id = %s
-        ORDER BY ordering IS NULL, ordering""", [APP.id])
+    with amo.models.skip_cache():
+        qs = DiscoveryModule.objects.raw("""
+            SELECT * from discovery_modules WHERE app_id = %s
+            ORDER BY ordering IS NULL, ordering""", [APP.id])
     qs.ordered = True  # The formset looks for this.
     _sync_db_and_registry(qs, APP)
 

--- a/apps/editors/models.py
+++ b/apps/editors/models.py
@@ -439,9 +439,9 @@ class ReviewerScore(amo.models.ModelBase):
         if val is not None:
             return val
 
-        val = (ReviewerScore.uncached.filter(user=user)
-                                     .aggregate(total=Sum('score'))
-                                     .values())[0]
+        val = (ReviewerScore.objects.no_cache().filter(user=user)
+                                    .aggregate(total=Sum('score'))
+                                    .values())[0]
         if val is None:
             val = 0
 
@@ -456,7 +456,7 @@ class ReviewerScore(amo.models.ModelBase):
         if val is not None:
             return val
 
-        val = ReviewerScore.uncached.filter(user=user)
+        val = ReviewerScore.objects.no_cache().filter(user=user)
         if addon_type is not None:
             val.filter(addon__type=addon_type)
 
@@ -482,7 +482,8 @@ class ReviewerScore(amo.models.ModelBase):
              GROUP BY `addons`.`addontype_id`
              ORDER BY `total` DESC
         """
-        val = list(ReviewerScore.uncached.raw(sql, [user.id]))
+        with amo.models.skip_cache():
+            val = list(ReviewerScore.objects.raw(sql, [user.id]))
         cache.set(key, val, 0)
         return val
 
@@ -507,7 +508,8 @@ class ReviewerScore(amo.models.ModelBase):
              GROUP BY `addons`.`addontype_id`
              ORDER BY `total` DESC
         """
-        val = list(ReviewerScore.uncached.raw(sql, [user.id, since]))
+        with amo.models.skip_cache():
+            val = list(ReviewerScore.objects.raw(sql, [user.id, since]))
         cache.set(key, val, 3600)
         return val
 

--- a/apps/perf/views.py
+++ b/apps/perf/views.py
@@ -32,7 +32,7 @@ def index(request):
         redis = redisutils.connections['master']
         os_perf = dict(zip(ids, redis.hmget(Performance.ALL_PLATFORMS, ids)))
         platforms = dict((unicode(p), p.id)
-                         for p in PerformanceOSVersion.uncached.all())
+                         for p in PerformanceOSVersion.objects.no_cache().all())
         ctx.update(
             os_perf=os_perf,
             platforms=platforms,

--- a/apps/reviews/models.py
+++ b/apps/reviews/models.py
@@ -109,7 +109,7 @@ class Review(amo.models.ModelBase):
     @staticmethod
     def transformer(reviews):
         user_ids = dict((r.user_id, r) for r in reviews)
-        for user in UserProfile.uncached.filter(id__in=user_ids):
+        for user in UserProfile.objects.no_cache().filter(id__in=user_ids):
             user_ids[user.id].user = user
 
 

--- a/apps/reviews/tasks.py
+++ b/apps/reviews/tasks.py
@@ -66,7 +66,7 @@ def addon_bayesian_rating(*addons, **kw):
     if avg['rating'] is None:
         return
     mc = avg['reviews'] * avg['rating']
-    for addon in Addon.uncached.filter(id__in=addons):
+    for addon in Addon.objects.no_cache().filter(id__in=addons):
         if addon.average_rating is None:
             # Ignoring addons with no average rating.
             continue

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -167,7 +167,7 @@ class TestVersion(amo.tests.TestCase):
         version = Version.objects.get(pk=81551)
         version.delete()
 
-        addon = Addon.uncached.get(pk=3615)
+        addon = Addon.objects.no_cache().get(pk=3615)
         assert not Version.objects.filter(addon=addon).exists()
         assert not Version.with_deleted.filter(addon=addon).exists()
 
@@ -176,7 +176,7 @@ class TestVersion(amo.tests.TestCase):
     def test_version_delete_marketplace(self, storage_mock):
         version = Version.objects.get(pk=81551)
         version.delete()
-        addon = Addon.uncached.get(pk=3615)
+        addon = Addon.objects.no_cache().get(pk=3615)
         assert addon
 
         assert not Version.objects.filter(addon=addon).exists()
@@ -187,7 +187,7 @@ class TestVersion(amo.tests.TestCase):
     @mock.patch('versions.models.settings.MARKETPLACE', True)
     @mock.patch('versions.models.storage')
     def test_packaged_version_delete_marketplace(self, storage_mock):
-        addon = Addon.uncached.get(pk=3615)
+        addon = Addon.objects.no_cache().get(pk=3615)
         addon.update(is_packaged=True)
         version = Version.objects.get(pk=81551)
         version.delete()
@@ -232,7 +232,7 @@ class TestVersion(amo.tests.TestCase):
         file = File(platform_id=amo.PLATFORM_MAC.id, version=version)
         file.save()
         # The transform don't know bout my new files.
-        version = Version.uncached.get(pk=81551)
+        version = Version.objects.no_cache().get(pk=81551)
         assert not version.is_allowed_upload()
 
     def test_version_is_not_allowed_upload_full(self):

--- a/apps/zadmin/tests/test_tasks.py
+++ b/apps/zadmin/tests/test_tasks.py
@@ -70,9 +70,9 @@ class TestLangpackFetcher(amo.tests.TestCase):
         self.addCleanup(request_patch.stop)
 
     def get_langpacks(self):
-        return (Addon.uncached
-                 .filter(addonuser__user__email=settings.LANGPACK_OWNER_EMAIL,
-                         type=amo.ADDON_LPAPP))
+        return (Addon.objects.no_cache()
+                .filter(addonuser__user__email=settings.LANGPACK_OWNER_EMAIL,
+                        type=amo.ADDON_LPAPP))
 
     def fetch_langpacks(self, version):
         path = settings.LANGPACK_PATH_DEFAULT % ('firefox', version)

--- a/apps/zadmin/tests/test_views.py
+++ b/apps/zadmin/tests/test_views.py
@@ -131,8 +131,8 @@ class TestFlagged(amo.tests.TestCase):
                                     follow=True)
         self.assertRedirects(response, self.url)
 
-        assert not Addon.uncached.get(id=1).admin_review
-        assert not Addon.uncached.get(id=2).admin_review
+        assert not Addon.objects.no_cache().get(id=1).admin_review
+        assert not Addon.objects.no_cache().get(id=2).admin_review
 
         addons = response.context['addons']
         eq_(len(addons), 1)

--- a/apps/zadmin/views.py
+++ b/apps/zadmin/views.py
@@ -61,8 +61,9 @@ def flagged(request):
     types = (amo.MARKETPLACE_TYPES if settings.MARKETPLACE
              else list(set(amo.ADDON_TYPES.keys()) -
                        set(amo.MARKETPLACE_TYPES)))
-    addons = (Addon.uncached.filter(admin_review=True, type__in=types)
-                            .no_transforms().order_by('-created'))
+    addons = (Addon.objects.no_cache()
+                           .filter(admin_review=True, type__in=types)
+                           .no_transforms().order_by('-created'))
 
     if request.method == 'POST':
         ids = map(int, request.POST.getlist('addon_id'))
@@ -113,7 +114,7 @@ def langpacks(request):
 
         return redirect('zadmin.langpacks')
 
-    addons = (Addon.uncached
+    addons = (Addon.objects.no_cache()
                    .filter(addonuser__user__email=settings.LANGPACK_OWNER_EMAIL,
                            type=amo.ADDON_LPAPP)
                    .order_by('name'))

--- a/lib/es/management/commands/reindex_mkt.py
+++ b/lib/es/management/commands/reindex_mkt.py
@@ -90,7 +90,8 @@ def index_webapp(ids, **kw):
     index = kw.pop('index', None) or ALIAS
     sys.stdout.write('Indexing %s apps' % len(ids))
 
-    qs = Webapp.indexing_transformer(Webapp.uncached.filter(id__in=ids))
+    qs = Webapp.indexing_transformer(Webapp.objects.no_cache()
+                                                   .filter(id__in=ids))
 
     docs = []
     for obj in qs:

--- a/lib/es/utils.py
+++ b/lib/es/utils.py
@@ -25,7 +25,7 @@ def index_objects(ids, model, search, index=None, transforms=None):
     if transforms is None:
         transforms = []
 
-    qs = model.uncached.filter(id__in=ids)
+    qs = model.objects.no_cache().filter(id__in=ids)
     for t in transforms:
         qs = qs.transform(t)
 

--- a/migrations/566-add-tiers.py
+++ b/migrations/566-add-tiers.py
@@ -9,7 +9,7 @@ from market.models import Price
 def run():
     print 'Adding in new tiers'
     for tier in ['0.10', '0.25', '0.50', '12.49']:
-        exists = Price.uncached.filter(price=Decimal(tier)).exists()
+        exists = Price.objects.no_cache().filter(price=Decimal(tier)).exists()
         if exists:
             print 'Tier already exists, skipping: %s' % tier
             continue

--- a/migrations/568-rename-tiers.py
+++ b/migrations/568-rename-tiers.py
@@ -6,7 +6,7 @@ from market.models import Price
 @transaction.commit_on_success
 def run():
     print 'Renaming tiers'
-    for k, tier in enumerate(Price.uncached.filter(active=True)
+    for k, tier in enumerate(Price.objects.no_cache().filter(active=True)
                                   .order_by('price')):
         new = 'Tier %s' % k
         print 'Renaming %s to %s' % (tier.name, new)

--- a/migrations/607-reboot-price-currencies.py
+++ b/migrations/607-reboot-price-currencies.py
@@ -270,7 +270,7 @@ class FrozenPriceCurrency(amo.models.ModelBase):
 
 
 def run():
-    FrozenPriceCurrency.uncached.all().delete()
+    FrozenPriceCurrency.objects.no_cache().all().delete()
     for k in sorted(tiers.keys()):
         v = tiers[k]
         try:

--- a/mkt/account/api.py
+++ b/mkt/account/api.py
@@ -100,8 +100,9 @@ class InstalledResource(AppResource):
         slug_lookup = None
 
     def obj_get_list(self, request=None, **kwargs):
-        return Webapp.uncached.filter(installed__user=request.amo_user,
-                                     installed__install_type=INSTALL_TYPE_USER)
+        return Webapp.objects.no_cache().filter(
+            installed__user=request.amo_user,
+            installed__install_type=INSTALL_TYPE_USER)
 
 
 class LoginResource(CORSResource, MarketplaceResource):

--- a/mkt/developers/api_payments.py
+++ b/mkt/developers/api_payments.py
@@ -141,7 +141,8 @@ class PaymentAccountViewSet(CreateModelMixin, RetrieveModelMixin,
             raise PermissionDenied('Not allowed to alter that object.')
 
         if self.request.method != 'POST':
-            if not obj.addon == obj.__class__.uncached.get(pk=obj.pk).addon:
+            addon = obj.__class__.objects.no_cache().get(pk=obj.pk).addon
+            if not obj.addon == addon:
                 # This should be a 400 error.
                 raise PermissionDenied('Cannot change the add-on.')
 

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -534,7 +534,7 @@ def standalone_hosted_upload(request):
 @json_view
 @anonymous_csrf_exempt
 def standalone_upload_detail(request, type_, uuid):
-    upload = get_object_or_404(FileUpload.uncached, uuid=uuid)
+    upload = get_object_or_404(FileUpload, uuid=uuid)
     url = reverse('mkt.developers.standalone_upload_detail',
                   args=[type_, uuid])
     return upload_validation_context(request, upload, url=url)
@@ -543,7 +543,7 @@ def standalone_upload_detail(request, type_, uuid):
 @dev_required
 @json_view
 def upload_detail_for_addon(request, addon_id, addon, uuid):
-    upload = get_object_or_404(FileUpload.uncached, uuid=uuid)
+    upload = get_object_or_404(FileUpload, uuid=uuid)
     return json_upload_detail(request, upload, addon=addon)
 
 
@@ -639,7 +639,7 @@ def upload_validation_context(request, upload, addon=None, url=None):
 
 
 def upload_detail(request, uuid, format='html'):
-    upload = get_object_or_404(FileUpload.uncached, uuid=uuid)
+    upload = get_object_or_404(FileUpload, uuid=uuid)
 
     if format == 'json' or request.is_ajax():
         return json_upload_detail(request, upload)

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -249,7 +249,7 @@ def payments_accounts_delete(request, id):
 @login_required
 @waffle_switch('in-app-sandbox')
 def in_app_keys(request):
-    keys = (UserInappKey.uncached
+    keys = (UserInappKey.objects.no_cache()
             .filter(solitude_seller__user=request.amo_user))
     # TODO(Kumar) support multiple test keys. For now there's only one.
     if keys.count():
@@ -273,7 +273,7 @@ def in_app_keys(request):
 @login_required
 @waffle_switch('in-app-sandbox')
 def in_app_key_secret(request, pk):
-    key = (UserInappKey.uncached
+    key = (UserInappKey.objects.no_cache()
            .filter(solitude_seller__user=request.amo_user, pk=pk))
     if not key.count():
         # Either the record does not exist or it's not owned by the

--- a/mkt/inapp_pay/management/commands/rotate_inapp_key.py
+++ b/mkt/inapp_pay/management/commands/rotate_inapp_key.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         num = 0
         print 'migrating keys...'
         with transaction.commit_on_success():
-            for cfg in (InappConfig.uncached
+            for cfg in (InappConfig.objects.no_cache()
                                    .exclude(_encrypted_private_key=None)):
                 InappConfig.objects.invalidate(cfg)
                 num += 1

--- a/mkt/inapp_pay/tests/test_commands.py
+++ b/mkt/inapp_pay/tests/test_commands.py
@@ -36,7 +36,7 @@ class TestCommand(amo.tests.TestCase):
             cfg = create_inapp_config()
             old_key = cfg.get_private_key()
             old_raw_key = cfg._encrypted_private_key
-            cfg = InappConfig.uncached.get(pk=cfg.pk)
+            cfg = InappConfig.objects.no_cache().get(pk=cfg.pk)
             eq_(cfg.key_timestamp, '2012-05-10')
 
         with mock.patch.object(settings, 'INAPP_KEY_PATHS',
@@ -44,7 +44,7 @@ class TestCommand(amo.tests.TestCase):
                  '2012-05-11': resource('inapp-sample-pay-alt.key')}):
             Command().handle(old_timestamp='2012-05-10',
                              new_timestamp='2012-05-11')
-            cfg = InappConfig.uncached.get(pk=cfg.pk)
+            cfg = InappConfig.objects.no_cache().get(pk=cfg.pk)
             eq_(cfg.get_private_key(), old_key)
             new_raw_key = cfg._encrypted_private_key
             assert new_raw_key != old_raw_key, ('raw keys were changed')

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -1039,7 +1039,7 @@ class TestReviewTransaction(AttachmentManagementMixin,
                        'webapp_337141')
 
     def get_app(self):
-        return Webapp.uncached.get(id=337141)
+        return Webapp.objects.no_cache().get(id=337141)
 
     @mock.patch('mkt.webapps.models.Webapp.get_manifest_json')
     @mock.patch('lib.crypto.packaged.sign_app')
@@ -2573,7 +2573,7 @@ class TestQueueSearchSort(AppReviewerTest):
         """
         Test that apps are sorted in order specified in GET params
         """
-        qs = Webapp.uncached.all()
+        qs = Webapp.objects.no_cache().all()
 
         # Test apps are sorted by created/asc by default.
         r = self.rf.get(self.url, {'sort': 'invalidsort', 'order': 'dontcare'})

--- a/mkt/reviewers/views_themes.py
+++ b/mkt/reviewers/views_themes.py
@@ -123,7 +123,7 @@ def _get_themes(request, reviewer, flagged=False, rereview=False):
         num, themes, locks = _get_rereview_themes(reviewer)
     else:
         # Pending and flagged themes.
-        locks = ThemeLock.uncached.filter(
+        locks = ThemeLock.objects.no_cache().filter(
             reviewer=reviewer, theme__addon__status=status)
         num, themes = _calc_num_themes_checkout(locks)
         if themes:

--- a/mkt/submit/api.py
+++ b/mkt/submit/api.py
@@ -65,7 +65,7 @@ class ValidationResource(CORSResource, MarketplaceModelResource):
 
         # This is a reget of the object, we do this to get the refreshed
         # results if not celery delayed.
-        bundle.obj = FileUpload.uncached.get(pk=upload.pk)
+        bundle.obj = FileUpload.objects.get(pk=upload.pk)
         log.info('Validation created: %s' % bundle.obj.pk)
         return bundle
 

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -171,11 +171,11 @@ class Webapp(Addon):
             return []
 
         ids = set(app.id for app in apps)
-        versions = (Version.uncached.filter(addon__in=ids)
+        versions = (Version.objects.no_cache().filter(addon__in=ids)
                                     .select_related('addon'))
         vids = [v.id for v in versions]
-        files = (File.uncached.filter(version__in=vids)
-                              .select_related('version'))
+        files = (File.objects.no_cache().filter(version__in=vids)
+                             .select_related('version'))
 
         # Attach the files to the versions.
         f_dict = dict((k, list(vs)) for k, vs in
@@ -1165,7 +1165,7 @@ class WebappIndexer(MappingType, Indexable):
     def extract_document(cls, pk, obj=None):
         """Extracts the ElasticSearch index document for this instance."""
         if obj is None:
-            obj = cls.get_model().uncached.get(pk=pk)
+            obj = cls.get_model().objects.no_cache().get(pk=pk)
 
         latest_version = obj.latest_version
         version = obj.current_version

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -126,7 +126,7 @@ def _update_manifest(id, check_hash, failed_fetches):
     upload.add_file([content], webapp.manifest_url, len(content),
                     is_webapp=True)
     validator(upload.pk)
-    upload = FileUpload.uncached.get(pk=upload.pk)
+    upload = FileUpload.objects.get(pk=upload.pk)
     if upload.validation:
         v8n = json.loads(upload.validation)
         if v8n['errors']:
@@ -261,7 +261,8 @@ def index_webapps(ids, **kw):
     indices = get_indices(index)
 
     es = WebappIndexer.get_es(urls=settings.ES_URLS)
-    qs = Webapp.indexing_transformer(Webapp.uncached.filter(id__in=ids))
+    qs = Webapp.indexing_transformer(Webapp.objects.no_cache().filter(
+        id__in=ids))
     for obj in qs:
         doc = WebappIndexer.extract_document(obj.id, obj)
         for idx in indices:

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -1238,7 +1238,7 @@ class TestWebappIndexer(amo.tests.TestCase):
 
     def _get_doc(self):
         qs = Webapp.indexing_transformer(
-            Webapp.uncached.filter(id__in=[self.app.pk]))
+            Webapp.objects.no_cache().filter(id__in=[self.app.pk]))
         obj = qs[0]
         return obj, WebappIndexer.extract_document(obj.pk, obj)
 

--- a/mkt/zadmin/management/commands/collapse_versions.py
+++ b/mkt/zadmin/management/commands/collapse_versions.py
@@ -21,7 +21,7 @@ def do_collapsing():
     vkey = unicode(Version._meta)
     fkey = 'files'
 
-    for app in (Webapp.uncached.filter(type=amo.ADDON_WEBAPP,
+    for app in (Webapp.objects.no_cache().filter(type=amo.ADDON_WEBAPP,
                                        is_packaged=False)
                                .exclude(status=amo.STATUS_DELETED)
                                .no_transforms()):

--- a/mkt/zadmin/models.py
+++ b/mkt/zadmin/models.py
@@ -15,7 +15,7 @@ import mkt.regions
 from mkt.carriers import get_carrier, get_carrier_id
 
 
-class FeaturedAppQuerySet(models.query.QuerySet):
+class FeaturedAppQuerySet(amo.models.CachingQuerySet):
     """
     Custom QuerySet that encapsulates common filtering logic used when
     querying QuerySets of FeaturedApp instances.

--- a/mkt/zadmin/views.py
+++ b/mkt/zadmin/views.py
@@ -45,7 +45,7 @@ def featured_apps_ajax(request):
         cat_slug = request.POST.get('category')
         deleteid = request.POST.get('delete')
         if deleteid:
-            delete_apps = FeaturedApp.uncached.filter(
+            delete_apps = FeaturedApp.objects.no_cache().filter(
                 app__id=int(deleteid))
             if not cat_slug:
                 delete_apps = delete_apps.filter(category__isnull=True)
@@ -62,7 +62,7 @@ def featured_apps_ajax(request):
                 except (Category.DoesNotExist,
                         Category.MultipleObjectsReturned):
                     pass
-            app, created = FeaturedApp.uncached.get_or_create(
+            app, created = FeaturedApp.objects.no_cache().get_or_create(
                 category=category, app_id=int(appid))
             if created:
                 FeaturedAppRegion.objects.create(
@@ -100,7 +100,7 @@ def set_attrs_ajax(request):
     app = request.POST.get('app', None)
     if not app:
         return HttpResponse()
-    fa = FeaturedApp.uncached.get(pk=app)
+    fa = FeaturedApp.objects.no_cache().get(pk=app)
     if regions or carriers:
         regions = set(int(r) for r in regions)
         fa.regions.exclude(region__in=regions).delete()
@@ -135,11 +135,13 @@ def set_attrs_ajax(request):
 def featured_categories_ajax(request):
     cats = Category.objects.filter(type=amo.ADDON_WEBAPP)
     return jingo.render(request, 'zadmin/featured_categories_ajax.html', {
-        'homecount': FeaturedApp.uncached.filter(category=None).count(),
+        'homecount': FeaturedApp.objects.no_cache().filter(
+            category=None).count(),
         'categories': [{
             'name': cat.name,
             'id': cat.slug,
-            'count': FeaturedApp.uncached.filter(category=cat).count()
+            'count': FeaturedApp.objects.no_cache().filter(
+                category=cat).count()
         } for cat in cats]})
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=913010
https://bugzilla.mozilla.org/show_bug.cgi?id=912178

This completely removes the `uncached` generic manager and replaces it with calling `.objects.no_cache()`. This fixes at least 2 weird issues we've been having: non-webapps being returned and deleted stuff being returned when calling `Webapp.uncached`.

I probably could have kept `uncached` for the other models, but we don't really need to have multiple ways to do the same thing, and it's really annoying to make it work properly when you throw inheritance and soft deletion into the mix anyway. 
