### PR TITLE
Upgrade django-cache-machine to 0.8 (bug 883477)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -18,6 +18,7 @@ from django.http import SimpleCookie
 from django.test.client import Client
 from django.utils import translation
 
+import caching
 import elasticutils.contrib.django as elasticutils
 import mock
 import pyelasticsearch.exceptions as pyelasticsearch
@@ -275,6 +276,9 @@ class TestCase(MockEsMixin, RedisTest, test_utils.TestCase):
     def _pre_setup(self):
         super(TestCase, self)._pre_setup()
         cache.clear()
+        # Override django-cache-machine caching.base.TIMEOUT because it's
+        # computed too early, before settings_test.py is imported.
+        caching.base.TIMEOUT = settings.CACHE_COUNT_TIMEOUT
 
     @contextmanager
     def activate(self, locale=None, app=None):

--- a/apps/translations/models.py
+++ b/apps/translations/models.py
@@ -56,13 +56,13 @@ class Translation(amo.models.ModelBase):
 
     @property
     def cache_key(self):
-        return self._cache_key(self.id)
+        return self._cache_key(self.id, self._state.db)
 
     @classmethod
-    def _cache_key(cls, pk):
+    def _cache_key(cls, pk, db):
         # Hard-coding the class name here so that subclasses don't try to cache
         # themselves under something like "o:translations.purifiedtranslation".
-        key_parts = ('o', 'translations.translation', pk)
+        key_parts = ('o', 'translations.translation', pk, db)
         return ':'.join(map(encoding.smart_unicode, key_parts))
 
     @classmethod

--- a/docs/settings/settings_local.prod.py
+++ b/docs/settings/settings_local.prod.py
@@ -31,7 +31,7 @@ SLAVE_DATABASES = ['slave']
 # Use IP:PORT pairs separated by semicolons.
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.CacheClass',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
         'LOCATION': ['localhost:11211', 'localhost:11212'],
         'TIMEOUT': 500,
     }

--- a/docs/topics/install-zamboni/advanced-installation.rst
+++ b/docs/topics/install-zamboni/advanced-installation.rst
@@ -43,7 +43,7 @@ We slipped this in with the basic install.  The package was
 
     CACHES = {
         'default': {
-            'BACKEND': 'caching.backends.memcached.CacheClass',
+            'BACKEND': 'caching.backends.memcached.MemcachedCache',
             'LOCATION': ['localhost:11211'],
             'TIMEOUT': 500,
         }

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -17,7 +17,7 @@ Django==1.4.8
 dj-database-url==0.2.2
 django-aesfield==0.1
 django-browserid==0.8
-django-cache-machine==0.6
+django-cache-machine==0.8
 django-celery==3.0.17
 django-cronjobs==0.2.3
 django_csp==1.0.2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,7 +80,7 @@ DATABASES['default']['TEST_CHARSET'] = 'utf8'
 DATABASES['default']['TEST_COLLATION'] = 'utf8_general_ci'
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.locmem.CacheClass',
+        'BACKEND': 'caching.backends.locmem.LocMemCache',
     }
 }
 CELERY_ALWAYS_EAGER = True

--- a/scripts/run_jstests.sh
+++ b/scripts/run_jstests.sh
@@ -70,7 +70,7 @@ DATABASES = {
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.locmem.CacheClass',
+        'BACKEND': 'caching.backends.locmem.LocMemCache',
     }
 }
 CELERY_ALWAYS_EAGER = True

--- a/scripts/run_mkt_tests.sh
+++ b/scripts/run_mkt_tests.sh
@@ -75,7 +75,7 @@ DATABASES['default']['TEST_CHARSET'] = 'utf8'
 DATABASES['default']['TEST_COLLATION'] = 'utf8_general_ci'
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.locmem.CacheClass',
+        'BACKEND': 'caching.backends.locmem.LocMemCache',
     }
 }
 CELERY_ALWAYS_EAGER = True

--- a/settings_test.py
+++ b/settings_test.py
@@ -71,9 +71,13 @@ USERPICS_URL = STATIC_URL + '/img/uploads/userpics/%s/%s/%s.png?modified=%d'
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.locmem.CacheClass',
+        'BACKEND': 'caching.backends.locmem.LocMemCache',
     }
 }
+
+# COUNT() caching can't be invalidated, it just expires after x seconds. This
+# is just too annoying for tests, so disable it.
+CACHE_COUNT_TIMEOUT = None
 
 # No more failures!
 APP_PREVIEW = False

--- a/sites/altdev/settings_base.py
+++ b/sites/altdev/settings_base.py
@@ -46,7 +46,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.CacheClass',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
 #        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
 #        'BACKEND': 'memcachepool.cache.UMemcacheCache',
         'LOCATION': splitstrip(private.CACHES_DEFAULT_LOCATION),

--- a/sites/dev/settings_base.py
+++ b/sites/dev/settings_base.py
@@ -47,7 +47,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.CacheClass',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
         'LOCATION': splitstrip(private.CACHES_DEFAULT_LOCATION),
         'TIMEOUT': 500,
         'KEY_PREFIX': CACHE_PREFIX,

--- a/sites/landfill/settings_base.py
+++ b/sites/landfill/settings_base.py
@@ -46,7 +46,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.CacheClass',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
 #        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
 #        'BACKEND': 'memcachepool.cache.UMemcacheCache',
         'LOCATION': splitstrip(private.CACHES_DEFAULT_LOCATION),

--- a/sites/prod/settings_base.py
+++ b/sites/prod/settings_base.py
@@ -37,7 +37,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.CacheClass',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
         'LOCATION': splitstrip(private.CACHES_DEFAULT_LOCATION),
         'TIMEOUT': 500,
         'KEY_PREFIX': CACHE_PREFIX,

--- a/sites/stage/settings_base.py
+++ b/sites/stage/settings_base.py
@@ -44,7 +44,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.CacheClass',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
 #        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
 #        'BACKEND': 'memcachepool.cache.UMemcacheCache',
         'LOCATION': splitstrip(private.CACHES_DEFAULT_LOCATION),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=883477

`count()`s caching is disabled in tests, this was already done before by accident, this is now done on purpose because it messes up with all the tests.

(@robhudson did most of the work, I just had to figure out what the hell was happening with the tests :)
