### PR TITLE
Prevent error when uploading a new version of an app (bug 927179)

### DIFF
--- a/apps/editors/models.py
+++ b/apps/editors/models.py
@@ -315,7 +315,14 @@ def send_notifications(signal=None, sender=None, **kw):
     if sender.is_beta:
         return
 
+    # See bug 741679 for implementing this in Marketplace. This is deactivated
+    # in the meantime because EditorSubscription.send_notification() uses
+    # AMO-specific code.
+    if settings.MARKETPLACE:
+        return
+
     subscribers = sender.addon.editorsubscription_set.all()
+
     if not subscribers:
         return
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=927179

The UI to subscribe to new versions of an app is present but is
not implemented, that's . Let's not fail if someones
decides to subscribe in the meantime :-)
