### PR TITLE
script to award theme reviewer points retroactively (bug 909985)

### DIFF
--- a/mkt/reviewers/management/commands/award_theme_points.py
+++ b/mkt/reviewers/management/commands/award_theme_points.py
@@ -1,0 +1,33 @@
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+import amo
+from amo.utils import chunked
+from devhub.models import ActivityLog
+
+import mkt.constants.reviewers as rvw
+from mkt.reviewers.tasks import _batch_award_points
+
+
+class Command(BaseCommand):
+    help = ('Retroactively award theme reviewer points for all the theme '
+            'reviewers done since the Great Theme Migration to amo up to when '
+            'we started recording points. MEANT FOR ONE-TIME RUN.')
+
+    def handle(self, *args, **options):
+        start_date = datetime.date(2013, 8, 27)
+
+        # Get theme reviews that are approves and rejects from before we started
+        # awarding.
+        approve = '"action": %s' % rvw.ACTION_APPROVE
+        reject = '"action": %s' % rvw.ACTION_REJECT
+        al_ids = (ActivityLog.objects.filter(
+            Q(_details__contains=approve) | Q(_details__contains=reject),
+            action=amo.LOG.THEME_REVIEW.id, created__lte=start_date)
+            .values_list('id', flat=True))
+
+        for chunk in chunked(al_ids, 1000):
+            # Review and thou shall receive.
+            _batch_award_points.delay(chunk)

--- a/mkt/reviewers/tasks.py
+++ b/mkt/reviewers/tasks.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 
 from celeryutils import task
@@ -8,6 +10,7 @@ from addons.tasks import create_persona_preview_images
 from amo.decorators import write
 from amo.storage_utils import copy_stored_file, move_stored_file
 from amo.utils import LocalFileStorage, send_mail_jinja
+from devhub.models import ActivityLog
 from editors.models import ReviewerScore
 
 import mkt.constants.reviewers as rvw
@@ -116,15 +119,15 @@ def reject_rereview(theme):
 
 @task
 @write
-def _batch_award_points(activity_logs, **kwargs):
-    """For migration award_theme_rev_points."""
-    for log in activity_logs:
-        if not ReviewerScore.objects.filter(
-            user=log.user, addon=log.arguments[0],
-            score=amo.REVIEWED_SCORES.get(amo.REVIEWED_PERSONA),
-            note_key=amo.REVIEWED_PERSONA, note='RETROACTIVE').exists():
+def _batch_award_points(activity_log_ids, **kwargs):
+    """For command award_theme_points."""
+    activity_logs = (ActivityLog.objects.filter(id__in=activity_log_ids)
+        .select_related('user'))
 
-            ReviewerScore.objects.create(
-                user=log.user, addon=log.arguments[0],
-                score=amo.REVIEWED_SCORES.get(amo.REVIEWED_PERSONA),
-                note_key=amo.REVIEWED_PERSONA, note='RETROACTIVE')
+    score = amo.REVIEWED_SCORES.get(amo.REVIEWED_PERSONA)
+    ReviewerScore.objects.bulk_create(
+        [ReviewerScore(user=log.user, score=score, note='RETROACTIVE',
+                       note_key=amo.REVIEWED_PERSONA,
+                       addon_id=json.loads(log._arguments)[0]['addons.addon'])
+         for log in activity_logs]
+    )


### PR DESCRIPTION
Runs well locally and on -dev. Well tested. Committing as script rather than migration this time - to run on prod in more controlled situation.

About 4000 objects to create.

Some optimizations have been made
- using `bulk_create`
- removing `get_or_create` functionality.
- Celery tasks chunked to handle 1000 at a time to hog only a few workers.
-  `select_related` on `ActivityLog.user` 
- Don't call `ActivityLog.arguments` since fetches Addon objects, just dump `_arguments` to json and get the addon id.
