### PR TITLE
add delete user functionality to lookup tool (bug 901783)

### DIFF
--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -640,6 +640,12 @@ class CHANGE_VERSION_STATUS(_LOG):
     format = _(u'{version} status changed to {0}.')
     keep = True
 
+class DELETE_USER_LOOKUP(_LOG):
+    id = 125
+    # L10n: {0} is the status
+    format = _(u'User {0.name} {0.id} deleted via lookup tool.')
+    keep = True
+
 
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]

--- a/media/css/devreg/lookup-tool.styl
+++ b/media/css/devreg/lookup-tool.styl
@@ -180,7 +180,7 @@ h1 {
         }
     }
 }
-#developer-info {
+#developer-info, #delete-user {
     float: right;
     width: 668px;
 }
@@ -370,6 +370,33 @@ dd {
         &:after {
             color: #aaa;
             content: "\00a0\00a0•\00a0";
+        }
+    }
+}
+
+#delete-user {
+    button.open-delete-modal {
+        margin-top: 13px;
+    }
+    p.error {
+        margin-bottom: 13px;
+    }
+}
+
+.modal {
+    bottom: 0;
+    display: none;
+    left: 0;
+    height: 195px;
+    margin: auto;
+    position: fixed;
+    right: 0;
+    top: 0;
+
+    .listing-footer {
+        button, .button {
+            float: right;
+            margin-left: 5px;
         }
     }
 }

--- a/media/js/mkt/lookup-tool.js
+++ b/media/js/mkt/lookup-tool.js
@@ -2,11 +2,20 @@ require(['prefetchManifest']);
 
 
 (function() {
+
+    // Delete user button.
+    $('#delete-user button').click(function() {
+        $('#delete-user .modal-delete').show().find('textarea').focus();
+    });
+    $('.modal .close').click(_pd(function() {
+        $(this).closest('.modal-delete').hide();
+    }));
+
+    // Search suggestions.
     $('#account-search').searchSuggestions($('#account-search-suggestions'),
                                            processResults);
     $('#app-search').searchSuggestions($('#app-search-suggestions'),
                                        processResults);
-
     function processResults(settings) {
         if (!(settings && settings.constructor === Object)) {
             return;

--- a/mkt/lookup/forms.py
+++ b/mkt/lookup/forms.py
@@ -21,3 +21,9 @@ class TransactionRefundForm(happyforms.Form):
         super(TransactionRefundForm, self).__init__(*args, **kw)
         if not settings.BANGO_FAKE_REFUNDS:
             del self.fields['fake']
+
+
+class DeleteUserForm(happyforms.Form):
+    delete_reason = forms.CharField(
+        label=_lazy(u'Reason for Deletion'),
+        widget=forms.Textarea(attrs={'rows': 2}))

--- a/mkt/lookup/templates/lookup/helpers/user_header.html
+++ b/mkt/lookup/templates/lookup/helpers/user_header.html
@@ -3,6 +3,9 @@
   <a href="{{ url('lookup.user_summary', account.id) }}"
      title="{{ _('Account Summary') }}">{{ account.display_name }}</a>
   ({{ account.pk }})
+  {% if account.deleted %}
+    <small class="error">({{ _('Account Deleted') }})</small>
+  {% endif %}
 </h1>
 
 <section id="avatar">

--- a/mkt/lookup/templates/lookup/user_summary.html
+++ b/mkt/lookup/templates/lookup/user_summary.html
@@ -10,6 +10,7 @@
     {{ user_header(account, _('Account Lookup results for'), is_admin) }}
 
     <section id="prose">
+      <h2>{{ _('General') }}</h2>
       <dl>
         <dt>{{ _('Display Name') }}</dt>
         <dd>{{ account.display_name }}</dd>
@@ -100,5 +101,42 @@
       </dl>
       {{ user_addons|impala_paginator }}
     </section>
+
+    <section id="delete-user">
+      <h2>{{ _('Delete User') }}</h2>
+      {% if not account.deleted %}
+        <p>
+          {% trans %}
+            Deleting this user will <strong>permanently</strong> delete this
+            user's account.
+          {% endtrans %}
+        </p>
+        <button class="open-delete-modal manage">{{ _('Delete User') }}</button>
+        <div class="modal modal-delete modal-hidden">
+          <form method="post" action="{{ url('lookup.user_delete', account.id) }}">
+            {{ csrf() }}
+            <h3>{{ _('Delete User') }}</h3>
+            <p class="warning">{{ _('Are you sure you wish to delete this user?') }}</p>
+            <p>{{ delete_form }}</p>
+            <p class="listing-footer c">
+              <button class="bad delete-button" type="submit">{{ _('Delete User') }}</button>
+              <a href="#" class="close cancel button">{{ _('Cancel') }}</a>
+            </p>
+          </form>
+          <a class="close">{{ _('Cancel') }}</a>
+        </div>
+      {% else %}
+        <p class="error">{{ _('This user has already been deleted.') }}</p>
+        <dl>
+          <dt>{{ _('Deleted by') }}</dt>
+          <dd>{{ emaillink(delete_log.user.email, delete_log.user.username) }}</dd>
+          {% if delete_log.details.reason %}
+            <dt>{{ _('Reason') }}</dt>
+            <dd>{{ delete_log.details.reason }}</dd>
+          {% endif %}
+        </dl>
+      {% endif %}
+    </section>
+
   </section>
 {% endblock %}

--- a/mkt/lookup/urls.py
+++ b/mkt/lookup/urls.py
@@ -9,6 +9,7 @@ user_patterns = patterns('',
     url(r'^purchases$', views.user_purchases,
         name='lookup.user_purchases'),
     url(r'^activity$', views.user_activity, name='lookup.user_activity'),
+    url(r'^delete$', views.user_delete, name='lookup.user_delete'),
 )
 
 


### PR DESCRIPTION
Delete sets a `UserProfile`'s `deleted` attribute and deletes the one-to-one `User` model.

Also this logs  appropriately using `ActivityLog`.

Can be done by anyone with `AccountLookup:View`

**Delete section**
![screen shot 2013-09-17 at 2 53 05 pm](https://f.cloud.github.com/assets/674727/1161028/a175b1e0-1fe3-11e3-926b-cd842259921c.png)

**Delete modal**
![screen shot 2013-09-17 at 2 53 20 pm](https://f.cloud.github.com/assets/674727/1161029/a2be160a-1fe3-11e3-96fc-c40bc8fca489.png)

**Post-delete section**
![screen shot 2013-09-17 at 2 53 29 pm](https://f.cloud.github.com/assets/674727/1161032/a493d956-1fe3-11e3-868f-0caa43971f37.png)
