### PR TITLE
Add validation rule preventing operator shelves from beign associated with categories in API (bug 923231)

### DIFF
--- a/mkt/collections/serializers.py
+++ b/mkt/collections/serializers.py
@@ -168,6 +168,26 @@ class CollectionSerializer(serializers.ModelSerializer):
             del native['can_be_hero']
         return native
 
+    def validate(self, attrs):
+        """
+        Prevent operator shelves from being associated with a category.
+        """
+        existing = getattr(self, 'object')
+        exc = 'Operator shelves may not be associated with a category.'
+
+        if (not existing and attrs['collection_type'] ==
+            COLLECTIONS_TYPE_OPERATOR and attrs.get('category')):
+            raise serializers.ValidationError(exc)
+
+        elif existing:
+            collection_type = attrs.get('collection_type',
+                                        existing.collection_type)
+            category = attrs.get('category', existing.category)
+            if collection_type == COLLECTIONS_TYPE_OPERATOR and category:
+                raise serializers.ValidationError(exc)
+
+        return attrs
+
     def full_clean(self, instance):
         instance = super(CollectionSerializer, self).full_clean(instance)
         if not instance:

--- a/mkt/collections/tests/test_serializers.py
+++ b/mkt/collections/tests/test_serializers.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from nose.tools import eq_, ok_
+from rest_framework import serializers
 from tastypie.bundle import Bundle
 from test_utils import RequestFactory
 
+import amo
 import amo.tests
+from addons.models import Category
 from amo.urlresolvers import reverse
 
 from mkt.api.resources import AppResource
@@ -170,6 +173,19 @@ class TestCollectionSerializer(CollectionDataMixin, amo.tests.TestCase):
         keys = data['apps'][0].keys()
         ok_('name' in keys)
         ok_('id' in keys)
+
+    def validate(self, **kwargs):
+        return self.serializer.validate(kwargs)
+
+    def test_validation_operatorshelf_category(self):
+        category = Category.objects.create(name='BastaCorp', slug='basta',
+                                           type=amo.ADDON_WEBAPP)
+        ok_(self.validate(collection_type=COLLECTIONS_TYPE_BASIC,
+                          category=category))
+        ok_(self.validate(collection_type=COLLECTIONS_TYPE_OPERATOR))
+        with self.assertRaises(serializers.ValidationError):
+            self.validate(collection_type=COLLECTIONS_TYPE_OPERATOR,
+                          category=category)
 
 
 IMAGE_DATA = """


### PR DESCRIPTION
r? @diox @robhudson
