### PR TITLE
Delete old exports before doing new ones (bug 905072)

### DIFF
--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import subprocess
 
 from django.conf import settings
@@ -358,8 +359,15 @@ def dump_app(id, **kw):
     json.dump(res[0], open(target_file, 'w'), cls=JSONEncoder)
     return target_file
 
-
 @task
+def clean_apps(pks, **kw):
+    app_dir = os.path.join(settings.DUMPED_APPS_PATH, 'apps')
+    if os.path.exists(app_dir):
+        shutil.rmtree(app_dir)
+    return pks
+
+
+@task(ignore_result=False)
 def dump_apps(ids, **kw):
     task_log.info(u'Dumping apps {0} to {0}. [{0}]'
                   .format(ids[0], ids[-1], len(ids)))

--- a/mkt/webapps/tests/test_tasks.py
+++ b/mkt/webapps/tests/test_tasks.py
@@ -552,6 +552,20 @@ class TestDumpApps(amo.tests.TestCase):
         call_command('process_addons', task='dump_apps')
         assert not dump_app.called
 
+    def test_removed(self):
+        # At least one public app must exist for dump_apps to run.
+        amo.tests.app_factory(name="second app", status=amo.STATUS_PUBLIC)
+        app_path = os.path.join(settings.DUMPED_APPS_PATH, 'apps', '337',
+                                '337141.json')
+        app = Addon.objects.get(pk=337141)
+        app.update(status=amo.STATUS_PUBLIC)
+        call_command('process_addons', task='dump_apps')
+        assert os.path.exists(app_path)
+
+        app.update(status=amo.STATUS_PENDING)
+        call_command('process_addons', task='dump_apps')
+        assert not os.path.exists(app_path)
+
     @mock.patch('mkt.webapps.tasks.dump_app')
     def test_public(self, dump_app):
         call_command('process_addons', task='dump_apps')


### PR DESCRIPTION
non-public apps show up in exports if they were ever public because we never delete files from the export directory that tarballs are created from. This patch cleans the directory each time we export.
