### PR TITLE
steal migration number, fix comm_thread_notes body field on stage (bug 917354)

### DIFF
--- a/migrations/667-comm-note-body.sql
+++ b/migrations/667-comm-note-body.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comm_thread_notes MODIFY COLUMN body text;


### PR DESCRIPTION
`body` on stage has column type `int (11) unsigned` when it should be a `text` field.

It is a `longtext` field on dev and prod, but this will just make it a `text` field.

comm_thread_notes

+---------------------------------+------------------+------+-----+---------+----------------+
| Field                           | Type             | Null | Key | Default | Extra          |
+---------------------------------+------------------+------+-----+---------+----------------+
| id                              | int(11) unsigned | NO   | PRI | NULL    | auto_increment |
| created                         | datetime         | NO   |     | NULL    |                |
| modified                        | datetime         | NO   |     | NULL    |                |
| thread_id                       | int(11) unsigned | NO   | MUL | NULL    |                |
| author_id                       | int(11) unsigned | NO   | MUL | NULL    |                |
| note_type                       | int(11)          | NO   |     | NULL    |                |
| body                            | int(11) unsigned | YES  | UNI | NULL    |                |
| read_permission_public          | tinyint(1)       | NO   |     | NULL    |                |
| read_permission_developer       | tinyint(1)       | NO   | MUL | NULL    |                |
| read_permission_reviewer        | tinyint(1)       | NO   |     | NULL    |                |
| read_permission_senior_reviewer | tinyint(1)       | NO   |     | NULL    |                |
| read_permission_staff           | tinyint(1)       | NO   |     | NULL    |                |
| read_permission_mozilla_contact | tinyint(1)       | NO   |     | NULL    |                |
| reply_to_id                     | int(11) unsigned | YES  | MUL | NULL    |                |
+---------------------------------+------------------+------+-----+---------+----------------+
