### PR TITLE
In DRF APIs, return a single translation if 'lang' GET param is passed (bug 907820)

### DIFF
--- a/docs/api/topics/rocketfuel.rst
+++ b/docs/api/topics/rocketfuel.rst
@@ -16,6 +16,25 @@ Collections
 A collection is a group of applications
 
 
+.. note::
+
+    When dealing with Collections in the API, translatable fields (currently
+    name, description) are returned by default as an object containing all
+    translations, with languages as keys:
+
+    .. code-block:: json
+
+        {
+            "en-US": "Games",
+            "fr": "Jeux",
+            "kn": "ಆಟಗಳು"
+        }
+
+    If you pass the `lang` parameter to a `GET` request, then then only the most
+    relevant translation (the specified language or the fallback, depending on
+    whether a translation is available) will be returned as a string.
+
+
 Listing
 -------
 

--- a/mkt/api/fields.py
+++ b/mkt/api/fields.py
@@ -11,15 +11,37 @@ class TranslationSerializerField(fields.WritableField):
       dictionary. If a string is given, it'll be considered to be in the
       default language.
 
-    - When serializing, it returns a dict with all translations for the given
-      `field_name` on `obj`, with languages as the keys.
+    - When serializing, its behavior depends on the parent's serializer context:
+
+      If a request was included, and its method is 'GET', and a 'lang' parameter
+      was passed, then only returns one translation (letting the TranslatedField
+      figure out automatically which language to use).
+
+      Else, just returns a dict with all translations for the given `field_name`
+      on `obj`, with languages as the keys.
     """
+    def __init__(self, *args, **kwargs):
+        super(TranslationSerializerField, self).__init__(*args, **kwargs)
+        # Default to return all translations for each field.
+        self.return_all_translations = True
+
+    def initialize(self, parent, field_name):
+        super(TranslationSerializerField, self).initialize(parent, field_name)
+        request = self.context.get('request', None)
+        if request and request.method == 'GET' and 'lang' in request.GET:
+            # A specific language was requested, we only return one translation
+            # per field.
+            self.return_all_translations = False
+
     def field_to_native(self, obj, field_name):
         field = getattr(obj, field_name)
-        translations = field.__class__.objects.filter(id=field.id,
-            localized_string__isnull=False)
-        return dict((to_language(trans.locale), unicode(trans))
-                    for trans in translations)
+        if not self.return_all_translations:
+            return unicode(field)
+        else:
+            translations = field.__class__.objects.filter(id=field.id,
+                localized_string__isnull=False)
+            return dict((to_language(trans.locale), unicode(trans))
+                        for trans in translations)
 
     def from_native(self, data):
         if isinstance(data, basestring):

--- a/mkt/api/tests/test_fields.py
+++ b/mkt/api/tests/test_fields.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from nose.tools import eq_
+from rest_framework.request import Request
+from rest_framework.serializers import Serializer
+from rest_framework.test import APIRequestFactory
 
 from amo.tests import TestCase
 from mkt.api.fields import TranslationSerializerField
@@ -10,6 +13,37 @@ from translations.models import Translation
 
 class TestTranslationSerializerField(TestCase):
     fixtures = fixture('user_2519', 'webapp_337141')
+
+    def setUp(self):
+        super(TestTranslationSerializerField, self).setUp()
+        self.factory = APIRequestFactory()
+        self.app = Webapp.objects.get(pk=337141)
+
+    def _test_expected_dict(self, field):
+        result = field.field_to_native(self.app, 'name')
+        expected = {
+            'en-US': unicode(Translation.objects.get(id=self.app.name.id,
+                                                     locale='en-US')),
+            'es': unicode(Translation.objects.get(id=self.app.name.id,
+                                                  locale='es')),
+        }
+        eq_(result, expected)
+
+        result = field.field_to_native(self.app, 'description')
+        expected = {
+            'en-US': Translation.objects.get(id=self.app.description.id,
+                                             locale='en-US'),
+        }
+        eq_(result, expected)
+
+    def _test_expected_single_string(self, field):
+        result = field.field_to_native(self.app, 'name')
+        expected = unicode(self.app.name)
+        eq_(result, expected)
+
+        result = field.field_to_native(self.app, 'description')
+        expected = unicode(self.app.description)
+        eq_(result, expected)
 
     def test_from_native(self):
         data = u'Translatiön'
@@ -40,18 +74,45 @@ class TestTranslationSerializerField(TestCase):
         eq_(result, {'fr': u'Non mais Allô quoi !', 'en-US': u''})
 
     def test_field_to_native(self):
-        app = Webapp.objects.get(pk=337141)
         field = TranslationSerializerField()
-        result = field.field_to_native(app, 'name')
-        expected = {
-            'en-US': Translation.objects.get(id=app.name.id, locale='en-US'),
-            'es': Translation.objects.get(id=app.name.id, locale='es')
-        }
-        eq_(result, expected)
+        self._test_expected_dict(field)
 
-        result = field.field_to_native(app, 'description')
-        expected = {
-            'en-US': Translation.objects.get(id=app.description.id, 
-                                             locale='en-US'),
-        }
-        eq_(result, expected)
+    def test_field_to_native_empty_context(self):
+        mock_serializer = Serializer()
+        mock_serializer.context = {}
+        field = TranslationSerializerField()
+        field.initialize(mock_serializer, 'name')
+        self._test_expected_dict(field)
+
+    def test_field_to_native_request_POST(self):
+        request = Request(self.factory.post('/'))
+        mock_serializer = Serializer()
+        mock_serializer.context = {'request': request}
+        field = TranslationSerializerField()
+        field.initialize(mock_serializer, 'name')
+        self._test_expected_dict(field)
+
+    def test_field_to_native_request_GET(self):
+        request = Request(self.factory.get('/'))
+        mock_serializer = Serializer()
+        mock_serializer.context = {'request': request}
+        field = TranslationSerializerField()
+        field.initialize(mock_serializer, 'name')
+        self._test_expected_dict(field)
+
+    def test_field_to_native_request_GET_lang(self):
+        """
+        Pass a lang in the query string, expect to have a single string
+        returned instead of an object.
+        """
+        # Note that we don't go through the middlewares etc so the actual
+        # language for the process isn't changed, we don't care as
+        # _expect_single_string() method simply tests with the current language,
+        # whatever it is.
+        request = Request(self.factory.get('/', {'lang': 'lol'}))
+        eq_(request.GET['lang'], 'lol')
+        mock_serializer = Serializer()
+        mock_serializer.context = {'request': request}
+        field = TranslationSerializerField()
+        field.initialize(mock_serializer, 'name')
+        self._test_expected_single_string(field)

--- a/mkt/collections/tests/test_views.py
+++ b/mkt/collections/tests/test_views.py
@@ -23,7 +23,6 @@ from mkt.collections.constants import (COLLECTIONS_TYPE_BASIC,
                                        COLLECTIONS_TYPE_FEATURED,
                                        COLLECTIONS_TYPE_OPERATOR)
 from mkt.collections.models import Collection
-from mkt.collections.serializers import CollectionSerializer
 from mkt.collections.views import CollectionViewSet
 from mkt.site.fixtures import fixture
 from mkt.webapps.models import Webapp
@@ -42,7 +41,6 @@ class BaseCollectionViewSetTest(RestOAuth):
     def setUp(self):
         self.create_switch('rocketfuel')
         super(BaseCollectionViewSetTest, self).setUp()
-        self.serializer = CollectionSerializer()
         self.collection_data = {
             'author': u'My Àuthør',
             'background_color': '#FFF000',
@@ -185,6 +183,18 @@ class TestCollectionViewSetListing(BaseCollectionViewSetTest):
     def test_listing_curator(self):
         self.make_curator()
         self.listing(self.client)
+
+    def test_listing_single_lang(self):
+        self.collection.name = {
+            'fr': u'Basta la pomme de terre frite',
+        }
+        self.collection.save()
+        res = self.client.get(self.list_url, {'lang': 'fr'})
+        data = json.loads(res.content)
+        eq_(res.status_code, 200)
+        collection = data['objects'][0]
+        eq_(collection['name'], u'Basta la pomme de terre frite')
+        eq_(collection['description'], u'A cöllection of my favorite games')
 
     def test_listing_filter_unowned_hidden(self):
         """


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=907820

cc @mattbasta , this is a backwards-incompatible change affecting all collections-related APIs (rocketfuel and search/featured)
