### PR TITLE
link from devhub to commbadge (bug 907569)

### DIFF
--- a/mkt/commonplace/urls.py
+++ b/mkt/commonplace/urls.py
@@ -6,6 +6,8 @@ from . import views
 urlpatterns = patterns('',
     url('^server.html$', views.commonplace, {'repo': 'fireplace'},
         name='commonplace.fireplace'),
+    url('^comm/thread/(?P<thread_id>\d+)$', views.commonplace, {'repo': 'commbadge'},
+        name='commonplace.commbadge.show_thread'),
     url('^comm/.*$', views.commonplace, {'repo': 'commbadge'},
         name='commonplace.commbadge'),
     url('^curation/.*$', views.commonplace, {'repo': 'rocketfuel'},

--- a/mkt/commonplace/views.py
+++ b/mkt/commonplace/views.py
@@ -9,7 +9,7 @@ import jingo
 from mkt.api.resources import waffles
 
 
-def commonplace(request, repo):
+def commonplace(request, repo, **kwargs):
     if repo not in settings.COMMONPLACE_REPOS:
         raise HttpResponseNotFound
 

--- a/mkt/developers/templates/developers/apps/listing/item_actions_app.html
+++ b/mkt/developers/templates/developers/apps/listing/item_actions_app.html
@@ -75,5 +75,11 @@
       </a>
     </li>
   {% endif %}
+  {% if waffle.switch('comm-dashboard') %}
+    <li>
+      <a class="action-link" href="{{ addon.get_comm_thread_url() }}">
+        {{ _('Communication') }}</a>
+    </li>
+  {% endif %}
 </ul>
 {% endif %}

--- a/mkt/developers/templates/developers/includes/addons_edit_nav.html
+++ b/mkt/developers/templates/developers/includes/addons_edit_nav.html
@@ -31,6 +31,12 @@
     (url('mkt.developers.transactions')|urlparams(app=addon.id), _('View Transactions')),
   ) %}
 {% endif %}
+{% if waffle.switch('comm-dashboard') %}
+  {% do urls.append(
+    (addon.get_comm_thread_url(), _('View Communication Dashboard'))
+  ) %}
+{% endif %}
+
 
 <section class="secondary manage" role="complementary">
   <div class="island" id="edit-addon-nav">

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -183,6 +183,7 @@ class TestAppDashboard(AppHubTest):
             'Pending Version: 1.24')
 
     def test_action_links(self):
+        self.create_switch('comm-dashboard')
         self.create_switch('view-transactions')
         app = self.get_app()
         app.update(public_stats=True, is_packaged=False)
@@ -197,12 +198,14 @@ class TestAppDashboard(AppHubTest):
             ('Statistics', app.get_stats_url()),
             ('Transactions', urlparams(
                 reverse('mkt.developers.transactions'), app=app.id)),
+            ('Communication', app.get_comm_thread_url()),
         ]
         amo.tests.check_links(expected, doc('a.action-link'), verify=False)
 
     def test_action_links_packaged(self):
-        self.create_switch('view-transactions')
+        self.create_switch('comm-dashboard')
         self.create_switch('in-app-payments')
+        self.create_switch('view-transactions')
         app = self.get_app()
         app.update(public_stats=True, is_packaged=True,
                    premium_type=amo.ADDON_PREMIUM_INAPP)
@@ -219,10 +222,12 @@ class TestAppDashboard(AppHubTest):
             ('Transactions', urlparams(
                 reverse('mkt.developers.transactions'), app=app.id)),
             ('Manage In-App Payments', app.get_dev_url('in_app_config')),
+            ('Communication', app.get_comm_thread_url()),
         ]
         amo.tests.check_links(expected, doc('a.action-link'), verify=False)
 
     def test_disabled_payments_action_links(self):
+        self.create_switch('comm-dashboard')
         self.create_switch('disabled-payments')
         self.create_switch('view-transactions')
         app = self.get_app()
@@ -238,6 +243,7 @@ class TestAppDashboard(AppHubTest):
             ('Statistics', app.get_stats_url()),
             ('Transactions', urlparams(
                 reverse('mkt.developers.transactions'), app=app.id)),
+            ('Communication', app.get_comm_thread_url()),
         ]
         amo.tests.check_links(expected, doc('a.action-link'), verify=False)
 

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -33,6 +33,7 @@ from amo.helpers import absolutify
 from amo.storage_utils import copy_stored_file
 from amo.urlresolvers import reverse
 from amo.utils import JSONEncoder, memoize, memoize_key, smart_path
+from comm.models import CommunicationThread
 from constants.applications import DEVICE_TYPES
 from files.models import File, nfd_str, Platform
 from files.utils import parse_addon, WebAppParser
@@ -250,6 +251,13 @@ class Webapp(Addon):
         # get_stats_url.
         return reverse(('mkt.stats.%s' % action),
                        args=[self.app_slug] + (args or []))
+
+    def get_comm_thread_url(self):
+        threads = self.threads.order_by('-created')
+        if threads.exists():
+            return reverse('commonplace.commbadge.show_thread',
+                           args=[threads[0].id])
+        return reverse('commonplace.commbadge')
 
     @staticmethod
     def domain_from_url(url, allow_none=False):

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -26,6 +26,7 @@ from addons.signals import version_changed as version_changed_signal
 from amo.helpers import absolutify
 from amo.tests import app_factory, version_factory
 from amo.urlresolvers import reverse
+from comm.utils import create_comm_thread
 from constants.applications import DEVICE_TYPES
 from editors.models import EscalationQueue, RereviewQueue
 from files.models import File
@@ -151,6 +152,17 @@ class TestWebapp(amo.tests.TestCase):
                                    args=['day', '20120101', '20120201',
                                          'json'])
         eq_(url, '/app/woo/statistics/installs-day-20120101-20120201.json')
+
+    def test_get_comm_thread_url(self):
+        self.create_switch('comm-dashboard')
+        webapp = app_factory()
+        eq_(webapp.get_comm_thread_url(), '/comm/')
+
+        thread, note = create_comm_thread(
+            addon=webapp, version=webapp.versions.get(), perms=[],
+            action='approve', comments='lol',
+            profile=UserProfile.objects.create(username='lol'))
+        eq_(webapp.get_comm_thread_url(), '/comm/thread/%s' % thread.id)
 
     def test_get_origin(self):
         url = 'http://www.xx.com:4000/randompath/manifest.webapp'
@@ -553,7 +565,6 @@ class DeletedAppTests(amo.tests.ESTestCase):
         webapp.save()
         webapp.delete()
         eq_(webapp.latest_version, None)
-
 
 
 class TestExclusions(amo.tests.TestCase):


### PR DESCRIPTION
Previous attempt: https://github.com/mozilla/zamboni/pull/1088

If no comm thread, link to `/comm/`

If comm thread, link to `/comm/thread/<thread_id>`

**Screenshots**
![screen shot 2013-09-30 at 2 50 14 pm](https://f.cloud.github.com/assets/674727/1241280/54fecbda-2a1a-11e3-8ab7-45cf5ff0bff0.png)
![screen shot 2013-09-30 at 2 50 19 pm](https://f.cloud.github.com/assets/674727/1241281/575520f0-2a1a-11e3-8afd-50adad6cccfd.png)

![](http://i.imgur.com/Kh2Osoy.gif)
