### PR TITLE
Notify app developers when their manifest is broken (bug 850830)

### DIFF
--- a/mkt/developers/templates/developers/validation.html
+++ b/mkt/developers/templates/developers/validation.html
@@ -11,7 +11,7 @@
 {% block content %}
 <header>
   {{ hub_breadcrumbs(addon, items=[(None, title)]) }}
-  <h1>{{ title|truncate(40) }}</h1>
+  <h1>{{ title }}</h1>
 </header>
 
 <div class="results-intro">

--- a/mkt/webapps/templates/webapps/emails/update_manifest_failure.txt
+++ b/mkt/webapps/templates/webapps/emails/update_manifest_failure.txt
@@ -1,0 +1,15 @@
+The manifest for your app, {{ app.name }}, is experiencing an issue.
+
+Manifest URL: {{ app.manifest_url }}
+
+{{ error_message }}
+
+{% if has_link %}Specific details can be found at the validation result URL above. {% endif %}You should check that your app manifest is still online, is served with a Content-Type header of application/x-web-app-manifest+json, and has valid JSON syntax. In case you need it, here’s the documentation for manifests: https://developer.mozilla.org/en-US/docs/Apps/Manifest
+
+This is an automated email and you don't need to contact us to let us know the problem has been resolved. If this issue persists, a reviewer will then manually check your app and contact you with a list of specific issues. We’ll temporarily remove your app from Marketplace if it doesn’t install.
+
+If you have a question please don’t hesitate to reach us at {{ MKT_SUPPORT_EMAIL }} or join #app-reviewers on irc.mozilla.org. For development help, you can ask the good folks at dev-webapps@lists.mozilla.org.
+
+--
+Firefox Marketplace
+{{ SITE_URL }}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=850830
- There are now 4 manifest fetch attempts (the task is ran once every day)
- Developer is now notified on 3rd fetch attempt that there is a problem (*)
- App enters re-review on the 4th attempt, which is the last
- If fetch was successful, developer is notified if there was a validation error (*)

(*) Unless its app is no longer public or already in the re-review queue.
