### PR TITLE
fixed l10n broken display texts an buttons on theme page (bug 920002)

### DIFF
--- a/media/css/zamboni/zamboni.css
+++ b/media/css/zamboni/zamboni.css
@@ -1119,7 +1119,7 @@ ul.license li.copyr { background-position: 0 -260px; }
 .persona-install button {
     border-radius: 1px;
     height: 25px;
-    width: 65px;
+    min-width: 65px;
 }
 .persona .persona-install.incompat-browser button.disabled {
     background: #fff;
@@ -1337,13 +1337,13 @@ ul.license li.copyr { background-position: 0 -260px; }
     border-top: 0;
     background: #e5f0fc url(../../img/zamboni/personas/complete-theme-promo.png) no-repeat 367px 0;
     background-size: 120% auto;
-    height: 140px;
 }
 
 .html-rtl #featured-addons.personas-home .featured-inner.complete-themes {
     background-position: -500px 0;
 }
 
+.featured-inner.complete-themes h2,
 .featured-inner.complete-themes .intro {
     width: 350px;
 }


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=920002 (page before the fix: https://addons.mozilla.org/de/firefox/themes/)
![css_themepage_l10n-920002](https://f.cloud.github.com/assets/145172/1211241/7d2f56dc-2606-11e3-9ac6-f93c53854231.png)
