### PR TITLE
Migrate free apps without world AER (bug 916853)

### DIFF
--- a/mkt/developers/management/commands/migrate_free_apps_without_worldwide_aer.py
+++ b/mkt/developers/management/commands/migrate_free_apps_without_worldwide_aer.py
@@ -1,0 +1,28 @@
+import logging
+
+from django.core.management.base import NoArgsCommand
+
+import amo
+from mkt.constants.regions import WORLDWIDE
+
+log = logging.getLogger('z.task')
+
+
+class Command(NoArgsCommand):
+    help = 'Migrate free apps without a world AER to enable_new_regions=True.'
+
+    def handle_noargs(self, *args, **options):
+        # Avoid import error.
+        from mkt.webapps.models import AddonExcludedRegion as AER, Webapp
+
+        # First exclude apps that have opted out of enabling new regions.
+        excludes = (AER.objects.filter(region=WORLDWIDE.id)
+                               .values_list('addon', flat=True))
+
+        qs = (Webapp.objects.filter(premium_type=amo.ADDON_FREE)
+                            .exclude(id__in=excludes))
+        # Now update the relevant apps.
+        for app in qs.iterator():
+            log.info('[App %s] Updated to have '
+                     'enable_new_regions=True' % app.pk)
+            app.update(enable_new_regions=True)

--- a/mkt/developers/tests/test_commands.py
+++ b/mkt/developers/tests/test_commands.py
@@ -4,8 +4,13 @@ from nose.tools import eq_
 import amo
 import amo.tests
 from addons.models import Addon, AddonPremium
-from mkt.developers.management.commands import cleanup_addon_premium
+from mkt.constants.regions import WORLDWIDE
+from mkt.developers.management.commands import (
+    cleanup_addon_premium,
+    migrate_free_apps_without_worldwide_aer
+)
 from mkt.site.fixtures import fixture
+from mkt.webapps.models import AddonExcludedRegion as AER, Webapp
 
 
 class TestCommandViews(amo.tests.TestCase):
@@ -25,3 +30,41 @@ class TestCommandViews(amo.tests.TestCase):
         self.webapp.update(premium_type=amo.ADDON_FREE)
         cleanup_addon_premium.Command().handle()
         eq_(AddonPremium.objects.all().count(), 0)
+
+
+class TestMigrateFreeAppsWithoutWorldAER(amo.tests.TestCase):
+    fixtures = fixture('webapp_337141')
+
+    def setUp(self):
+        self.webapp = Webapp.objects.get(pk=337141)
+
+    def test_migration_of_free_apps_without_world_aer(self):
+        eq_(self.webapp.enable_new_regions, False)
+        eq_(self.webapp.addonexcludedregion.filter(
+            region=WORLDWIDE.id).count(), 0)
+        migrate_free_apps_without_worldwide_aer.Command().handle()
+        eq_(Webapp.objects.no_cache().get(pk=337141).enable_new_regions, True)
+
+    def test_no_migration_of_free_apps_without_world_aer_paid_app(self):
+        """Paid app users already have the ability to set enable_new_regions
+        so we don't want to clobber that.
+
+        """
+        self.webapp.update(premium_type=amo.ADDON_PREMIUM)
+        eq_(self.webapp.enable_new_regions, False)
+        eq_(self.webapp.addonexcludedregion.filter(
+            region=WORLDWIDE.id).count(), 0)
+        migrate_free_apps_without_worldwide_aer.Command().handle()
+        eq_(Webapp.objects.no_cache().get(pk=337141).enable_new_regions, False)
+
+    def test_no_migration_of_free_apps_with_world_aer(self):
+        eq_(self.webapp.enable_new_regions, False)
+        AER.objects.create(addon=self.webapp, region=WORLDWIDE.id)
+        migrate_free_apps_without_worldwide_aer.Command().handle()
+        eq_(Webapp.objects.no_cache().get(pk=337141).enable_new_regions, False)
+
+    def test_no_migration_of_free_apps_with_world_aer_already_enabled(self):
+        self.webapp.update(enable_new_regions=True)
+        AER.objects.create(addon=self.webapp, region=WORLDWIDE.id)
+        migrate_free_apps_without_worldwide_aer.Command().handle()
+        eq_(Webapp.objects.no_cache().get(pk=337141).enable_new_regions, True)


### PR DESCRIPTION
Adds a management command to migrate free apps without a worldwide AddonExcludedRegion (AER) record to have enable_new_regions=True (bug 916853)
