### PR TITLE
fix reuploading of legacy getpersonas themes (bug 921214)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1788,6 +1788,14 @@ class Persona(caching.CachingMixin, models.Model):
             return self._image_url('preview.jpg')
 
     @amo.cached_property
+    def thumb_path(self):
+        """Path to Persona's thumbnail preview."""
+        if self.is_new():
+            return self._image_path('preview.png')
+        else:
+            return self._image_path('preview.jpg')
+
+    @amo.cached_property
     def icon_url(self):
         """URL to personas square preview."""
         if self.is_new():
@@ -1796,12 +1804,28 @@ class Persona(caching.CachingMixin, models.Model):
             return self._image_url('preview_small.jpg')
 
     @amo.cached_property
+    def icon_path(self):
+        """Path to personas square preview."""
+        if self.is_new():
+            return self._image_path('icon.png')
+        else:
+            return self._image_path('preview_small.jpg')
+
+    @amo.cached_property
     def preview_url(self):
         """URL to Persona's big, 680px, preview."""
         if self.is_new():
             return self._image_url('preview.png')
         else:
             return self._image_url('preview_large.jpg')
+
+    @amo.cached_property
+    def preview_path(self):
+        """Path to Persona's big, 680px, preview."""
+        if self.is_new():
+            return self._image_path('preview.png')
+        else:
+            return self._image_path('preview_large.jpg')
 
     @amo.cached_property
     def header_url(self):

--- a/apps/addons/tasks.py
+++ b/apps/addons/tasks.py
@@ -335,8 +335,8 @@ def save_theme_reupload(header, footer, addon, **kw):
 
     if header_dst or footer_dst:
         theme = addon.persona
-        header = 'pending_header.png' if header_dst else 'header.png'
-        footer = 'pending_footer.png' if footer_dst else 'footer.png'
+        header = 'pending_header.png' if header_dst else theme.header
+        footer = 'pending_footer.png' if footer_dst else theme.footer
 
         # Store pending header and/or footer file paths for review.
         RereviewQueueTheme.objects.filter(theme=theme).delete()

--- a/mkt/reviewers/tasks.py
+++ b/mkt/reviewers/tasks.py
@@ -76,6 +76,13 @@ def approve_rereview(theme):
     reupload = rereview[0]
 
     if reupload.header_path != reupload.theme.header_path:
+        create_persona_preview_images(
+            src=reupload.header_path,
+            full_dst=[
+                reupload.theme.preview_path,
+                reupload.theme.icon_path],
+            set_modified_on=[reupload.theme.addon])
+
         move_stored_file(
             reupload.header_path, reupload.theme.header_path,
             storage=storage)
@@ -83,12 +90,6 @@ def approve_rereview(theme):
         move_stored_file(
             reupload.footer_path, reupload.theme.footer_path,
             storage=storage)
-    create_persona_preview_images(
-        src=reupload.theme.header_path,
-        full_dst=[
-            reupload.theme.header_path.replace('header', 'preview'),
-            reupload.theme.header_path.replace('header', 'icon')],
-        set_modified_on=[reupload.theme.addon])
     rereview.delete()
 
     theme.addon.increment_version()


### PR DESCRIPTION
**Status:** needing review (p1).

Some important theme bug fixes.

[test 1: updating a getpersonas-uploaded theme (header-only or footer-only)](https://github.com/ngokevin/zamboni/compare/legacytheme?expand=1#diff-368507455056cae0c97c26f00581b555R547)

``` diff
+        """
+        STR the bug this test fixes:
+
+        - Reupload a legacy theme (/w footer == leg.png) legacy, header only.
+        - The header would get saved as 'pending_header.png'.
+        - The footer would get saved as 'footer.png'.
+        - On approving, it would see 'footer.png' !== 'leg.png'
+        - It run move_stored_file('footer.png', 'leg.png').
+        - But footer.png does not exist. BAM BUG.
+        """ 
```

[test 2: approving a getpersonas-uploaded theme doesn't update preview images correctly](https://github.com/ngokevin/zamboni/compare/legacytheme?expand=1#diff-e65341e2fcec962f7e0d0a2e41d7be4eR543)

``` diff
+        """
+        Test updating themes that were submitted from GetPersonas.
+        STR the bug this test fixes:
+
+        - Reupload a legacy theme and approve it.
+        - On approving, it would make a preview image with the destination as
+         'preview.png' and 'icon.png', but legacy themes use
+         'preview_large.jpg' and 'preview_small.png'.
+        - Thus the preview images were not being updated, but the header/footer
+          images were.
+        """ 
```
