### PR TITLE
count line breaks as two chars in char counter (bug 922744)

### DIFF
--- a/media/js/zamboni/global.js
+++ b/media/js/zamboni/global.js
@@ -482,7 +482,9 @@ function initCharCount() {
         var $el = $(el),
             val = $el.val(),
             max = parseInt(cc.attr('data-maxlength'), 10),
-            left = max - val.length;
+            // Count \r\n as one character, not two.
+            lineBreaks = val.split('\n').length - 1,
+            left = max - val.length - lineBreaks;
         // L10n: {0} is the number of characters left.
         cc.html(format(ngettext('<b>{0}</b> character left.',
                                 '<b>{0}</b> characters left.', left), [left]))


### PR DESCRIPTION
Related to https://github.com/mozilla/zamboni/pull/1237

In the character counter js, \r\n gets counted as one character. 

In Django, \r\n gets counter as two characters.

Inconsistencies in field length validation. Force js to think of them as two.
