### PR TITLE
optimize nullbooleanfields for mobile (bug 917439)

### DIFF
--- a/mkt/reviewers/forms.py
+++ b/mkt/reviewers/forms.py
@@ -267,16 +267,27 @@ class ApiReviewersSearchForm(ApiSearchForm):
                                label=_lazy(u'Status'))
     has_editor_comment = forms.NullBooleanField(
         required=False,
-        label=_lazy(u'Contains Editor Comment'),
+        label=_lazy(u'Has Editor Comment'),
         widget=CustomNullBooleanSelect)
     has_info_request = forms.NullBooleanField(
         required=False,
-        label=_lazy(u'More Information Requested'),
+        label=_lazy(u'More Info Requested'),
         widget=CustomNullBooleanSelect)
     is_escalated = forms.NullBooleanField(
         required=False,
         label=_lazy(u'Escalated'),
         widget=CustomNullBooleanSelect)
+
+    def __init__(self, *args, **kwargs):
+        super(ApiReviewersSearchForm, self).__init__(*args, **kwargs)
+
+        # Mobile form, to render, expects choices from the Django field.
+        BOOL_CHOICES = ((u'', _lazy('Unknown')),
+                        (u'true', _lazy('Yes')),
+                        (u'false', _lazy('No')))
+        for field_name, field in self.fields.iteritems():
+            if isinstance(field, forms.NullBooleanField):
+                self.fields[field_name].choices = BOOL_CHOICES
 
     def clean_status(self):
         status = self.cleaned_data['status']

--- a/mkt/reviewers/templates/reviewers/includes/queue_search_mobile.html
+++ b/mkt/reviewers/templates/reviewers/includes/queue_search_mobile.html
@@ -15,9 +15,9 @@
       </span>
 
       <div class="advanced-search c hidden">
-        <!--Switch/single-checkbox fields-->
-        {# TODO: add back admin_review ? #}
-        {% for elem in ('has_editor_comment', 'has_info_request', 'is_escalated') %}
+        <!-- Switch/single-checkbox fields. -->
+        {# Commented because we may need plain Boolean fields for future search filters. #}
+        {# for elem in (FIELD_NAMES) %}
           <div class="form-elem c">
             {{ search_form[elem].label_tag() }}
             <label>
@@ -26,11 +26,13 @@
             </label>
           </div>
           {{ search_form[elem].errors }}
-        {% endfor %}
+        {% endfor #}
 
-        <!--Value selector fields.-->
-        {% for field in ('status', 'app_type', 'device', 'premium_types') %}
-          <!--Differentiate radio and checkbox form elements.-->
+        <!-- Value selector fields. -->
+        {% for field in ('has_editor_comment', 'has_info_request',
+                         'is_escalated', 'status', 'app_type', 'device',
+                         'premium_types') %}
+          <!-- Differentiate radio and checkbox form elements. -->
           {% set multi = field in ('premium_types',) %}
 
           <!-- Pretty and visible representation of form. -->


### PR DESCRIPTION
NullBooleanFields don't have `choices` attached to them which the mobile search template expects, so I just added from the Django form. The template loops over the `choices` of the Django form fields to manually populate a specially-styled dropdown menu. The before is ugly because, in the template, it was set to render as is. I moved it to render with the special styles.

[Here](https://github.com/ngokevin/zamboni/blob/cf795484885ee308d97968a7ed261be52ecf9878/mkt/reviewers/templates/reviewers/includes/queue_search_mobile.html#L53) is where it expects `choices`

[Here](https://github.com/mozilla/zamboni/pull/1149/files#L0R287) is where I added `choices` to the `NullBooleanFields`

**BEFORE**

![screen shot 2013-09-17 at 11 48 19 am](https://f.cloud.github.com/assets/674727/1159633/c0abf99e-1fc9-11e3-9bc9-cb8d13b9345a.png)

**AFTER**

![screen shot 2013-09-17 at 11 47 48 am](https://f.cloud.github.com/assets/674727/1159635/c1e58e60-1fc9-11e3-9faf-bc3448664962.png)
