### PR TITLE
When checking for collection uniqueness, exclude current instance (bug 9914874)

### DIFF
--- a/mkt/collections/serializers.py
+++ b/mkt/collections/serializers.py
@@ -173,11 +173,15 @@ class CollectionSerializer(serializers.ModelSerializer):
         # best place to do it.
         unique_collections_types = (COLLECTIONS_TYPE_FEATURED,
                                     COLLECTIONS_TYPE_OPERATOR)
+        qs = Collection.objects.filter(
+            collection_type=instance.collection_type,
+            category=instance.category,
+            region=instance.region,
+            carrier=instance.carrier)
+        if instance.pk:
+            qs = qs.exclude(pk=instance.pk)
         if (instance.collection_type in unique_collections_types and
-            Collection.objects.filter(collection_type=instance.collection_type,
-                                      category=instance.category,
-                                      region=instance.region,
-                                      carrier=instance.carrier).exists()):
+            qs.exists()):
             self._errors['collection_uniqueness'] = _(
                 u'You can not have more than one Featured Apps/Operator Shelf '
                 u'collection for the same category/carrier/region combination.'

--- a/mkt/collections/tests/test_views.py
+++ b/mkt/collections/tests/test_views.py
@@ -956,6 +956,12 @@ class TestCollectionViewSetUnique(TestCollectionViewSetMixin, RestOAuth):
         res, data = self.edit_collection(self.client, **update_data)
         eq_(res.status_code, 200)
 
+        # A dumb change to see if you can still edit afterwards. The uniqueness
+        # check should exclude the current instance and allow it, obviously.
+        update_data = {'is_public': False}
+        res, data = self.edit_collection(self.client, **update_data)
+        eq_(res.status_code, 200)
+
     def test_edit_collection_operator_shelf_duplicate(self):
         """
         Featured Apps & Operator Shelf should not have duplicates for a
@@ -977,6 +983,12 @@ class TestCollectionViewSetUnique(TestCollectionViewSetMixin, RestOAuth):
         nyan = Category.objects.create(type=amo.ADDON_WEBAPP, name='Nyan Cat',
                                       slug='nyan-cat')
         update_data['category'] = nyan.pk
+        res, data = self.edit_collection(self.client, **update_data)
+        eq_(res.status_code, 200)
+
+        # A dumb change to see if you can still edit afterwards. The uniqueness
+        # check should exclude the current instance and allow it, obviously.
+        update_data = {'is_public': False}
         res, data = self.edit_collection(self.client, **update_data)
         eq_(res.status_code, 200)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=914874

Otherwise, we simply can't edit an existing operator shelf / featured apps
collection...
