### PR TITLE
show time and IP address of last login for AMO users (bug 690284)

### DIFF
--- a/apps/users/helpers.py
+++ b/apps/users/helpers.py
@@ -73,8 +73,14 @@ def _user_link(user):
 
 
 @register.filter
-def user_vcard(user, table_class='person-info', is_profile=False):
-    c = {'profile': user, 'table_class': table_class, 'is_profile': is_profile}
+@jinja2.contextfilter
+def user_vcard(context, user, table_class='person-info', is_profile=False):
+    c = dict(context.items())
+    c.update({
+        'profile': user,
+        'table_class': table_class,
+        'is_profile': is_profile
+    })
     t = env.get_template('users/vcard.html').render(**c)
     return jinja2.Markup(t)
 

--- a/apps/users/templates/users/vcard.html
+++ b/apps/users/templates/users/vcard.html
@@ -34,6 +34,20 @@
       <th>{{ _('User since') }}</th>
       <td>{{ profile.created|datetime }}</td>
     </tr>
+    {% if own_profile or edit_any_user %}
+      {% if profile.user.last_login %}
+        <tr>
+          <th>{{ _('Time of last login') }}</th>
+          <td>{{ profile.user.last_login|babel_datetime }}</td>
+        </tr>
+      {% endif %}
+      {% if profile.last_login_ip %}
+        <tr>
+          <th>{{ _('IP address of last login') }}</th>
+          <td>{{ profile.last_login_ip }}</td>
+        </tr>
+      {% endif %}
+    {% endif %}
     <tr>
       <th>
         {{ _('Number of add-ons developed') }}


### PR DESCRIPTION
# if I'm logged in and looking at my profile (or if I'm an admin)

![](http://cl.ly/image/373q2Z2q240P/Screen%20Shot%202013-09-12%20at%203.32.22%20PM.png)
# if I'm not logged in or I'm looking at someone else's profile

![](http://cl.ly/image/2e2J002m230U/Screen%20Shot%202013-09-12%20at%203.31.35%20PM.png)
