### PR TITLE
Fix error message displaying when uploading a screenshot (bug 928287)

### DIFF
--- a/media/css/devreg/media.styl
+++ b/media/css/devreg/media.styl
@@ -18,8 +18,6 @@
     border-bottom: 1px dotted #ADD0DC;
     background-color: #fff;
     margin-bottom: 15px;
-    min-height: 125px;
-    max-height: 135px;
     padding-bottom: 15px;
 
     &:last-child {
@@ -57,11 +55,7 @@
 }
 
 #file-list .preview .edit-previews-text {
-    float: left;
-
-    &.error {
-        float: none;
-    }
+    display: inline-block;
 }
 
 .edit-previews-submit {
@@ -107,9 +101,9 @@
     &:before {
         display: block;
         content: "\2639";  /* sadface */
-        font-size: 100px;
+        font-size: 72px;
         font-weight: bold;
-        line-height: 94px;
+        line-height: 90px;
         text-align: center;
         width: 100%;
     }

--- a/media/js/devreg/devhub.js
+++ b/media/js/devreg/devhub.js
@@ -573,13 +573,15 @@ function initUploadPreview() {
 
         var $thumb = form.show().find('.preview-thumb');
         $thumb.addClass('loading');
-        if (file.type.indexOf('video') > -1) {
-            $thumb.replaceWith(format(
-                '<video controls class="preview-thumb loading" src="{0}" ' +
-                'preload="auto" type="video/webm"></video>', file.dataURL));
-        } else {
-            handle_landscape_class($thumb, file.dataURL);
-            $thumb.css('background-image', 'url(' + file.dataURL + ')');
+        if (file.dataURL) {
+            if (file.type.indexOf('video') > -1) {
+                $thumb.replaceWith(format(
+                    '<video controls class="preview-thumb loading" src="{0}" ' +
+                    'preload="auto" type="video/webm"></video>', file.dataURL));
+            } else {
+                handle_landscape_class($thumb, file.dataURL);
+                $thumb.css('background-image', 'url(' + file.dataURL + ')');
+            }
         }
         renumberPreviews();
     }

--- a/mkt/developers/templates/developers/apps/forms_shared/media.html
+++ b/mkt/developers/templates/developers/apps/forms_shared/media.html
@@ -122,6 +122,7 @@
                     {{ form.id }}
                     <a href="#" class="remove">x</a>
                     <span class="js-hidden delete">{{ form.DELETE }}{{ form.DELETE.label_tag() }}</span>
+                    <div class="edit-previews-text">{# div holding potential error messages #}</div>
                     <div class="js-hidden position">
                       {{ form.position }}
                     </div>

--- a/mkt/submit/templates/submit/details.html
+++ b/mkt/submit/templates/submit/details.html
@@ -141,6 +141,7 @@
               {{ form.id }}
               <a href="#" class="remove">x</a>
               <span class="js-hidden delete">{{ form.DELETE }}{{ form.DELETE.label_tag() }}</span>
+              <div class="edit-previews-text">{# div holding potential error messages #}</div>
               <div class="js-hidden position">
                 {{ form.position }}
               </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=928287

The heart of the problem was the missing `<div class="edit-previews-text">` which is used by the js to display the errors, but I had to modify the CSS too to make everything fit correctly with the last style modifications. Also a drive-by fix to stop us from trying to load  "/developers/app/<app>/edit/false" by checking `fileURL` before using it as a background-image.

Post-fix screenshot:
![fix-screenshot-error](https://f.cloud.github.com/assets/187006/1360192/48424a54-37f1-11e3-84bd-7e20425366ad.png)
