### PR TITLE
Don't take the db into account when building cache keys (bug 928881)

### DIFF
--- a/apps/amo/tests/test_models.py
+++ b/apps/amo/tests/test_models.py
@@ -139,3 +139,9 @@ class TestModelBase(TestCase):
         # Reload. And it's magically now a persona.
         eq_(addon.reload().type, amo.ADDON_PERSONA)
         eq_(addon.type, amo.ADDON_PERSONA)
+
+
+def test_cache_key():
+    # Test that we are not taking the db into account when building our
+    # cache keys for django-cache-machine. See bug 928881.
+    eq_(Addon._cache_key(1, 'default'), Addon._cache_key(1, 'slave'))

--- a/apps/translations/models.py
+++ b/apps/translations/models.py
@@ -91,7 +91,10 @@ class Translation(amo.models.ModelBase):
     def _cache_key(cls, pk, db):
         # Hard-coding the class name here so that subclasses don't try to cache
         # themselves under something like "o:translations.purifiedtranslation".
-        key_parts = ('o', 'translations.translation', pk, db)
+        #
+        # Like in ModelBase, we avoid putting the real db in the key because it
+        # does us more harm than good.
+        key_parts = ('o', 'translations.translation', pk, 'default')
         return ':'.join(map(encoding.smart_unicode, key_parts))
 
     @classmethod

--- a/apps/translations/tests/test_models.py
+++ b/apps/translations/tests/test_models.py
@@ -17,10 +17,10 @@ from nose.tools import eq_, ok_
 from test_utils import ExtraAppTestCase, trans_eq
 
 from testapp.models import TranslatedModel, UntranslatedModel, FancyModel
-from translations.models import (Translation, PurifiedTranslation,
-                                 TranslationSequence)
 from translations import widgets
 from translations.query import order_by_translation
+from translations.models import (LinkifiedTranslation, PurifiedTranslation,
+                                 Translation, TranslationSequence)
 
 
 def ids(qs):
@@ -477,3 +477,17 @@ def test_comparison_with_lazy():
     lazy_u = lazy(lambda x: x, unicode)
     x == lazy_u('xxx')
     lazy_u('xxx') == x
+
+
+def test_cache_key():
+    # Test that we are not taking the db into account when building our
+    # cache keys for django-cache-machine. See bug 928881.
+    eq_(Translation._cache_key(1, 'default'),
+        Translation._cache_key(1, 'slave'))
+
+    # Test that we are using the same cache no matter what Translation class
+    # we use.
+    eq_(PurifiedTranslation._cache_key(1, 'default'),
+        Translation._cache_key(1, 'default'))
+    eq_(LinkifiedTranslation._cache_key(1, 'default'),
+        Translation._cache_key(1, 'default'))


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=928881

This should fix cache invalidation problems we had with django-cache-machine 0.8.
