### PR TITLE
rename comm link (bug 928164)

### DIFF
--- a/mkt/developers/templates/developers/apps/listing/item_actions_app.html
+++ b/mkt/developers/templates/developers/apps/listing/item_actions_app.html
@@ -78,7 +78,7 @@
   {% if waffle.switch('comm-dashboard') %}
     <li>
       <a class="action-link" href="{{ addon.get_comm_thread_url() }}">
-        {{ _('Communication') }}</a>
+        {{ _('Messages') }}</a>
     </li>
   {% endif %}
 </ul>

--- a/mkt/developers/templates/developers/includes/addons_edit_nav.html
+++ b/mkt/developers/templates/developers/includes/addons_edit_nav.html
@@ -33,7 +33,7 @@
 {% endif %}
 {% if waffle.switch('comm-dashboard') %}
   {% do urls.append(
-    (addon.get_comm_thread_url(), _('View Communication Dashboard'))
+    (addon.get_comm_thread_url(), _('View Messages'))
   ) %}
 {% endif %}
 

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -195,7 +195,7 @@ class TestAppDashboard(AppHubTest):
             ('Statistics', app.get_stats_url()),
             ('Transactions', urlparams(
                 reverse('mkt.developers.transactions'), app=app.id)),
-            ('Communication', app.get_comm_thread_url()),
+            ('Messages', app.get_comm_thread_url()),
         ]
         amo.tests.check_links(expected, doc('a.action-link'), verify=False)
 
@@ -219,7 +219,7 @@ class TestAppDashboard(AppHubTest):
             ('Transactions', urlparams(
                 reverse('mkt.developers.transactions'), app=app.id)),
             ('Manage In-App Payments', app.get_dev_url('in_app_config')),
-            ('Communication', app.get_comm_thread_url()),
+            ('Messages', app.get_comm_thread_url()),
         ]
         amo.tests.check_links(expected, doc('a.action-link'), verify=False)
 
@@ -240,7 +240,7 @@ class TestAppDashboard(AppHubTest):
             ('Statistics', app.get_stats_url()),
             ('Transactions', urlparams(
                 reverse('mkt.developers.transactions'), app=app.id)),
-            ('Communication', app.get_comm_thread_url()),
+            ('Messages', app.get_comm_thread_url()),
         ]
         amo.tests.check_links(expected, doc('a.action-link'), verify=False)
 


### PR DESCRIPTION
View Communication Dashboard => View Messages
Communication => Messages
