### PR TITLE
set submitted apps as incomplete status without iarc ratings (bug 931935)

### DIFF
--- a/mkt/developers/templates/developers/apps/listing/item_actions_app.html
+++ b/mkt/developers/templates/developers/apps/listing/item_actions_app.html
@@ -2,21 +2,30 @@
 <ul>
 {% if addon.is_incomplete() %}
   {% if check_addon_ownership(request, addon, dev=True) %}
-    {% if addon.is_complete()[0] and addon.needs_payment() %}
-      {# TODO: display whether app needs to be rated. #}
-      {# The app just needs payments information. #}
-      <li>
-        <a href="{{ addon.get_dev_url('payments') }}" class="tooltip"
-           title="{{ _('Provide payment information for the app.') }}">
-        {{ _('Set Up Payments') }}</a>
-      </li>
-    {% else %}
+    {% if not addon.is_complete()[0] %}
       {# The app's submission is incomplete. #}
       <li>
         <a href="{{ url('submit.app.resume', addon.app_slug) }}" class="tooltip"
            title="{{ _('Resume the submission process for this app.') }}">
         {{ _('Resume') }}</a>
       </li>
+    {% else %}
+      {% if addon.needs_payment() and not addon.has_payment_account() %}
+        {# The app needs payments information. #}
+        <li>
+          <a href="{{ addon.get_dev_url('payments') }}" class="tooltip"
+             title="{{ _('Provide payment information for the app.') }}">
+          {{ _('Set Up Payments') }}</a>
+        </li>
+      {% endif %}
+      {% if waffle.switch('iarc') and not addon.is_rated() %}
+        {# The app needs content ratings. #}
+        <li>
+          <a href="{{ addon.get_dev_url('ratings_edit') }}" class="tooltip"
+             title="{{ _('Get content ratings for the app.') }}">
+          {{ _('Set Up Content Ratings') }}</a>
+        </li>
+      {% endif %}
     {% endif %}
   {% endif %}
 

--- a/mkt/developers/templates/developers/apps/listing/items.html
+++ b/mkt/developers/templates/developers/apps/listing/items.html
@@ -8,8 +8,18 @@
       {{ dev_heading(addon, amo) }}
       {% if addon.is_incomplete() %}
         <p class="incomplete">
-          {{ _('This app will be deleted automatically after a few days if
-                the submission process is not completed.') }}
+          {# is_complete doesn't check for payments/ratings.
+             Thus is_incomplete + is_complete == needs payments/ratings #}
+          {% if not addon.is_complete()[0] %}
+            {{ _("This app's submission process has not been fully completed.") }}
+          {% else %}
+            {% if waffle.switch('iarc') and not addon.is_rated() %}
+              {{ _('This app needs to get a content rating.') }}
+            {% endif %}
+            {% if addon.needs_payment() and not addon.has_payment_account()  %}
+              {{ _('This app needs a payment account set up.') }}
+            {% endif %}
+          {% endif %}
         </p>
       {% else %}
         <ul class="item-details">
@@ -45,7 +55,7 @@
           <li class="payments">
             <strong>{{ _('Price:') }}</strong>
             {{ price(request, addon) }}
-            {% if addon.is_premium() and not hasOneToOne(addon, 'app_payment_account') %}
+            {% if addon.is_premium() and not addon.has_payment_account() %}
               <a href="{{ addon.get_dev_url('payments') }}">{{ _('Set up Payment Account') }}</a>
             {% endif %}
           </li>

--- a/mkt/developers/templates/developers/apps/listing/macros.html
+++ b/mkt/developers/templates/developers/apps/listing/macros.html
@@ -1,6 +1,6 @@
 {% macro dev_heading(addon, amo) %}
   <h3>
-    {% set is_complete = not addon.is_incomplete() %}
+    {% set is_complete = addon.is_complete()[0] %}
     {% if is_complete %}<a href="{{ addon.get_dev_url() }}">{% endif %}
     <img class="icon" src="{{ addon.get_icon_url(64) }}">
     {{ addon.name }}{% if is_complete %}</a>{% endif %}

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -190,14 +190,13 @@
   <div id="review-actions" class="review-actions">
     <div class="action_nav">
       <ul>
-        {% set unrated = waffle.switch('iarc') and not product.is_rated() %}
+        {% set incomplete = product.is_incomplete() %}
         {% for (setting, action) in form.fields.action.choices %}
-          {% set unrated_no_approve = unrated and setting == 'public' %}
-          <li{% if unrated_no_approve %} class="disabled"{% endif %}>
+          <li{% if setting == 'public' and incomplete %} class="disabled"{% endif %}>
             <label for>
               <input type="radio" name="action" value="{{ setting }}">
-              {% if unrated_no_approve %}
-                {{ _('App not rated') }}
+              {% if setting == 'public' and incomplete %}
+                {{ _('App submission incomplete') }}
               {% else %}
                 {{ action }}
               {% endif %}

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -226,9 +226,8 @@ class ReviewApp(ReviewBase):
             self.comm_thread, self.comm_note = res
 
     def process_public(self):
-        if waffle.switch_is_active('iarc') and not self.addon.is_rated():
-            # Shouldn't be able to get here. Don't allow unrated apps to go
-            # live.
+        if self.addon.is_incomplete():
+            # Failsafe.
             return
 
         # Hold onto the status before we change it.
@@ -247,9 +246,8 @@ class ReviewApp(ReviewBase):
 
     def process_public_waiting(self):
         """Make an app pending."""
-        if waffle.switch_is_active('iarc') and not self.addon.is_rated():
-            # Shouldn't be able to get here. Don't allow unrated apps to go
-            # live.
+        if self.addon.is_incomplete():
+            # Failsafe.
             return
 
         self.addon.sign_if_packaged(self.version.pk)
@@ -267,9 +265,8 @@ class ReviewApp(ReviewBase):
 
     def process_public_immediately(self):
         """Approve an app."""
-        if waffle.switch_is_active('iarc') and not self.addon.is_rated():
-            # Shouldn't be able to get here. Don't allow unrated apps to go
-            # live.
+        if self.addon.is_incomplete():
+            # Failsafe.
             return
 
         self.addon.sign_if_packaged(self.version.pk)

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -524,9 +524,6 @@ def queue_apps(request):
           .order_by('nomination', 'created')
           .select_related('addon', 'files').no_transforms())
 
-    if waffle.switch_is_active('iarc'):
-        qs = qs.exclude(addon__content_ratings__isnull=True)
-
     apps = _do_sort(request, qs, date_sort='nomination')
     apps = [QueuedApp(app, app.all_versions[0].nomination)
             for app in Webapp.version_and_file_transformer(apps)]

--- a/mkt/submit/templates/submit/next_steps.html
+++ b/mkt/submit/templates/submit/next_steps.html
@@ -5,10 +5,7 @@
 {% block title %}{{ hub_page_title(title) }}{% endblock %}
 
 {% set payments = waffle.flag('allow-b2g-paid-submission') and addon.is_premium() %}
-{% set has_payments = hasOneToOne(addon, 'app_payment_account') %}
 {% set rated = addon.is_rated() %}
-{% set pending = addon.is_pending() %}
-{% set public_waiting = addon.status == amo.STATUS_PUBLIC_WAITING %}
 {% set public = addon.is_public() %}
 
 {% block content %}
@@ -37,13 +34,13 @@
           {% endtrans -%}
         </li>
         {% if addon.is_premium() %}
-          <li{% if has_payments %} class="done"{% endif %}>
+          <li{% if not addon.has_payment_account() %} class="done"{% endif %}>
             {% trans url=addon.get_dev_url('payments') %}
               Set up <a href="{{ url }}">Payments & Countries</a>
             {% endtrans %}
           </li>
         {% endif %}
-        <li{% if not pending %} class="done"{% endif %}><span>{{ _('Wait for Review') }}</span></li>
+        <li{% if public or addon.is_public_waiting() %} class="done"{% endif %}><span>{{ _('Wait for Review') }}</span></li>
         <li{% if public %} class="done"{% endif %}><span>{{ _('Publish') }}</span></li>
       </ol>
 
@@ -104,13 +101,13 @@
               <strong>What's next:</strong> Set up Content Ratings
             {% endtrans %}
           </span>
-        {% elif payments and not has_payments %}
+        {% elif payments and not addon.has_payment_account() %}
           <span>
             {% trans %}
               <strong>What's next:</strong> Set up Payments & Countries
             {% endtrans %}
           </span>
-        {% elif public_waiting %}
+        {% elif addon.is_public_waiting() %}
           <span>
             {% trans %}
               <strong>What's next:</strong> Publish Your App

--- a/mkt/submit/tests/test_views.py
+++ b/mkt/submit/tests/test_views.py
@@ -699,6 +699,24 @@ class TestDetails(TestSubmit):
         self.assert3xx(r, self.get_url('done'))
 
         eq_(self.webapp.status, amo.STATUS_PENDING)
+
+        assert record_action.called
+
+    @mock.patch('mkt.submit.views.record_action')
+    def test_success_iarc(self, record_action):
+        """TODO: delete the above test when cleaning up waffle."""
+        self.create_switch('iarc')
+
+        self._step()
+        data = self.get_dict()
+        r = self.client.post(self.url, data)
+        self.assertNoFormErrors(r)
+        self.check_dict(data=data)
+        self.webapp = self.get_webapp()
+        self.assert3xx(r, self.get_url('done'))
+
+        eq_(self.webapp.status, amo.STATUS_NULL)
+
         assert record_action.called
 
     def test_success_paid(self):
@@ -821,6 +839,17 @@ class TestDetails(TestSubmit):
         app = Webapp.objects.exclude(app_slug=self.webapp.app_slug)[0]
         self.assert3xx(r, reverse('submit.app.done', args=[app.app_slug]))
         eq_(self.get_webapp().status, amo.STATUS_PENDING)
+
+    def test_unique_allowed_iarc(self):
+        """TODO: delete the above test when cleaning up waffle."""
+        self.create_switch('iarc')
+
+        self._step()
+        r = self.client.post(self.url, self.get_dict(name=self.webapp.name))
+        self.assertNoFormErrors(r)
+        app = Webapp.objects.exclude(app_slug=self.webapp.app_slug)[0]
+        self.assert3xx(r, reverse('submit.app.done', args=[app.app_slug]))
+        eq_(self.get_webapp().status, amo.STATUS_NULL)
 
     def test_slug_invalid(self):
         self._step()

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -389,7 +389,7 @@ class Webapp(Addon):
 
     def is_complete(self):
         """See if the app is complete. If not, return why. This function does
-        not consider or include payments-related information.
+        not consider or include payments-related or IARC information.
 
         """
         reasons = []
@@ -411,6 +411,14 @@ class Webapp(Addon):
 
     def is_rated(self):
         return self.content_ratings.exists()
+
+    def has_payment_account(self):
+        """App doesn't have a payment account set up yet."""
+        try:
+            self.app_payment_account
+        except ObjectDoesNotExist:
+            return False
+        return True
 
     def mark_done(self):
         """When the submission process is done, update status accordingly."""

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -39,6 +39,8 @@ from versions.models import update_status, Version
 import mkt
 from mkt.constants import APP_FEATURES, apps
 from mkt.constants.ratingsdescriptors import RATING_DESCS
+from mkt.developers.models import (AddonPaymentAccount, PaymentAccount,
+                                   SolitudeSeller)
 from mkt.site.fixtures import fixture
 from mkt.submit.tests.test_views import BasePackagedAppTest, BaseWebAppTest
 from mkt.webapps.models import (AddonExcludedRegion, AppFeatures, AppManifest,
@@ -481,6 +483,17 @@ class TestWebapp(amo.tests.TestCase):
         self.create_switch('iarc')
         assert app_factory().is_rated()
         assert not app_factory(unrated=True).is_rated()
+
+    def test_has_payment_account(self):
+        app = app_factory()
+        assert not app.has_payment_account()
+
+        user = UserProfile.objects.create(email='a', username='b')
+        payment = PaymentAccount.objects.create(
+            solitude_seller=SolitudeSeller.objects.create(user=user),
+            user=user)
+        AddonPaymentAccount.objects.create(addon=app, payment_account=payment)
+        assert app.has_payment_account()
 
 
 class DeletedAppTests(amo.tests.ESTestCase):


### PR DESCRIPTION
@eviljeff: "An app should _only_ change to status pending review when it is ready for review, and an app in that state should be always reviewable. What should instead happen is the app is status incomplete until the rating is set (as the app is). This is consistent with all the other settings an app needs to be ready for approval."

**Notes:** 
- set all newly submitted apps to be STATUS_INCOMPLETE upon submission (due to no content ratings yet). TODO will be to flip these apps to STATUS_PENDING once the iarc pingback gives them a rating through our API (don't flip to pending if payment info still required)
- change incomplete app submission messages on Submission Dashboard to reflect what needs to be done (remove the msg about app getting deleted if not finished soon)

![screen shot 2013-11-04 at 4 23 08 pm](https://f.cloud.github.com/assets/674727/1470136/42c746ec-45b1-11e3-849e-40c20dc36b21.png)

![screen shot 2013-11-04 at 4 23 05 pm](https://f.cloud.github.com/assets/674727/1470141/5f1fa302-45b1-11e3-84a5-ae225da6cce1.png)

![screen shot 2013-11-04 at 4 23 11 pm](https://f.cloud.github.com/assets/674727/1470139/48312774-45b1-11e3-90fc-4fcb02f059e3.png)

![screen shot 2013-11-04 at 4 24 52 pm](https://f.cloud.github.com/assets/674727/1470137/459cfe5c-45b1-11e3-9e77-e2ff7fb39a7e.png)
