### PR TITLE
Convert FeedbackResource to DRF (bug 910556)

### DIFF
--- a/mkt/account/forms.py
+++ b/mkt/account/forms.py
@@ -7,8 +7,6 @@ import happyforms
 from tower import ugettext_lazy as _lazy
 
 import amo
-from market.models import PriceCurrency
-from mkt.site.forms import PotatoCaptchaForm
 from users.forms import BaseAdminUserEditForm
 from users.models import UserProfile
 
@@ -78,19 +76,6 @@ class UserDeleteForm(forms.Form):
                                                           % self.request.user)
             raise forms.ValidationError('Developers cannot delete their '
                                         'accounts.')
-
-
-class FeedbackForm(PotatoCaptchaForm):
-    """Site feedback form."""
-
-    feedback = forms.CharField(required=True, label='',
-                               widget=forms.Textarea(attrs={'rows': 4}))
-    platform = forms.CharField(required=False, widget=forms.HiddenInput,
-                               label='')
-    chromeless = forms.CharField(required=False, widget=forms.HiddenInput,
-                                 label='')
-    from_url = forms.CharField(required=False, widget=forms.HiddenInput,
-                               label='')
 
 
 class LoginForm(happyforms.Form):

--- a/mkt/account/helpers.py
+++ b/mkt/account/helpers.py
@@ -2,19 +2,9 @@ from jingo import register
 import jinja2
 
 from mkt.site.helpers import new_context
-from mkt.account import forms
 
 
 @register.inclusion_tag('account/helpers/refund_info.html')
 @jinja2.contextfunction
 def refund_info(context, product, contributions, show_link):
-    return new_context(**locals())
-
-
-@register.inclusion_tag('account/helpers/feedback_form.html')
-@jinja2.contextfunction
-def feedback_form(context, fform=None):
-    if not fform:
-        fform = forms.FeedbackForm(None, request=context['request'])
-
     return new_context(**locals())

--- a/mkt/account/serializers.py
+++ b/mkt/account/serializers.py
@@ -1,0 +1,20 @@
+from rest_framework import fields
+
+from mkt.api.serializers import PotatoCaptchaSerializer
+
+
+class FeedbackSerializer(PotatoCaptchaSerializer):
+    feedback = fields.CharField()
+    platform = fields.CharField(required=False)
+    chromeless = fields.CharField(required=False)
+    from_url = fields.CharField(required=False)
+    user = fields.Field()
+
+    def validate(self, attrs):
+        attrs = super(FeedbackSerializer, self).validate(attrs)
+
+        if not attrs.get('platform'):
+            attrs['platform'] = self.request.GET.get('dev', '')
+        attrs['user'] = self.request.amo_user
+
+        return attrs

--- a/mkt/account/urls.py
+++ b/mkt/account/urls.py
@@ -2,20 +2,20 @@ from django.conf.urls import include, patterns, url
 
 from tastypie.api import Api
 
-from mkt.account.api import (AccountResource, FeedbackResource,
-                             InstalledResource, LoginResource,
+from mkt.account.api import (AccountResource, InstalledResource, LoginResource,
                              NewsletterResource, PermissionResource)
+from mkt.account.views import FeedbackView
 
 
 # Account API.
 account = Api(api_name='account')
 account.register(AccountResource())
-account.register(FeedbackResource())
 account.register(InstalledResource())
 account.register(LoginResource())
 account.register(PermissionResource())
 account.register(NewsletterResource())
 
 api_patterns = patterns('',
+    url('^account/feedback/', FeedbackView.as_view(), name='account-feedback'),
     url('^', include(account.urls)),
 )

--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -1,8 +1,22 @@
+from django.conf import settings
+
 import jingo
+from rest_framework import status
+from rest_framework.generics import CreateAPIView
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 
 import amo
 from amo.decorators import login_required
+from amo.utils import send_mail_jinja
 from devhub.views import _get_items
+
+from mkt.account.serializers import FeedbackSerializer
+from mkt.api.authentication import (RestAnonymousAuthentication,
+                                    RestOAuthAuthentication,
+                                    RestSharedSecretAuthentication)
+from mkt.api.base import CORSMixin
 
 
 @login_required
@@ -10,3 +24,44 @@ def activity_log(request, userid):
     all_apps = request.amo_user.addons.filter(type=amo.ADDON_WEBAPP)
     return jingo.render(request, 'account/activity.html',
                         {'log': _get_items(None, all_apps)})
+
+
+class FeedbackView(CORSMixin, CreateAPIView):
+    class FeedbackThrottle(UserRateThrottle):
+        THROTTLE_RATES = {
+            'user': '30/hour',
+        }
+
+    authentication_classes = [RestOAuthAuthentication,
+                              RestSharedSecretAuthentication,
+                              RestAnonymousAuthentication]
+    cors_allowed_methods = ['post']
+    permission_classes = (AllowAny,)
+    serializer_class = FeedbackSerializer
+    throttle_classes = (FeedbackThrottle,)
+    throttle_scope = 'user'
+
+    def create(self, request, *args, **kwargs):
+        # FIXME: might be nice to have a generic 'create without model' mixin.
+        serializer = self.get_serializer(data=request.DATA)
+
+        if serializer.is_valid():
+            context_data = self.get_context_data(request, serializer)
+            self.send_email(request, context_data)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def send_email(self, request, context_data):
+        sender = getattr(request.amo_user, 'email', settings.NOBODY_EMAIL)
+        send_mail_jinja(u'Marketplace Feedback', 'account/email/feedback.txt',
+                        context_data, from_email=sender,
+                        recipient_list=[settings.MKT_FEEDBACK_EMAIL])
+
+    def get_context_data(self, request, serializer):
+        context_data = {
+            'user_agent': request.META.get('HTTP_USER_AGENT', ''),
+            'ip_address': request.META.get('REMOTE_ADDR', '')
+        }
+        context_data.update(serializer.data)
+        return context_data

--- a/mkt/api/serializers.py
+++ b/mkt/api/serializers.py
@@ -1,10 +1,16 @@
 from django.http import QueryDict
 from django.utils.simplejson import JSONDecodeError
 
+import commonware.log
+from rest_framework import serializers
 from tastypie.serializers import Serializer
 from tastypie.exceptions import UnsupportedFormat
+from tower import ugettext as _
 
 from mkt.api.exceptions import DeserializationError
+
+
+log = commonware.log.getLogger('z.mkt.api.forms')
 
 
 class Serializer(Serializer):
@@ -44,3 +50,57 @@ class SuggestionsSerializer(Serializer):
         return super(SuggestionsSerializer, self).serialize(bundle,
                                                             format=format,
                                                             options=options)
+
+
+class PotatoCaptchaSerializer(serializers.Serializer):
+    """
+    Serializer class to inherit from to get PotatoCaptcha (tm) protection for
+    an API based on DRF.
+
+    Clients using this API are supposed to have 2 fields in their HTML, "tuber"
+    and "sprout". They should never submit a value for "tuber", and they should
+    always submit "potato" as the value for "sprout". This is to prevent dumb
+    bots from spamming us.
+
+    If a wrong value is entered for "sprout" or "tuber" is present, a 
+    ValidationError will be returned.
+
+    Note: this is completely disabled for authenticated users.
+    """
+
+    # This field's value should always be blank (spammers are dumb).
+    tuber = serializers.CharField(required=False)
+
+    # This field's value should always be 'potato' (set by JS).
+    sprout = serializers.CharField()
+
+    def __init__(self, *args, **kwargs):
+        super(PotatoCaptchaSerializer, self).__init__(*args, **kwargs)
+        if hasattr(self, 'context') and 'request' in self.context:
+            self.request = self.context['request']
+        else:
+            raise serializers.ValidationError('Need request in context')
+
+        self.has_potato_recaptcha = True
+        if self.request.user.is_authenticated():
+            self.fields.pop('tuber')
+            self.fields.pop('sprout')
+            self.has_potato_recaptcha = False
+
+    def validate(self, attrs):
+        attrs = super(PotatoCaptchaSerializer, self).validate(attrs)
+        if self.has_potato_recaptcha:
+            sprout = attrs.get('sprout', None)
+            tuber = attrs.get('tuber', None)
+
+            if tuber or sprout != 'potato':
+                ip = self.request.META.get('REMOTE_ADDR', '')
+                log.info(u'Spammer thwarted: %s' % ip)
+                raise serializers.ValidationError(
+                    _('Form could not be submitted.'))
+
+            # Don't keep the internal captcha fields, we don't want them to
+            # pollute self.data
+            self.fields.pop('tuber')
+            self.fields.pop('sprout')
+        return attrs

--- a/mkt/site/tests/test_forms.py
+++ b/mkt/site/tests/test_forms.py
@@ -15,6 +15,7 @@ class PotatoCaptchaTestCase(amo.tests.TestCase):
         self.request = mock.Mock()
         self.request.META = {}
         self.request.user = mock.Mock()
+        self.context = {'request': self.request}
         self.request.user.is_authenticated = lambda: False
         self.data = {'tuber': '', 'sprout': 'potato'}
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=910556

Notable changes due to the conversion:
- Errors used to be inside an 'error_message' key ; DRF returns them directly instead, so instead of:

```
{'error_message': {'error1': 'foo'},{'error_2': 'bar'}}
```

We have

```
{'error1': 'foo'},{'error_2': 'bar'}
```

We determined that because it's always associated to a 400 HTTP Status code, putting the errors in an 'error_message' key is superfluous. This is a backwards-incompatible change but shouldn't have much impact for now.
- `ThrottleTests` is tastypie specific. We removed it from the tests because it wasn't very useful anyway. We might have to revisit this issue in the next API we switch to DRF.
