### PR TITLE
Display portal links only if the flag is activated (bug 917698)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -25,6 +25,7 @@ import pyes.exceptions as pyes
 import test_utils
 from nose.exc import SkipTest
 from nose.tools import eq_, nottest, ok_
+from pyquery import PyQuery as pq
 from redisutils import mock_redis, reset_redis
 from tastypie.exceptions import ImmediateHttpResponse
 from test_utils import RequestFactory
@@ -506,6 +507,18 @@ class TestCase(RedisTest, test_utils.TestCase):
         eq_(Translation.objects.get(id=trans.id,
                                     locale=locale).localized_string,
             localized_string)
+
+    def extract_script_template(self, html, template_selector):
+        """Extracts the inner JavaScript text/template from a html page.
+
+        Example::
+
+            >>> template = extract_script_template(res.content, '#template-id')
+            >>> template('#my-jquery-selector')
+
+        Returns a PyQuery object that you can refine using jQuery selectors.
+        """
+        return pq(pq(html)(template_selector).html())
 
 
 class AMOPaths(object):

--- a/mkt/developers/templates/developers/payments/includes/account_list.html
+++ b/mkt/developers/templates/developers/payments/includes/account_list.html
@@ -12,7 +12,9 @@
           <th>{{ _('Account Name') }}</th>
           <th>{{ _('Modify') }}</th>
           <th>{{ _('Delete') }}</th>
-          <th>{{ _('Portal') }}</th>
+          {% if waffle.switch('bango-portal') %}
+            <th>{{ _('Portal') }}</th>
+          {% endif %}
         </tr>
 
         {# Payment accounts get added via JS here. #}
@@ -38,6 +40,8 @@
     <td>{name}</td>
     <td><a href="#" class="modify-account">{{ _('Modify') }}</a> <a href="#" class="accept-tos">{{ _('Accept Terms of Service') }}</a></td>
     <td><a href="#" class="delete-account">{{ _('Delete') }}</a></td>
-    <td><a href="#" class="portal-account">{{ _('Portal') }}</a></td>
+    {% if waffle.switch('bango-portal') %}
+      <td><a href="#" class="portal-account">{{ _('Portal') }}</a></td>
+    {% endif %}
   </tr>
 </script>

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -698,6 +698,18 @@ class TestPayments(amo.tests.TestCase):
         self.account = setup_payment_account(self.webapp, self.user)
         self.portal_url = self.webapp.get_dev_url('payments.bango_portal')
 
+    def test_bango_portal_links(self):
+        payments_url = self.webapp.get_dev_url('payments')
+        res = self.client.get(payments_url)
+        account_template = self.extract_script_template(
+                                res.content, '#account-row-template')
+        eq_(len(account_template('.portal-account')), 0)
+        self.create_switch('bango-portal', db=True)
+        res = self.client.get(payments_url)
+        account_template = self.extract_script_template(
+                                res.content, '#account-row-template')
+        eq_(len(account_template('.portal-account')), 1)
+
     @mock.patch('mkt.developers.views_payments.client.api')
     def test_bango_portal_redirect(self, api):
         self.setup_bango_portal()


### PR DESCRIPTION
I added a new method to amo.tests.TestCase: `extract_template`. Quite useful to test html within javascript text/templates.
