### PR TITLE
rename status terms for clarity ( bug 895560)

### DIFF
--- a/apps/addons/cron.py
+++ b/apps/addons/cron.py
@@ -292,7 +292,7 @@ def hide_disabled_files():
     # GUARDED_ADDONS_PATH so it's not publicly visible.
     q = (Q(version__addon__status=amo.STATUS_DISABLED)
          | Q(version__addon__disabled_by_user=True))
-    ids = (File.objects.filter(q | Q(status=amo.STATUS_DISABLED))
+    ids = (File.objects.filter(q | Q(status=amo.STATUS_OBSOLETE))
            .values_list('id', flat=True))
     for chunk in chunked(ids, 300):
         qs = File.objects.no_cache().filter(id__in=chunk)
@@ -308,7 +308,7 @@ def unhide_disabled_files():
     log = logging.getLogger('z.files.disabled')
     q = (Q(version__addon__status=amo.STATUS_DISABLED)
          | Q(version__addon__disabled_by_user=True))
-    files = set(File.objects.filter(q | Q(status=amo.STATUS_DISABLED))
+    files = set(File.objects.filter(q | Q(status=amo.STATUS_OBSOLETE))
                 .values_list('version__addon', 'filename'))
     for filepath in path.path(settings.GUARDED_ADDONS_PATH).walkfiles():
         addon, filename = filepath.split('/')[-2:]

--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1097,7 +1097,7 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
                             amo.STATUS_LITE_AND_NOMINATED,
                             amo.STATUS_DELETED) or
             not self.latest_version or
-            not self.latest_version.files.exclude(status=amo.STATUS_DISABLED)):
+            not self.latest_version.files.exclude(status=amo.STATUS_OBSOLETE)):
             return ()
         elif self.status == amo.STATUS_NOMINATED:
             return (amo.STATUS_LITE,)

--- a/apps/addons/tests/test_buttons.py
+++ b/apps/addons/tests/test_buttons.py
@@ -393,7 +393,7 @@ class TestButton(ButtonTest):
 
     def test_link_with_invalid_file(self):
         self.version.all_files = self.platform_files
-        self.version.all_files[0].status = amo.STATUS_DISABLED
+        self.version.all_files[0].status = amo.STATUS_OBSOLETE
         links = self.get_button().links()
 
         expected_platforms = self.platforms[1:]

--- a/apps/addons/tests/test_cron.py
+++ b/apps/addons/tests/test_cron.py
@@ -191,7 +191,7 @@ class TestHideDisabledFiles(amo.tests.TestCase):
     @mock.patch('files.models.storage')
     def test_move_disabled_file(self, m_storage, mv_mock):
         Addon.objects.filter(id=self.addon.id).update(status=amo.STATUS_LITE)
-        File.objects.filter(id=self.f1.id).update(status=amo.STATUS_DISABLED)
+        File.objects.filter(id=self.f1.id).update(status=amo.STATUS_OBSOLETE)
         File.objects.filter(id=self.f2.id).update(status=amo.STATUS_UNREVIEWED)
         cron.hide_disabled_files()
         # Only f1 should have been moved.

--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -1123,7 +1123,7 @@ class TestAddonModels(amo.tests.TestCase):
 
     def test_can_request_review_rejected(self):
         addon = Addon.objects.get(pk=3615)
-        addon.latest_version.files.update(status=amo.STATUS_DISABLED)
+        addon.latest_version.files.update(status=amo.STATUS_OBSOLETE)
         eq_(addon.can_request_review(), ())
 
     def check(self, status, exp, kw={}):

--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -381,7 +381,7 @@ class APPROVE_VERSION_WAITING(_LOG):
     id = 53
     action_class = 'approve'
     format = _(u'{addon} {version} approved but waiting to be made public.')
-    short = _(u'Approved but waiting')
+    short = _(u'Approved but unpublished')
     keep = True
     review_email_user = True
     review_queue = True
@@ -639,6 +639,7 @@ class CHANGE_VERSION_STATUS(_LOG):
     # L10n: {0} is the status
     format = _(u'{version} status changed to {0}.')
     keep = True
+
 
 class DELETE_USER_LOOKUP(_LOG):
     id = 125

--- a/apps/api/tests/test_views.py
+++ b/apps/api/tests/test_views.py
@@ -265,7 +265,7 @@ class APITest(TestCase):
         self.assertContains(response,
                 """<guid>{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}</guid>""")
         self.assertContains(response, "<version>2.1.072</version>")
-        self.assertContains(response, '<status id="4">Fully Reviewed</status>')
+        self.assertContains(response, '<status id="4">Published</status>')
         self.assertContains(response,
             u'<author>55021 \u0627\u0644\u062a\u0637\u0628</author>')
         self.assertContains(response, "<summary>Delicious Bookmarks is the")

--- a/apps/constants/base.py
+++ b/apps/constants/base.py
@@ -21,13 +21,14 @@ STATUS_REJECTED = 12  # This applies only to apps (for now)
 STATUS_PUBLIC_WAITING = 13  # bug 740967
 STATUS_REVIEW_PENDING = 14  # Themes queue, reviewed, needs further action.
 STATUS_BLOCKED = 15
+STATUS_OBSOLETE = 16  # This applies only to files and versions.
 
 STATUS_CHOICES = {
     STATUS_NULL: _(u'Incomplete'),
     STATUS_UNREVIEWED: _(u'Awaiting Preliminary Review'),
     STATUS_PENDING: _(u'Pending approval'),
     STATUS_NOMINATED: _(u'Awaiting Full Review'),
-    STATUS_PUBLIC: _(u'Fully Reviewed'),
+    STATUS_PUBLIC: _(u'Published'),
     STATUS_DISABLED: _(u'Disabled by Mozilla'),
     STATUS_BETA: _(u'Beta'),
     STATUS_LITE: _(u'Preliminarily Reviewed'),
@@ -38,9 +39,10 @@ STATUS_CHOICES = {
     STATUS_REJECTED: _(u'Rejected'),
     # Approved, but the developer would like to put it public when they want.
     # The need to go to the marketplace and actualy make it public.
-    STATUS_PUBLIC_WAITING: _(u'Approved but waiting'),
+    STATUS_PUBLIC_WAITING: _(u'Approved but unpublished'),
     STATUS_REVIEW_PENDING: _(u'Flagged for further review'),
     STATUS_BLOCKED: _(u'Blocked'),
+    STATUS_OBSOLETE: _(u'Obsolete'),
 }
 
 # We need to expose nice values that aren't localisable.
@@ -60,6 +62,7 @@ STATUS_CHOICES_API = {
     STATUS_PUBLIC_WAITING: 'waiting',
     STATUS_REVIEW_PENDING: 'review-pending',
     STATUS_BLOCKED: 'blocked',
+    STATUS_OBSOLETE: 'obsolete',
 }
 
 STATUS_CHOICES_API_LOOKUP = {
@@ -78,6 +81,7 @@ STATUS_CHOICES_API_LOOKUP = {
     'waiting': STATUS_PUBLIC_WAITING,
     'review-pending': STATUS_REVIEW_PENDING,
     'blocked': STATUS_BLOCKED,
+    'obsolete': STATUS_OBSOLETE,
 }
 
 PUBLIC_IMMEDIATELY = None

--- a/apps/devhub/tasks.py
+++ b/apps/devhub/tasks.py
@@ -179,7 +179,7 @@ def flag_binary(ids, **kw):
         try:
             log.info('Validating addon with id: %s' % addon.pk)
             files = (File.objects.filter(version__addon=addon)
-                                 .exclude(status=amo.STATUS_DISABLED)
+                                 .exclude(status=amo.STATUS_OBSOLETE)
                                  .order_by('-created'))
             if latest:
                 files = [files[0]]

--- a/apps/devhub/tests/test_helpers.py
+++ b/apps/devhub/tests/test_helpers.py
@@ -207,5 +207,5 @@ class TestDevFilesStatus(amo.tests.TestCase):
 
     def test_disabled(self):
         self.addon.status = amo.STATUS_PUBLIC
-        self.file.status = amo.STATUS_DISABLED
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_DISABLED])
+        self.file.status = amo.STATUS_OBSOLETE
+        self.expect(amo.STATUS_CHOICES[amo.STATUS_OBSOLETE])

--- a/apps/devhub/tests/test_views_versions.py
+++ b/apps/devhub/tests/test_views_versions.py
@@ -310,7 +310,7 @@ class TestVersion(amo.tests.TestCase):
 
     def test_rejected_request_review(self):
         self.addon.update(status=amo.STATUS_NULL)
-        self.addon.latest_version.files.update(status=amo.STATUS_DISABLED)
+        self.addon.latest_version.files.update(status=amo.STATUS_OBSOLETE)
         doc = pq(self.client.get(self.url).content)
         buttons = doc('.version-status-actions form button').text()
         eq_(buttons, None)

--- a/apps/editors/forms.py
+++ b/apps/editors/forms.py
@@ -263,7 +263,7 @@ class ReviewAddonForm(happyforms.Form):
         self.fields['addon_files'].queryset = self.helper.all_files
         self.addon_files_disabled = (self.helper.all_files
                 # We can't review disabled, and public are already reviewed.
-                .filter(status__in=[amo.STATUS_DISABLED, amo.STATUS_PUBLIC])
+                .filter(status__in=[amo.STATUS_OBSOLETE, amo.STATUS_PUBLIC])
                 .values_list('pk', flat=True))
 
         # We're starting with an empty one, which will be hidden via CSS.

--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -41,14 +41,14 @@ def file_compare(file_obj, version):
 
 @register.function
 def file_review_status(addon, file):
-    if file.status not in [amo.STATUS_DISABLED, amo.STATUS_PUBLIC]:
+    if file.status not in [amo.STATUS_OBSOLETE, amo.STATUS_PUBLIC]:
         if addon.status in [amo.STATUS_UNREVIEWED, amo.STATUS_LITE]:
             return _(u'Pending Preliminary Review')
         elif addon.status in [amo.STATUS_NOMINATED,
                               amo.STATUS_LITE_AND_NOMINATED,
                               amo.STATUS_PUBLIC]:
             return _(u'Pending Full Review')
-    if file.status in [amo.STATUS_DISABLED, amo.STATUS_REJECTED]:
+    if file.status in [amo.STATUS_OBSOLETE, amo.STATUS_REJECTED]:
         if file.reviewed is not None:
             return _(u'Rejected')
         # Can't assume that if the reviewed date is missing its
@@ -301,7 +301,7 @@ log = commonware.log.getLogger('z.mailer')
 NOMINATED_STATUSES = (amo.STATUS_NOMINATED, amo.STATUS_LITE_AND_NOMINATED)
 PRELIMINARY_STATUSES = (amo.STATUS_UNREVIEWED, amo.STATUS_LITE)
 PENDING_STATUSES = (amo.STATUS_BETA, amo.STATUS_DISABLED, amo.STATUS_NULL,
-                    amo.STATUS_PENDING, amo.STATUS_PUBLIC)
+                    amo.STATUS_PENDING, amo.STATUS_PUBLIC, amo.STATUS_OBSOLETE)
 
 
 def send_mail(template, subject, emails, context, perm_setting=None):
@@ -643,7 +643,7 @@ class ReviewAddon(ReviewBase):
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         self.notify_email('%s_to_public' % self.review_type,
-                          u'Mozilla Add-ons: %s %s Fully Reviewed')
+                          u'Mozilla Add-ons: %s %s Published')
 
         log.info(u'Making %s public' % (self.addon))
         log.info(u'Sending email for %s' % (self.addon))
@@ -664,7 +664,7 @@ class ReviewAddon(ReviewBase):
         else:
             self.set_addon(status=amo.STATUS_LITE)
 
-        self.set_files(amo.STATUS_DISABLED, self.version.files.all(),
+        self.set_files(amo.STATUS_OBSOLETE, self.version.files.all(),
                        hide_disabled_file=True)
 
         self.log_action(amo.LOG.REJECT_VERSION)
@@ -736,7 +736,7 @@ class ReviewFiles(ReviewBase):
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         self.notify_email('%s_to_public' % self.review_type,
-                          u'Mozilla Add-ons: %s %s Fully Reviewed')
+                          u'Mozilla Add-ons: %s %s Published')
 
         log.info(u'Making %s files %s public' %
                  (self.addon,
@@ -751,7 +751,7 @@ class ReviewFiles(ReviewBase):
         # Hold onto the status before we change it.
         status = self.addon.status
 
-        self.set_files(amo.STATUS_DISABLED, self.data['addon_files'],
+        self.set_files(amo.STATUS_OBSOLETE, self.data['addon_files'],
                        hide_disabled_file=True)
 
         self.log_action(amo.LOG.REJECT_VERSION)

--- a/apps/editors/tests/test_models.py
+++ b/apps/editors/tests/test_models.py
@@ -425,6 +425,7 @@ class TestReviewerScore(amo.tests.TestCase):
             amo.STATUS_PUBLIC_WAITING: None,
             amo.STATUS_REVIEW_PENDING: None,
             amo.STATUS_BLOCKED: None,
+            amo.STATUS_OBSOLETE: None,
         }
         for tk, tv in types.items():
             for sk, sv in statuses.items():

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -2065,13 +2065,13 @@ class TestReviewPreliminary(ReviewBase):
     def test_prelim_multiple_files(self):
         f = self.version.files.all()[0]
         f.pk = None
-        f.status = amo.STATUS_DISABLED
+        f.status = amo.STATUS_OBSOLETE
         f.save()
         self.addon.update(status=amo.STATUS_LITE)
         data = self.prelim_dict()
         data['addon_files'] = [f.pk]
         self.client.post(self.url, data)
-        eq_([amo.STATUS_DISABLED, amo.STATUS_LITE],
+        eq_([amo.STATUS_OBSOLETE, amo.STATUS_LITE],
             [f.status for f in self.version.files.all().order_by('status')])
 
 
@@ -2102,7 +2102,7 @@ class TestReviewPending(ReviewBase):
 
     def test_disabled_file(self):
         obj = File.objects.create(version=self.version,
-                                  status=amo.STATUS_DISABLED)
+                                  status=amo.STATUS_OBSOLETE)
         response = self.client.get(self.url, self.pending_dict())
         doc = pq(response.content)
         assert 'disabled' in doc('#file-%s' % obj.pk)[0].keys()
@@ -2184,7 +2184,7 @@ class TestStatusFile(ReviewBase):
         self.get_file().update(status=amo.STATUS_PUBLIC)
         for status in set(amo.STATUS_UNDER_REVIEW + amo.LITE_STATUSES):
             self.addon.update(status=status)
-            self.check_status('Fully Reviewed')
+            self.check_status('Published')
 
     def test_other(self):
         self.addon.update(status=amo.STATUS_BETA)

--- a/apps/files/forms.py
+++ b/apps/files/forms.py
@@ -21,14 +21,14 @@ class FileSelectWidget(widgets.Select):
             addon = files[0].version.addon
             # Make sure that if there's a non-disabled version,
             # that's the one we use for the ID.
-            files.sort(lambda a, b: ((a.status == amo.STATUS_DISABLED) -
-                                     (b.status == amo.STATUS_DISABLED)))
+            files.sort(lambda a, b: ((a.status == amo.STATUS_OBSOLETE) -
+                                     (b.status == amo.STATUS_OBSOLETE)))
 
             if label is None:
                 label = u', '.join(unicode(os.platform) for os in f)
 
             output = [u'<option value="', jinja2.escape(files[0].id), u'" ']
-            if files[0].status == amo.STATUS_DISABLED:
+            if files[0].status == amo.STATUS_OBSOLETE:
                 # Disabled files can be diffed on Marketplace.
                 if addon.type != amo.ADDON_WEBAPP:
                     output.append(u' disabled')

--- a/apps/files/helpers.py
+++ b/apps/files/helpers.py
@@ -72,7 +72,7 @@ class FileViewer(object):
         self.addon = self.file.version.addon
         self.is_webapp = is_webapp
         self.src = (file_obj.guarded_file_path
-                    if file_obj.status == amo.STATUS_DISABLED
+                    if file_obj.status == amo.STATUS_OBSOLETE
                     else file_obj.file_path)
         self.dest = os.path.join(settings.TMP_PATH, 'file_viewer',
                                  str(file_obj.pk))

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -121,7 +121,7 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
 
         if attachment:
             host = posixpath.join(settings.LOCAL_MIRROR_URL, '_attachments')
-        elif addon.is_disabled or self.status == amo.STATUS_DISABLED:
+        elif addon.is_disabled or self.status == amo.STATUS_OBSOLETE:
             host = settings.PRIVATE_MIRROR_URL
         elif (addon.status == amo.STATUS_PUBLIC
               and not addon.disabled_by_user
@@ -460,9 +460,9 @@ def check_file(old_attr, new_attr, instance, sender, **kw):
     if kw.get('raw'):
         return
     old, new = old_attr.get('status'), instance.status
-    if new == amo.STATUS_DISABLED and old != amo.STATUS_DISABLED:
+    if new == amo.STATUS_OBSOLETE and old != amo.STATUS_OBSOLETE:
         instance.hide_disabled_file()
-    elif old == amo.STATUS_DISABLED and new != amo.STATUS_DISABLED:
+    elif old == amo.STATUS_OBSOLETE and new != amo.STATUS_OBSOLETE:
         instance.unhide_disabled_file()
     elif (new in amo.MIRROR_STATUSES and old not in amo.MIRROR_STATUSES):
         instance.copy_to_mirror()

--- a/apps/files/tests/test_models.py
+++ b/apps/files/tests/test_models.py
@@ -123,7 +123,7 @@ class TestFile(amo.tests.TestCase, amo.tests.AMOPaths):
         f.save()
         assert not hide_mock.called
 
-        f.status = amo.STATUS_DISABLED
+        f.status = amo.STATUS_OBSOLETE
         f.save()
         assert hide_mock.called
 
@@ -135,7 +135,7 @@ class TestFile(amo.tests.TestCase, amo.tests.AMOPaths):
         assert not unhide_mock.called
 
         f = File.objects.get(pk=67442)
-        f.status = amo.STATUS_DISABLED
+        f.status = amo.STATUS_OBSOLETE
         f.save()
         assert not unhide_mock.called
 
@@ -162,7 +162,7 @@ class TestFile(amo.tests.TestCase, amo.tests.AMOPaths):
                 fp.write('<pretend this is an xpi>')
             with storage.open(fo.mirror_file_path, 'wb') as fp:
                 fp.write('<pretend this is an xpi>')
-            fo.status = amo.STATUS_DISABLED
+            fo.status = amo.STATUS_OBSOLETE
             fo.save()
             assert not storage.exists(fo.file_path), 'file not hidden'
             assert not storage.exists(fo.mirror_file_path), (
@@ -317,7 +317,7 @@ class TestFile(amo.tests.TestCase, amo.tests.AMOPaths):
 
     def test_disabled_is_not_testable(self):
         f = File.objects.get(pk=67442)
-        f.update(status=amo.STATUS_DISABLED)
+        f.update(status=amo.STATUS_OBSOLETE)
         eq_(f.can_be_perf_tested(), False)
 
     def test_deleted_addon_is_not_testable(self):
@@ -334,7 +334,7 @@ class TestFile(amo.tests.TestCase, amo.tests.AMOPaths):
         f = File.objects.get(pk=67442)
         eq_(f.is_mirrorable(), True)
 
-        f.update(status=amo.STATUS_DISABLED)
+        f.update(status=amo.STATUS_OBSOLETE)
         eq_(f.is_mirrorable(), False)
 
     def test_premium_addon_not_mirrorable(self):

--- a/apps/files/tests/test_views.py
+++ b/apps/files/tests/test_views.py
@@ -295,7 +295,7 @@ class FilesBase:
         eq_(files.eq(1).attr('value'), str(self.files[1].id))
 
     def test_file_chooser_disabled_coalescing(self):
-        self.files[1].update(status=amo.STATUS_DISABLED)
+        self.files[1].update(status=amo.STATUS_OBSOLETE)
 
         res = self.client.get(self.file_url())
         doc = pq(res.content)

--- a/apps/files/utils.py
+++ b/apps/files/utils.py
@@ -556,7 +556,7 @@ def find_jetpacks(minver, maxver, from_builder_only=False):
                                  version__addon__auto_repackage=True,
                                  version__addon__status__in=statuses,
                                  version__addon__disabled_by_user=False)
-             .exclude(status=amo.STATUS_DISABLED).no_cache()
+             .exclude(status=amo.STATUS_OBSOLETE).no_cache()
              .select_related('version'))
     if from_builder_only:
         files = files.exclude(builder_version=None)

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -466,7 +466,7 @@ class Version(amo.models.ModelBase):
                                                  amo.STATUS_PENDING])
             # Use File.update so signals are triggered.
             for f in qs:
-                f.update(status=amo.STATUS_DISABLED)
+                f.update(status=amo.STATUS_OBSOLETE)
 
     @property
     def developer_name(self):

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -283,7 +283,7 @@ class TestVersion(amo.tests.TestCase):
         qs.update(status=amo.STATUS_UNREVIEWED)
         version = Version.objects.create(addon=addon)
         version.disable_old_files()
-        eq_(qs.all()[0].status, amo.STATUS_DISABLED)
+        eq_(qs.all()[0].status, amo.STATUS_OBSOLETE)
         addon.current_version.all_files[0]
         assert hide_mock.called
 
@@ -567,27 +567,27 @@ class TestDownloads(TestDownloadsBase):
         eq_(self.client.get(self.file_url).status_code, 404)
 
     def test_file_disabled_anon_404(self):
-        self.file.update(status=amo.STATUS_DISABLED)
+        self.file.update(status=amo.STATUS_OBSOLETE)
         eq_(self.client.get(self.file_url).status_code, 404)
 
     def test_file_disabled_unprivileged_404(self):
         assert self.client.login(username='regular@mozilla.com',
                                  password='password')
-        self.file.update(status=amo.STATUS_DISABLED)
+        self.file.update(status=amo.STATUS_OBSOLETE)
         eq_(self.client.get(self.file_url).status_code, 404)
 
     def test_file_disabled_ok_for_author(self):
-        self.file.update(status=amo.STATUS_DISABLED)
+        self.file.update(status=amo.STATUS_OBSOLETE)
         assert self.client.login(username='g@gmail.com', password='password')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_file_disabled_ok_for_editor(self):
-        self.file.update(status=amo.STATUS_DISABLED)
+        self.file.update(status=amo.STATUS_OBSOLETE)
         self.client.login(username='editor@mozilla.com', password='password')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_file_disabled_ok_for_admin(self):
-        self.file.update(status=amo.STATUS_DISABLED)
+        self.file.update(status=amo.STATUS_OBSOLETE)
         self.client.login(username='admin@mozilla.com', password='password')
         self.assert_served_internally(self.client.get(self.file_url))
 
@@ -910,7 +910,7 @@ class TestStatusFromUpload(TestVersionFromUpload):
         qs = File.objects.filter(version=self.current)
         Version.from_upload(self.upload, self.addon, [self.platform])
         eq_(sorted([q.status for q in qs.all()]),
-            [amo.STATUS_PUBLIC, amo.STATUS_DISABLED])
+            [amo.STATUS_PUBLIC, amo.STATUS_OBSOLETE])
 
     @mock.patch('files.utils.parse_addon')
     def test_status_beta(self, parse_addon):

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -87,7 +87,7 @@ def download_file(request, file_id, type=None):
     if addon.is_premium():
         raise PermissionDenied
 
-    if addon.is_disabled or file.status == amo.STATUS_DISABLED:
+    if addon.is_disabled or file.status == amo.STATUS_OBSOLETE:
         if (acl.check_addon_ownership(request, addon, viewer=True,
                                       ignore_disabled=True) or
             acl.check_reviewer(request)):

--- a/apps/zadmin/tests/test_views.py
+++ b/apps/zadmin/tests/test_views.py
@@ -978,7 +978,7 @@ class TestBulkValidationTask(BulkValidationTest):
     def test_public_partial(self):
         self.create_version(self.addon, [amo.STATUS_PUBLIC])
         new_version = self.create_version(self.addon, [amo.STATUS_BETA,
-                                                       amo.STATUS_DISABLED])
+                                                       amo.STATUS_OBSOLETE])
         ids = self.find_files()
         eq_(len(ids), 2)
         assert new_version.files.all()[1].pk not in ids

--- a/migrations/689-obsolete-status.sql
+++ b/migrations/689-obsolete-status.sql
@@ -1,0 +1,1 @@
+UPDATE files SET status=16 where STATUS=5;

--- a/mkt/developers/tests/test_helpers.py
+++ b/mkt/developers/tests/test_helpers.py
@@ -199,10 +199,10 @@ class TestDevFilesStatus(amo.tests.TestCase):
         self.file.status = amo.STATUS_PUBLIC
         self.expect(amo.STATUS_CHOICES[amo.STATUS_PUBLIC])
 
-    def test_disabled(self):
+    def test_obsolete(self):
         self.addon.status = amo.STATUS_PUBLIC
-        self.file.status = amo.STATUS_DISABLED
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_DISABLED])
+        self.file.status = amo.STATUS_OBSOLETE
+        self.expect(amo.STATUS_CHOICES[amo.STATUS_OBSOLETE])
 
 
 class TestDevAgreement(amo.tests.TestCase):

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -550,7 +550,7 @@ class TestStatus(amo.tests.TestCase):
     def setUp(self):
         self.webapp = Addon.objects.get(id=337141)
         self.file = self.webapp.versions.latest().all_files[0]
-        self.file.update(status=amo.STATUS_DISABLED)
+        self.file.update(status=amo.STATUS_OBSOLETE)
         self.status_url = self.webapp.get_dev_url('versions')
         assert self.client.login(username='steamcube@mozilla.com',
                                  password='password')

--- a/mkt/developers/tests/test_views_edit.py
+++ b/mkt/developers/tests/test_views_edit.py
@@ -155,7 +155,7 @@ class TestEditListingWebapp(TestEdit):
 
         # Disable file for latest version, and then update app.current_version.
         app = self.get_webapp()
-        app.versions.latest().all_files[0].update(status=amo.STATUS_DISABLED)
+        app.versions.latest().all_files[0].update(status=amo.STATUS_OBSOLETE)
         app.update_version()
 
         # Now try to display edit page.
@@ -483,7 +483,7 @@ class TestEditBasic(TestEdit):
 
         # Disable file for latest version, and then update app.current_version.
         app = self.get_webapp()
-        app.versions.latest().all_files[0].update(status=amo.STATUS_DISABLED)
+        app.versions.latest().all_files[0].update(status=amo.STATUS_OBSOLETE)
         app.update_version()
 
         # Now try to display edit page.
@@ -1151,7 +1151,7 @@ class TestEditTechnical(TestEdit):
         # Reject the app.
         app = self.get_webapp()
         app.update(status=amo.STATUS_REJECTED)
-        app.versions.latest().all_files[0].update(status=amo.STATUS_DISABLED)
+        app.versions.latest().all_files[0].update(status=amo.STATUS_OBSOLETE)
         app.update_version()
 
         assert not RereviewQueue.objects.filter(addon=self.webapp).exists()

--- a/mkt/developers/tests/test_views_versions.py
+++ b/mkt/developers/tests/test_views_versions.py
@@ -89,7 +89,7 @@ class TestVersion(amo.tests.TestCase):
                 details={'comments': comments, 'reviewtype': 'pending'})
         self.webapp.update(status=amo.STATUS_REJECTED)
         (self.webapp.versions.latest()
-                             .all_files[0].update(status=amo.STATUS_DISABLED))
+                             .all_files[0].update(status=amo.STATUS_OBSOLETE))
 
         r = self.client.get(self.url)
         eq_(r.status_code, 200)
@@ -118,7 +118,7 @@ class TestVersion(amo.tests.TestCase):
         self.webapp.update(status=amo.STATUS_REJECTED)
         amo.set_user(UserProfile.objects.get(username='admin'))
         (self.webapp.versions.latest()
-                             .all_files[0].update(status=amo.STATUS_DISABLED))
+                             .all_files[0].update(status=amo.STATUS_OBSOLETE))
         my_reply = 'no give up'
         self.client.post(self.url, {'notes': my_reply,
                                     'resubmit-app': ''})
@@ -135,7 +135,7 @@ class TestVersion(amo.tests.TestCase):
                 details={'comments': comments, 'reviewtype': 'pending'})
         self.webapp.update(status=amo.STATUS_REJECTED)
         (self.webapp.versions.latest()
-                             .all_files[0].update(status=amo.STATUS_DISABLED))
+                             .all_files[0].update(status=amo.STATUS_OBSOLETE))
 
         r = self.client.get(self.url)
         eq_(r.status_code, 200)
@@ -194,7 +194,7 @@ class TestAddVersion(BasePackagedAppTest):
                                         created=self.days_ago(1))
         self.app.update(status=amo.STATUS_REJECTED)
         files = File.objects.filter(version__addon=self.app)
-        files.update(status=amo.STATUS_DISABLED)
+        files.update(status=amo.STATUS_OBSOLETE)
         self._post(302)
         self.app.reload()
         version = self.app.versions.latest()
@@ -227,7 +227,7 @@ class TestAddVersion(BasePackagedAppTest):
                                         created=self.days_ago(1))
         self.app.update(status=amo.STATUS_BLOCKED)
         files = File.objects.filter(version__addon=self.app)
-        files.update(status=amo.STATUS_DISABLED)
+        files.update(status=amo.STATUS_OBSOLETE)
         self._post(302)
         version = self.app.versions.latest()
         eq_(version.version, '1.0')
@@ -242,7 +242,7 @@ class TestAddVersion(BasePackagedAppTest):
                                         created=self.days_ago(1))
         self.app.update(status=amo.STATUS_NULL)
         files = File.objects.filter(version__addon=self.app)
-        files.update(status=amo.STATUS_DISABLED)
+        files.update(status=amo.STATUS_OBSOLETE)
         self._post(302)
         self.app.reload()
         version = self.app.versions.latest()

--- a/mkt/downloads/views.py
+++ b/mkt/downloads/views.py
@@ -17,7 +17,7 @@ def download_file(request, file_id, type=None):
     webapp = get_object_or_404(Webapp, pk=file.version.addon_id,
                                is_packaged=True)
 
-    if webapp.is_disabled or file.status == amo.STATUS_DISABLED:
+    if webapp.is_disabled or file.status == amo.STATUS_OBSOLETE:
         if not acl.check_addon_ownership(request, webapp, viewer=True,
                                          ignore_disabled=True):
             raise http.Http404()

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -415,7 +415,7 @@ class TestAppQueue(AppReviewerTest, AccessMixin, FlagsMixin, SearchMixin,
     def test_action_buttons_rejected(self):
         # Check action buttons for a previously rejected app.
         self.apps[0].update(status=amo.STATUS_REJECTED)
-        self.apps[0].latest_version.files.update(status=amo.STATUS_DISABLED)
+        self.apps[0].latest_version.files.update(status=amo.STATUS_OBSOLETE)
         r = self.client.get(self.review_url(self.apps[0]))
         eq_(r.status_code, 200)
         actions = pq(r.content)('#review-actions input')
@@ -617,7 +617,7 @@ class TestRereviewQueue(AppReviewerTest, AccessMixin, FlagsMixin, SearchMixin,
 
     def test_action_buttons_reject(self):
         self.apps[0].update(status=amo.STATUS_REJECTED)
-        self.apps[0].latest_version.files.update(status=amo.STATUS_DISABLED)
+        self.apps[0].latest_version.files.update(status=amo.STATUS_OBSOLETE)
         r = self.client.get(self.review_url(self.apps[0]))
         eq_(r.status_code, 200)
         actions = pq(r.content)('#review-actions input')
@@ -747,7 +747,7 @@ class TestUpdateQueue(AppReviewerTest, AccessMixin, FlagsMixin, SearchMixin,
         self.check_actions(expected, actions)
 
     def test_action_buttons_reject(self):
-        self.apps[0].versions.latest().files.update(status=amo.STATUS_DISABLED)
+        self.apps[0].versions.latest().files.update(status=amo.STATUS_OBSOLETE)
 
         r = self.client.get(self.review_url(self.apps[0]))
         eq_(r.status_code, 200)
@@ -1014,7 +1014,7 @@ class TestEscalationQueue(AppReviewerTest, AccessMixin, FlagsMixin,
 
     def test_action_buttons_reject(self):
         self.apps[0].update(status=amo.STATUS_REJECTED)
-        self.apps[0].latest_version.files.update(status=amo.STATUS_DISABLED)
+        self.apps[0].latest_version.files.update(status=amo.STATUS_OBSOLETE)
         r = self.client.get(self.review_url(self.apps[0]))
         eq_(r.status_code, 200)
         actions = pq(r.content)('#review-actions input')
@@ -1284,7 +1284,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
 
         eq_(len(mail.outbox), 1)
         msg = mail.outbox[0]
-        self._check_email(msg, 'App Approved but waiting')
+        self._check_email(msg, 'App Approved but unpublished')
         self._check_email_body(msg)
 
     def test_pending_to_reject_w_device_overrides(self):
@@ -1489,7 +1489,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
 
         eq_(len(mail.outbox), 1)
         msg = mail.outbox[0]
-        self._check_email(msg, 'App Approved but waiting')
+        self._check_email(msg, 'App Approved but unpublished')
         self._check_email_body(msg)
         self._check_score(amo.REVIEWED_WEBAPP_HOSTED)
 
@@ -1517,7 +1517,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(data)
         app = self.get_app()
         eq_(app.status, amo.STATUS_REJECTED)
-        eq_(File.objects.filter(id__in=files)[0].status, amo.STATUS_DISABLED)
+        eq_(File.objects.filter(id__in=files)[0].status, amo.STATUS_OBSOLETE)
         self._check_log(amo.LOG.REJECT_VERSION)
 
         eq_(len(mail.outbox), 1)
@@ -1537,7 +1537,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(data)
         app = self.get_app()
         eq_(app.status, amo.STATUS_REJECTED)
-        eq_(new_version.files.all()[0].status, amo.STATUS_DISABLED)
+        eq_(new_version.files.all()[0].status, amo.STATUS_OBSOLETE)
         self._check_log(amo.LOG.REJECT_VERSION)
 
         eq_(len(mail.outbox), 1)
@@ -1556,7 +1556,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(data)
         app = self.get_app()
         eq_(app.status, amo.STATUS_PUBLIC)
-        eq_(new_version.files.all()[0].status, amo.STATUS_DISABLED)
+        eq_(new_version.files.all()[0].status, amo.STATUS_OBSOLETE)
         self._check_log(amo.LOG.REJECT_VERSION)
 
         eq_(len(mail.outbox), 1)
@@ -1590,7 +1590,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(data)
         app = self.get_app()
         eq_(app.status, amo.STATUS_DISABLED)
-        eq_(app.current_version.files.all()[0].status, amo.STATUS_DISABLED)
+        eq_(app.current_version.files.all()[0].status, amo.STATUS_OBSOLETE)
         self._check_log(amo.LOG.APP_DISABLED)
         eq_(len(mail.outbox), 1)
         self._check_email(mail.outbox[0], 'App disabled by reviewer')
@@ -1633,7 +1633,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(data, queue='escalated')
         app = self.get_app()
         eq_(app.status, amo.STATUS_REJECTED)
-        eq_(File.objects.filter(id__in=files)[0].status, amo.STATUS_DISABLED)
+        eq_(File.objects.filter(id__in=files)[0].status, amo.STATUS_OBSOLETE)
         self._check_log(amo.LOG.REJECT_VERSION)
         eq_(EscalationQueue.objects.count(), 0)
 
@@ -1653,7 +1653,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(data, queue='escalated')
         app = self.get_app()
         eq_(app.status, amo.STATUS_DISABLED)
-        eq_(app.current_version.files.all()[0].status, amo.STATUS_DISABLED)
+        eq_(app.current_version.files.all()[0].status, amo.STATUS_OBSOLETE)
         self._check_log(amo.LOG.APP_DISABLED)
         eq_(EscalationQueue.objects.count(), 0)
         eq_(len(mail.outbox), 1)
@@ -2527,7 +2527,7 @@ class TestMiniManifestView(BasePackagedAppTest):
         # Rejected sets file.status to DISABLED and moves to a guarded path.
         self.setup_files()
         self.app.update(status=amo.STATUS_REJECTED)
-        self.file.update(status=amo.STATUS_DISABLED)
+        self.file.update(status=amo.STATUS_OBSOLETE)
         manifest = self.app.get_manifest_json(self.file)
 
         res = self.client.get(self.url)

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -260,7 +260,7 @@ class ReviewApp(ReviewBase):
 
         self.log_action(amo.LOG.APPROVE_VERSION_WAITING)
         self.notify_email('pending_to_public_waiting',
-                          u'App Approved but waiting: %s')
+                          u'App Approved but unpublished: %s')
 
         log.info(u'Making %s public but pending' % self.addon)
         log.info(u'Sending email for %s' % self.addon)
@@ -300,7 +300,7 @@ class ReviewApp(ReviewBase):
         # Hold onto the status before we change it.
         status = self.addon.status
 
-        self.set_files(amo.STATUS_DISABLED, self.version.files.all(),
+        self.set_files(amo.STATUS_OBSOLETE, self.version.files.all(),
                        hide_disabled_file=True)
         # If this app is not packaged (packaged apps can have multiple
         # versions) or if there aren't other versions with already reviewed
@@ -360,7 +360,7 @@ class ReviewApp(ReviewBase):
             return
 
         # Disable disables all files, not just those in this version.
-        self.set_files(amo.STATUS_DISABLED,
+        self.set_files(amo.STATUS_OBSOLETE,
                        File.objects.filter(version__addon=self.addon),
                        hide_disabled_file=True)
         self.addon.update(status=amo.STATUS_DISABLED)
@@ -492,7 +492,7 @@ class ReviewHelper(object):
                 self.addon.status not in [amo.STATUS_REJECTED,
                                           amo.STATUS_DISABLED]):
                 actions['reject'] = reject
-            elif multiple_versions and amo.STATUS_DISABLED not in file_status:
+            elif multiple_versions and amo.STATUS_OBSOLETE not in file_status:
                 actions['reject'] = reject
         elif not self.addon.is_packaged:
             # Hosted apps reject the app itself.
@@ -503,7 +503,7 @@ class ReviewHelper(object):
         # Disable.
         if (acl.action_allowed(self.handler.request, 'Addons', 'Edit') and (
                 self.addon.status != amo.STATUS_DISABLED or
-                amo.STATUS_DISABLED not in file_status)):
+                amo.STATUS_OBSOLETE not in file_status)):
             actions['disable'] = disable
 
         # Clear escalation.

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -344,7 +344,7 @@ class Webapp(Addon):
             # TODO: Remove this when we're satisified the above is working.
             log.info('Falling back to loading manifest from file system. '
                      'Webapp:%s File:%s' % (self.id, file_.id))
-            if file_.status == amo.STATUS_DISABLED:
+            if file_.status == amo.STATUS_OBSOLETE:
                 file_path = file_.guarded_file_path
             else:
                 file_path = file_.file_path

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -434,7 +434,7 @@ def import_manifests(ids, **kw):
         for version in app.versions.all():
             try:
                 file_ = version.files.latest()
-                if file_.status == amo.STATUS_DISABLED:
+                if file_.status == amo.STATUS_OBSOLETE:
                     file_path = file_.guarded_file_path
                 else:
                     file_path = file_.file_path

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -569,7 +569,7 @@ class TestPackagedAppManifestUpdates(amo.tests.TestCase):
             'name': u'Good App Name',
         }
         latest_version = version_factory(addon=self.webapp, version='2.3',
-            file_kw=dict(status=amo.STATUS_DISABLED))
+            file_kw=dict(status=amo.STATUS_OBSOLETE))
         current_version = self.webapp.current_version
         AppManifest.objects.create(version=current_version,
                                    manifest=json.dumps(good_manifest))
@@ -759,7 +759,7 @@ class TestPackagedManifest(BasePackagedAppTest):
         # Post an app, then emulate a reviewer reject and add a new, pending
         # version.
         webapp = self.post_addon()
-        webapp.latest_version.files.update(status=amo.STATUS_DISABLED)
+        webapp.latest_version.files.update(status=amo.STATUS_OBSOLETE)
         webapp.latest_version.update(created=self.days_ago(1))
         webapp.update(status=amo.STATUS_REJECTED, _current_version=None)
         version = version_factory(addon=webapp, version='2.0',
@@ -1125,7 +1125,7 @@ class TestUpdateStatus(amo.tests.TestCase):
 
     def test_one_version_pending(self):
         app = amo.tests.app_factory(status=amo.STATUS_REJECTED,
-                                    file_kw=dict(status=amo.STATUS_DISABLED))
+                                    file_kw=dict(status=amo.STATUS_OBSOLETE))
         amo.tests.version_factory(addon=app,
                                   file_kw=dict(status=amo.STATUS_PENDING))
         app.update_status()
@@ -1134,7 +1134,7 @@ class TestUpdateStatus(amo.tests.TestCase):
     def test_one_version_public(self):
         app = amo.tests.app_factory(status=amo.STATUS_PUBLIC)
         amo.tests.version_factory(addon=app,
-                                  file_kw=dict(status=amo.STATUS_DISABLED))
+                                  file_kw=dict(status=amo.STATUS_OBSOLETE))
         app.update_status()
         eq_(app.status, amo.STATUS_PUBLIC)
 


### PR DESCRIPTION
![screen shot 2013-10-16 at 6 32 16 pm](https://f.cloud.github.com/assets/674727/1348578/fb2cb0ea-36cb-11e3-956f-4fc09603a3b6.png)

https://bugzilla.mozilla.org/show_bug.cgi?id=895560

Fully Reviewed => Published
Disabled by Mozilla => Obsolete
Approved but waiting => Approved but unpublished

Passing Test Suites
- apps.files
- apps.versions
- mkt.developers
- mkt.reviewers

Manually tested by submitting a packaged app, publishing the app, uploading new versions of the app, disabling the app.
