### PR TITLE
Include API-Fallback-[type] in search/featured API responses (bug 919993)

### DIFF
--- a/docs/api/topics/rocketfuel.rst
+++ b/docs/api/topics/rocketfuel.rst
@@ -39,6 +39,8 @@ Listing
     Filtering on null values is done by omiting the value for the corresponding
     parameter in the query string.
 
+.. _rocketfuel-fallback:
+
     If no results are found with the filters specified, the API will
     automatically use a fallback mechanism and try to change the values to null
     in order to try to find some results.

--- a/docs/api/topics/search.rst
+++ b/docs/api/topics/search.rst
@@ -103,6 +103,18 @@ Featured App Listing
     :type operator: array
     :status 200: successfully completed.
 
+    The different types of collections returned are filtered using the same
+    parameters as :ref:`rocketfuel <rocketfuel>` listing API, using the same
+    :ref:`fallback mechanism <rocketfuel-fallback>` if no results are found
+    with the filters specified.
+
+    However, because there are 3 separate types of collections returned,
+    you can have 3 different fallbacks. Therefore, instead of returning one
+    single `API-Fallback` header, the HTTP response will contain up to 3
+    separate headers: `API-Fallback-collections`, `API-Fallback-featured` and
+    `API-Fallback-operator`. Their content is identical to the `API-Fallback`
+    header returned in rocketfuel listing API.
+
 .. _feature-profile-label:
 
 Feature Profile Signatures


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=919993

So for instance, with that change, if, to find featured apps collections, we had to set region and carrier to `NULL`, then we'll have this in the response:
`API-Fallback-featured: region,carrier`
