### PR TITLE
refactor and fix queue sorting for name fields and pending queue (bug 890177)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -681,9 +681,13 @@ def collection_factory(**kw):
     return c
 
 
-def req_factory_factory(url, user=None):
+def req_factory_factory(url, user=None, post=False, data=None):
     """Creates a request factory, logged in with the user."""
-    req = RequestFactory().get(url)
+    req = RequestFactory()
+    if post:
+        req = req.post(url, data or {})
+    else:
+        req = req.get(url, data or {})
     if user:
         req.amo_user = user
         req.user = user.user

--- a/mkt/reviewers/templates/reviewers/queue.html
+++ b/mkt/reviewers/templates/reviewers/queue.html
@@ -31,7 +31,7 @@
               <th>&nbsp;</th>
               <th>{{ sort_link(_('App'), 'name')|safe }}</th>
               <th>{{ _('Flags') }}</th>
-              <th class="waiting-time">{{ sort_link(_('Waiting Time'), 'created')|safe }}</th>
+              <th class="waiting-time">{{ sort_link(_('Waiting Time'), date_sort or 'created')|safe }}</th>
               <th>{{ _('Devices') }}</th>
               {% if DESKTOP %}
                 <th class="payments">{{ _('Payments') }}</th>

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -517,16 +517,16 @@ class ReviewHelper(object):
         return self.actions[action]['method']()
 
 
-def clean_sort_param(request, date_field='created'):
+def clean_sort_param(request, date_sort='created'):
     """
     Handles empty and invalid values for sort and sort order
     'created' by ascending is the default ordering.
     """
-    sort = request.GET.get('sort', date_field)
+    sort = request.GET.get('sort', date_sort)
     order = request.GET.get('order', 'asc')
 
-    if sort not in ('name', date_field, 'num_abuse_reports'):
-        sort = date_field
+    if sort not in ('name', 'created', 'nomination', 'num_abuse_reports'):
+        sort = date_sort
     if order not in ('desc', 'asc'):
         order = 'asc'
     return sort, order


### PR DESCRIPTION
**The regression:**

The pending apps review queue was switched over to use a Version queryset over a Webapp queryset. 

Pending apps queue sorted as `nomination` but displayed as `created`.

**The fix:**

Use `order_by_translation` on a `values_list('addon')` from the Version queryset.

**The refactor:**
- Create two separate sort functions, one for Webapps and one for non-Webapps.
- Have one sort function that determines which separate sort function to call based on the queryset model.
- Remove the `_queue_to_apps` function and integrate it into the sort non-Webapp sort function.

**The tests:**

Already existed but slightly changed to accommodate the refactor. 

**The struggle:**
- Going 'bout it the wrong way, at first trying to manually use a double left join from Version to Translation field of the model. 
- Then later saw I was converting the queryset from non-Webapps to Webapps back to Webapps.
- Hours wasted on running into a [django ORM bug](https://github.com/django/django/commit/2f35c6f10fcbae541691207fb0c0560a13b754fc)
