### PR TITLE
change theme saving tasks to the images celery queue (bug 883272)

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1073,6 +1073,8 @@ CELERY_ROUTES = {
     'lib.video.tasks.resize_video': {'queue': 'devhub'},
 
     # Images.
+    'addons.tasks.save_theme': {'queue': 'images'},
+    'addons.tasks.save_theme_reupload': {'queue': 'images'},
     'bandwagon.tasks.resize_icon': {'queue': 'images'},
     'users.tasks.resize_photo': {'queue': 'images'},
     'users.tasks.delete_photo': {'queue': 'images'},


### PR DESCRIPTION
Often we get blank images in the theme review queues. This is due to the Theme image saving tasks being backed up for various reasons. They are forced to wait in line for the Celery queue to clear.

Let's try moving these image saving tasks over to the, presumably, less trafficked `images` Celery queue. 

r? for whether this is an appropriate action.
