### PR TITLE
add tags to API response for apps (bug 930593)

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -463,7 +463,6 @@ def _login(request, template=None, data=None, dont_redirect=False):
                     signature='AUTHFAIL',
                     msg='The username was invalid')
             pass
-
     partial_form = partial(forms.AuthenticationForm, use_recaptcha=limited)
     r = auth.views.login(request, template_name=template,
                          redirect_field_name='to',

--- a/mkt/api/resources.py
+++ b/mkt/api/resources.py
@@ -262,6 +262,7 @@ class AppResource(CORSResource, MarketplaceModelResource):
     def dehydrate_extra(self, bundle):
         if bundle.obj.upsold:
             bundle.data['upsold'] = self.get_resource_uri(bundle.obj.upsold.free)
+        bundle.data['tags'] = [t.tag_text for t in bundle.obj.tags.all()]
 
     def hydrate_premium_type(self, bundle):
         typ = amo.ADDON_PREMIUM_API_LOOKUP.get(bundle.data['premium_type'],

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -15,6 +15,7 @@ from addons.models import (Addon, AddonDeviceType, AddonUpsell,
 from amo.tests import AMOPaths, app_factory
 from files.models import FileUpload
 from market.models import Price, PriceCurrency
+from tags.models import AddonTag, Tag
 from users.models import UserProfile
 
 from mkt.api.base import get_url, list_url
@@ -629,6 +630,16 @@ class TestAppDetail(BaseOAuth, AMOPaths):
         eq_(res.json['upsold'],
             self.client.get_absolute_url(get_url('app', pk=free.pk),
                                          absolute=False))
+
+    def test_tags(self):
+        app = Webapp.objects.get(pk=337141)
+        tag1 = Tag.objects.create(tag_text='example1')
+        tag2 = Tag.objects.create(tag_text='example2')
+        AddonTag.objects.create(tag=tag1, addon=app)
+        AddonTag.objects.create(tag=tag2, addon=app)
+        res = self.client.get(self.get_url, pk=app.pk)
+        data = json.loads(res.content)
+        eq_(data['tags'], ['example1', 'example2'])
 
 
 class TestCategoryHandler(RestOAuth):


### PR DESCRIPTION
this just sticks tags in regular api response, no specialization for dump.
