### PR TITLE
Accept utf-8 in tastypie APIs with 'x-www-form-urlencoded' (bug 926502)

### DIFF
--- a/mkt/api/serializers.py
+++ b/mkt/api/serializers.py
@@ -1,5 +1,4 @@
-from urlparse import parse_qsl
-
+from django.http import QueryDict
 from django.utils.simplejson import JSONDecodeError
 
 from tastypie.serializers import Serializer
@@ -17,7 +16,7 @@ class Serializer(Serializer):
     }
 
     def from_urlencode(self, data):
-        return dict(parse_qsl(data))
+        return QueryDict(data).dict()
 
     def to_urlencode(self, data, options=None):
         raise UnsupportedFormat

--- a/mkt/api/tests/test_serializer.py
+++ b/mkt/api/tests/test_serializer.py
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
 from decimal import Decimal
 import json
-import urllib
 
 from django.test import TestCase
+from django.utils.http import urlencode
 
 from nose.tools import eq_
 from simplejson import JSONDecodeError
@@ -27,9 +28,13 @@ class TestSerializer(TestCase):
             json.dumps({'foo': '5.00'}))
 
     def test_url(self):
-        eq_(self.s.deserialize(urllib.urlencode({'foo': 'bar'}),
+        eq_(self.s.deserialize(urlencode({'foo': 'bar'}),
                                'application/x-www-form-urlencoded'),
             {'foo': 'bar'})
+
+        eq_(self.s.deserialize(urlencode({'foo': u'baré'}),
+                               'application/x-www-form-urlencoded'),
+            {'foo': u'baré'})
 
     def test_from_url(self):
         with self.assertRaises(UnsupportedFormat):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=926502
