### PR TITLE
Ensure that you return an uncached queryset of curators in addition to cache invalidation, to prevent possible race conditions on master/slave hardware (bug 918124)

### DIFF
--- a/mkt/collections/views.py
+++ b/mkt/collections/views.py
@@ -189,7 +189,7 @@ class CollectionViewSet(CORSMixin, SlugOrIdMixin, viewsets.ModelViewSet):
 
     def serialized_curators(self):
         return Response([CuratorSerializer(instance=c).data for c in
-                         self.get_object().curators.all()])
+                         self.get_object().curators.no_cache().all()])
 
     def get_curator(self, request):
         try:


### PR DESCRIPTION
r? @diox
