### PR TITLE
set tabzilla to default z-index (bug 927168)

### DIFF
--- a/media/css/impala/moz-tab.css
+++ b/media/css/impala/moz-tab.css
@@ -11,3 +11,9 @@
 #global-header-tab a {
     color: #fff;
 }
+
+/* Temp fix while mozorg.cdn.mozilla.net/media/css/tabzilla-min.css has a
+#tabzilla {z-index: 999} */
+#tabzilla {
+    z-index: inherit;
+}


### PR DESCRIPTION
See https://bugzil.la/927168
This is a fix while https://github.com/mozilla/bedrock/pull/1317 is pending.
