### PR TITLE
Restricting the receipt API to authenticated users (bug 917601)

### DIFF
--- a/docs/api/topics/payment.rst
+++ b/docs/api/topics/payment.rst
@@ -339,6 +339,7 @@ Payment status
     :type status: string
 
     :status 200: request processed, check status for value.
+    :status 401: not authenticated.
     :status 403: not authorized to view details on that transaction.
 
 Installing
@@ -368,6 +369,8 @@ Free apps
 Premium apps
 ------------
 
+.. note:: Authentication is required.
+
 .. http:post:: /api/v1/receipts/install/
 
     Returns a receipt if the app is paid and a receipt should be installed.
@@ -384,6 +387,7 @@ Premium apps
         {"receipt": "eyJhbGciOiAiUlM1MT...[truncated]"}
 
     :statuscode 201: successfully completed.
+    :statuscode 401: not authenticated.
     :statuscode 402: payment required.
     :statuscode 403: app is not public, install not allowed.
 

--- a/mkt/receipts/api.py
+++ b/mkt/receipts/api.py
@@ -12,7 +12,8 @@ from tastypie.validation import CleanedDataFormValidation
 from constants.payments import CONTRIB_NO_CHARGE
 from lib.cef_loggers import receipt_cef
 from market.models import AddonPurchase
-from mkt.api.authentication import (OptionalOAuthAuthentication,
+from mkt.api.authentication import (OAuthAuthentication,
+                                    OptionalOAuthAuthentication,
                                     SharedSecretAuthentication)
 from mkt.api.base import CORSResource, http_error, MarketplaceResource
 from mkt.api.http import HttpPaymentRequired
@@ -32,7 +33,7 @@ class ReceiptResource(CORSResource, MarketplaceResource):
     class Meta(MarketplaceResource.Meta):
         always_return_data = True
         authentication = (SharedSecretAuthentication(),
-                          OptionalOAuthAuthentication())
+                          OAuthAuthentication())
         authorization = Authorization()
         detail_allowed_methods = []
         list_allowed_methods = ['post']
@@ -75,10 +76,7 @@ class ReceiptResource(CORSResource, MarketplaceResource):
                 log.info('App not purchased: %s' % bundle.obj.pk)
                 raise http_error(HttpPaymentRequired, 'You have not purchased this app.')
 
-        # Anonymous users will fall through, they don't need anything else
-        # handling.
-        if request.user.is_authenticated():
-            return self.record(bundle, request, type_)
+        return self.record(bundle, request, type_)
 
     def record(self, bundle, request, install_type):
         # Generate or re-use an existing install record.

--- a/mkt/receipts/tests/test_api.py
+++ b/mkt/receipts/tests/test_api.py
@@ -53,8 +53,7 @@ class TestAPI(BaseOAuth):
 
     def test_record_logged_out(self):
         res = self.post(anon=True)
-        eq_(res.status_code, 201)
-        eq_(res.json['receipt'], None)
+        eq_(res.status_code, 401)
 
     @mock.patch('mkt.receipts.api.receipt_cef.log')
     def test_cef_logs(self, cef):

--- a/mkt/webpay/resources.py
+++ b/mkt/webpay/resources.py
@@ -9,7 +9,6 @@ import commonware.log
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-import waffle
 from tastypie import fields, http
 from tastypie.exceptions import ImmediateHttpResponse
 from tastypie.validation import CleanedDataFormValidation


### PR DESCRIPTION
Otherwise a 500 will be raised given the usage of `request.amo_user`
