### PR TITLE
strip carriage returns from theme description (bug 922744)

### DIFF
--- a/apps/devhub/templates/devhub/personas/edit.html
+++ b/apps/devhub/templates/devhub/personas/edit.html
@@ -113,7 +113,7 @@
             <div class="note">
               {{ some_html_tip() }}
               <span class="char-count" data-for-startswith="id_description"
-                    data-maxlength="{{ form.description.field.max_length }}"></span>
+                    data-maxlength="{{ form.DESCRIPTION_MAX_LENGTH }}"></span>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
Carriage returns counted as one character to the JS (\n), but two characters to Python (\r\n).

The character counter on the front-end becomes incorrect as it counts carriage returns (\r\n) as one character rather than two, but Django counts it as two. This causes inconsistencies between the frontend and backend validation. 

Strip the `\r`s for the description `TransField` in Django clean to make Django count them as one.
