### PR TITLE
Don't try to `update_version` if the addon is not in db yet.

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -847,7 +847,7 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
     @property
     def current_version(self):
         "Returns the current_version field or updates it if needed."
-        if self.status == amo.STATUS_DELETED:
+        if not self.id or self.status == amo.STATUS_DELETED:
             return None
         try:
             if not self._current_version:
@@ -858,7 +858,7 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
 
     @property
     def latest_version(self):
-        if self.status == amo.STATUS_DELETED:
+        if not self.id or self.status == amo.STATUS_DELETED:
             return None
         try:
             if not self._latest_version:

--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -307,6 +307,18 @@ class TestAddonModels(amo.tests.TestCase):
         eq_(a.latest_version, version)
         eq_(a._latest_version, version)
 
+    @patch('addons.models.Addon.update_version')
+    def test_current_version_unsaved(self, update_version):
+        a = Addon()
+        eq_(a.current_version, None)
+        assert not update_version.called
+
+    @patch('addons.models.Addon.update_version')
+    def test_latest_version_unsaved(self, update_version):
+        a = Addon()
+        eq_(a.latest_version, None)
+        assert not update_version.called
+
     def test_current_beta_version(self):
         a = Addon.objects.get(pk=5299)
         eq_(a.current_beta_version.id, 50000)


### PR DESCRIPTION
r? @diox

I noticed this happening in the logs a lot so I thought I'd nip it in the bud.
