### PR TITLE
memorize last choice in addon firefox version (bug 729414)

### DIFF
--- a/apps/search/tests/test_views.py
+++ b/apps/search/tests/test_views.py
@@ -977,6 +977,28 @@ class TestCollectionSearch(SearchBase):
         eq_(self.get_results(r), [sm_collection.id])
 
 
+    def test_session_version_sidebar(self):
+        request = RequestFactory()
+        request.session = {}
+        request.APP = amo.FIREFOX
+
+        request.get(reverse('search.search'))
+        facets = {
+            u'platforms': [{u'count': 58, u'term': 1}],
+            u'appversions': [{u'count': 58, u'term': 5000000200100}],
+            u'categories': [{u'count': 55, u'term': 1}],
+            u'tags': [],
+        }
+        versions = version_sidebar(request, {}, facets)
+        assert not versions[1].selected
+
+        versions = version_sidebar(request, {'appver': '5.0'}, facets)
+        assert versions[1].selected
+
+        versions = version_sidebar(request, {}, facets)
+        assert versions[1].selected
+
+
 def test_search_redirects():
     changes = (
         ('q=yeah&sort=newest', 'q=yeah&sort=updated'),

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -533,7 +533,9 @@ def category_sidebar(request, query, facets):
 
 
 def version_sidebar(request, query, facets):
-    appver = query.get('appver')
+    appver = query.get('appver') or request.session.get('search.appver')
+    if query.get('appver'):
+        request.session['search.appver'] = appver
     app = unicode(request.APP.pretty)
     exclude_versions = getattr(request.APP, 'exclude_versions', [])
     # L10n: {0} is an application, such as Firefox. This means "any version of


### PR DESCRIPTION
http://bugzil.la/729414
Storing in session the last user's choice for ff version
