### PR TITLE
don't allow theme updates while pending (bug 926950)

### DIFF
--- a/apps/addons/forms.py
+++ b/apps/addons/forms.py
@@ -706,9 +706,10 @@ class EditThemeForm(AddonFormBase):
             addon_cat.save()
 
         # Theme reupload.
-        if data['header_hash'] or data['footer_hash']:
-            save_theme_reupload.delay(data['header_hash'], data['footer_hash'],
-                                      addon)
+        if not addon.is_pending():
+            if data['header_hash'] or data['footer_hash']:
+                save_theme_reupload.delay(
+                    data['header_hash'], data['footer_hash'], addon)
 
         return data
 

--- a/apps/devhub/templates/devhub/personas/edit.html
+++ b/apps/devhub/templates/devhub/personas/edit.html
@@ -217,40 +217,45 @@
         <legend>{{ _('Theme Design') }}</legend>
 
         <!--Theme upload new design/reupload.-->
-        <a class="reupload">{{ _('Upload New Design') }}</a>
-        <a class="reupload cancel">{{ _('Cancel') }}</a>
-        <div class="theme-design c">
-          <h2>{{ _('Upload New Design') }}</h2>
-          <p>
-            {% trans %}
-              Upon upload and form submission, the AMO Team will review your
-              updated design. Your current design will still be public in the
-              meantime.
-            {% endtrans %}
-          </p>
+        {% if not addon.is_pending() %}
+          <a class="reupload">{{ _('Upload New Design') }}</a>
+          <a class="reupload cancel">{{ _('Cancel') }}</a>
+          <div class="theme-design c">
+            <h2>{{ _('Upload New Design') }}</h2>
+            <p>
+              {% trans %}
+                Upon upload and form submission, the AMO Team will review your
+                updated design. Your current design will still be public in the
+                meantime.
+              {% endtrans %}
+            </p>
 
-          <div class="theme-design-form">
-            {% with required = False %}
-              {% include "devhub/personas/includes/theme_design.html" %}
-            {% endwith %}
+            <div class="theme-design-form">
+              {% with required = False %}
+                {% include "devhub/personas/includes/theme_design.html" %}
+              {% endwith %}
+            </div>
+
+            {% set rereview = persona.rereviewqueuetheme_set.all() %}
+            {% if rereview.exists() %}
+              <h3>{{ _('Your previously resubmitted design, '
+                      ' which is under pending review.') }}</h3>
+              <ul class="rereview-preview">
+                <li id="persona-header" class="row">
+                  <h3>{{ _('Pending Header') }}</h3>
+                  <img class="preview loaded" src="{{ rereview[0].header_url }}">
+                </li>
+                <li id="persona-footer" class="row">
+                  <h3>{{ _('Pending Footer') }}</h3>
+                  <img class="preview loaded" src="{{ rereview[0].footer_url }}">
+                </li>
+              </ul>
+            {% endif %}
           </div>
-
-          {% set rereview = persona.rereviewqueuetheme_set.all() %}
-          {% if rereview.exists() %}
-            <h3>{{ _('Your previously resubmitted design, '
-                    ' which is under pending review.') }}</h3>
-            <ul class="rereview-preview">
-              <li id="persona-header" class="row">
-                <h3>{{ _('Pending Header') }}</h3>
-                <img class="preview loaded" src="{{ rereview[0].header_url }}">
-              </li>
-              <li id="persona-footer" class="row">
-                <h3>{{ _('Pending Footer') }}</h3>
-                <img class="preview loaded" src="{{ rereview[0].footer_url }}">
-              </li>
-            </ul>
-          {% endif %}
-        </div>
+        {% else %}
+          <span class="reupload">
+            {{ _('You may update your theme design here once it has been approved.') }}</span>
+        {% endif %}
 
         <ul class="theme-preview">
           <li id="persona-header" class="row">

--- a/apps/devhub/tests/test_views_edit.py
+++ b/apps/devhub/tests/test_views_edit.py
@@ -1319,3 +1319,18 @@ class TestThemeEdit(amo.tests.TestCase):
         r = edit_theme(req, self.addon.slug, self.addon)
         doc = pq(r.content)
         assert 'characters' in doc('#trans-description + ul li').text()
+
+    def test_no_reupload_on_pending(self):
+        self.addon.update(status=amo.STATUS_PENDING)
+        req = req_factory_factory(
+            self.addon.get_dev_url('edit'), user=self.user)
+        r = edit_theme(req, self.addon.slug, self.addon)
+        doc = pq(r.content)
+        assert not doc('a.reupload')
+
+        self.addon.update(status=amo.STATUS_PUBLIC)
+        req = req_factory_factory(
+            self.addon.get_dev_url('edit'), user=self.user)
+        r = edit_theme(req, self.addon.slug, self.addon)
+        doc = pq(r.content)
+        assert doc('a.reupload')

--- a/media/css/impala/personas.less
+++ b/media/css/impala/personas.less
@@ -396,7 +396,6 @@ ul.license {
 
 #persona-design.edit {
     .reupload {
-        cursor: pointer;
         float: right;
         position: relative;
         top: 3px;
@@ -404,6 +403,9 @@ ul.license {
         &.cancel {
             display: none;
         }
+    }
+    span.reupload {
+        font-style: italic;
     }
     .theme-design {
         display: none;

--- a/media/css/impala/site.less
+++ b/media/css/impala/site.less
@@ -38,6 +38,9 @@ a {
     &:hover {
         text-decoration: underline;
     }
+    &:not([href]) {
+        cursor: pointer;
+    }
 }
 
 .island {


### PR DESCRIPTION
**Status:** needing review

If submitting a theme, then immediately re-uploading a new design, there would be an entry in the pending queue and an entry in the updates queue. Causing a race condition between which one is approved and published first.

Don't allow updating theme until initially published.
