### PR TITLE
_update_manifest() third argument should be a dict (bug 927469)

### DIFF
--- a/mkt/developers/tests/test_views_edit.py
+++ b/mkt/developers/tests/test_views_edit.py
@@ -440,7 +440,7 @@ class TestEditBasic(TestEdit):
                       args=[self.webapp.app_slug])
         r = self.client.post(url)
         eq_(r.status_code, 204)
-        fetch.assert_called_once_with(self.webapp.pk, True, ())
+        fetch.assert_called_once_with(self.webapp.pk, True, {})
 
     @mock.patch('mkt.developers.views._update_manifest')
     def test_refresh_dev_only(self, fetch):

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -519,7 +519,7 @@ def upload_for_addon(request, addon_id, addon):
 @dev_required
 def refresh_manifest(request, addon_id, addon, webapp=False):
     log.info('Manifest %s refreshed for %s' % (addon.manifest_url, addon))
-    _update_manifest(addon_id, True, ())
+    _update_manifest(addon_id, True, {})
     return http.HttpResponse(status=204)
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=927469

Per mkt.webapps.tasks, `retries` is a dict, always has been. Not sure how the hell this worked before... 
