### PR TITLE
Avoid calling MakePremiumPerAccess twice (bug 890044)

### DIFF
--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -507,6 +507,7 @@ class TestPayments(amo.tests.TestCase):
                                          'accounts': acct.pk,
                                          'regions': self.price_regions}),
                                          follow=True)
+        eq_(api.bango.premium.post.call_count, 1)
         self.assertNoFormErrors(res)
         eq_(res.status_code, 200)
         eq_(self.webapp.app_payment_account.payment_account.pk, acct.pk)

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -102,23 +102,6 @@ def payments(request, addon_id, addon, webapp=False):
                     success = False
                     raise  # We want to see all the solitude errors now.
 
-            # Test again in case a call to Solitude failed.
-            if is_now_paid and success and not is_free_inapp:
-                # Update the product's price if we need to.
-                try:
-                    apa = AddonPaymentAccount.objects.get(addon=addon)
-                    apa.update_price(addon.addonpremium.price.price)
-                except AddonPaymentAccount.DoesNotExist:
-                    pass
-                except client.Error:
-                    log.error('Error updating AddonPaymentAccount (%s) price' %
-                                  apa.pk)
-                    messages.error(
-                        request, _(u'We encountered a problem while updating '
-                                   u'the payment server.'))
-                    success = False
-                    raise  # We want to see all the solitude errors now.
-
         # If everything happened successfully, give the user a pat on the back.
         if success:
             messages.success(request, _('Changes successfully saved.'))


### PR DESCRIPTION
As weird as it seems, removing that whole part solves the issue because
the price is already updated during the creation process just above
during the `bango_account_list_form.save()` call.
