### PR TITLE
Attempt to fix flaky AMO tests by not relying on ExtraAppTestCase anymore

### DIFF
--- a/apps/amo/runner.py
+++ b/apps/amo/runner.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.db.models import loading
+
+from test_utils.runner import RadicalTestSuiteRunner
+
+
+class RadicalTestSuiteRunnerWithExtraApps(RadicalTestSuiteRunner):
+    def setup_test_environment(self, **kwargs):
+        rval = super(RadicalTestSuiteRunnerWithExtraApps,
+                     self).setup_test_environment(**kwargs)
+        extra_apps = getattr(settings, 'TEST_INSTALLED_APPS')
+        if extra_apps:
+            installed_apps = getattr(settings, 'INSTALLED_APPS')
+            setattr(settings, 'INSTALLED_APPS', installed_apps + extra_apps)
+            loading.cache.loaded = False
+        return rval

--- a/docs/settings/settings_local.prod.py
+++ b/docs/settings/settings_local.prod.py
@@ -40,9 +40,6 @@ CACHES = {
 # This is used to hash some things in Django.
 SECRET_KEY = 'replace me with something long'
 
-# Remove any apps that are only needed for development.
-INSTALLED_APPS = tuple(app for app in INSTALLED_APPS if app not in DEV_APPS)
-
 LOG_LEVEL = logging.WARNING
 
 DEBUG_PROPAGATE_EXCEPTIONS = DEBUG

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -434,13 +434,14 @@ INSTALLED_APPS = (
     'django_statsd',
 )
 
-# These apps will be removed from INSTALLED_APPS in a production environment.
-DEV_APPS = (
-    'django_nose',
+# These apps are only needed in a testing environment. They are added to
+# INSTALLED_APPS by the RadicalTestSuiteRunnerWithExtraApps test runner.
+TEST_INSTALLED_APPS = (
+    'translations.tests.testapp',
 )
 
 # Tests
-TEST_RUNNER = 'test_utils.runner.RadicalTestSuiteRunner'
+TEST_RUNNER = 'amo.runner.RadicalTestSuiteRunnerWithExtraApps'
 NOSE_ARGS = [
     '--with-fixture-bundling',
     '--exclude=mkt/*',


### PR DESCRIPTION
ExtraAppTestCase causes problems depending on import order, because
any models with FKs that is imported get cached into its related
model's `_meta._related_objects_cache`.
