### PR TITLE
Add header to API responses indicating whether the request was pinned to the master database (bug 918124)

### DIFF
--- a/mkt/api/middleware.py
+++ b/mkt/api/middleware.py
@@ -10,7 +10,8 @@ from django.utils.cache import patch_vary_headers
 from django_statsd.clients import statsd
 from django_statsd.middleware import (GraphiteRequestTimingMiddleware,
                                       TastyPieRequestTimingMiddleware)
-from multidb.pinning import pin_this_thread, unpin_this_thread
+from multidb.pinning import (pin_this_thread, this_thread_is_pinned,
+                             unpin_this_thread)
 from multidb.middleware import PinningRouterMiddleware
 
 from mkt.carriers import get_carrier
@@ -73,6 +74,8 @@ class APIPinningMiddleware(PinningRouterMiddleware):
         if not getattr(request, 'API', False):
             return (super(APIPinningMiddleware, self)
                     .process_response(request, response))
+
+        response['API-Pinned'] = str(this_thread_is_pinned())
 
         if (request.amo_user and not request.amo_user.is_anonymous() and (
                 request.method in ['DELETE', 'PATCH', 'POST', 'PUT'] or

--- a/mkt/api/tests/test_middleware.py
+++ b/mkt/api/tests/test_middleware.py
@@ -138,6 +138,20 @@ class TestPinningMiddleware(amo.tests.TestCase):
             self.pin.process_response(self.req, HttpResponse())
             ok_(not cache.get(self.key))
 
+    def pinned_header(self):
+        self.attach_user(anon=True)
+        return self.pin.process_response(self.req, HttpResponse())['API-Pinned']
+
+    @mock.patch('mkt.api.middleware.this_thread_is_pinned')
+    def test_pinned_header_true(self, mock_pinned):
+        mock_pinned.return_value = True
+        eq_(self.pinned_header(), 'True')
+
+    @mock.patch('mkt.api.middleware.this_thread_is_pinned')
+    def test_pinned_header_false(self, mock_pinned):
+        mock_pinned.return_value = False
+        eq_(self.pinned_header(), 'False')
+
 
 class TestAPIVersionMiddleware(amo.tests.TestCase):
 


### PR DESCRIPTION
r? robhudson
