### PR TITLE
fix content rating options in admin form (bug 934735)

### DIFF
--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -289,13 +289,40 @@ RATINGS_BODIES = {
     ESRB.id: ESRB,
     PEGI.id: PEGI,
 }
-ALL_RATINGS = []
-for rb in RATINGS_BODIES.values():
-    ALL_RATINGS.extend(rb.ratings)
 
-RATINGS_BY_NAME = []
+
+# Attach ratings bodies to ratings.
 for rb in RATINGS_BODIES.values():
     for r in rb.ratings:
-        RATINGS_BY_NAME.append((ALL_RATINGS.index(r),
-                                '%s - %s' % (rb.name, r.name)))
         r.ratingsbody = rb
+
+
+def ALL_RATINGS():
+    """
+    List of all ratings with waffled bodies.
+    """
+    import waffle
+
+    ALL_RATINGS = []
+    for rb in RATINGS_BODIES.values():
+        if rb in (CLASSIND, GENERIC) or waffle.switch_is_active('iarc'):
+            ALL_RATINGS.extend(rb.ratings)
+    return ALL_RATINGS
+
+
+def RATINGS_BY_NAME():
+    """
+    Create a list of tuples (choices) after we know the locale since this
+    attempts to concatenate two lazy translations in constants file.
+    """
+    import waffle
+
+    all_ratings = ALL_RATINGS()
+
+    ratings_choices = []
+    for rb in RATINGS_BODIES.values():
+        if rb in (CLASSIND, GENERIC) or waffle.switch_is_active('iarc'):
+            for r in rb.ratings:
+                ratings_choices.append(
+                    (all_ratings.index(r), u'%s - %s' % (rb.name, r.name)))
+    return ratings_choices

--- a/mkt/constants/tests/test_ratingsbodies.py
+++ b/mkt/constants/tests/test_ratingsbodies.py
@@ -1,0 +1,49 @@
+from nose.tools import eq_
+
+import amo.tests
+
+import mkt.constants.ratingsbodies as ratingsbodies
+
+
+class TestRatingsBodies(amo.tests.TestCase):
+
+    def test_all_ratings_waffle_off(self):
+        ratings = ratingsbodies.ALL_RATINGS()
+
+        # Assert only CLASSIND and GENERIC ratings are present.
+        assert ratingsbodies.CLASSIND_L in ratings
+        assert ratingsbodies.GENERIC_3 in ratings
+        assert ratingsbodies.ESRB_E not in ratings
+        assert ratingsbodies.PEGI_3 not in ratings
+        assert ratingsbodies.USK_0 not in ratings
+
+    def test_all_ratings_waffle_on(self):
+        self.create_switch('iarc')
+        ratings = ratingsbodies.ALL_RATINGS()
+
+        # Assert all ratings bodies are present.
+        assert ratingsbodies.CLASSIND_L in ratings
+        assert ratingsbodies.GENERIC_3 in ratings
+        assert ratingsbodies.ESRB_E in ratings
+        assert ratingsbodies.PEGI_3 in ratings
+        assert ratingsbodies.USK_0 in ratings
+
+    def test_ratings_by_name_waffle(self):
+        without_waffle = ratingsbodies.RATINGS_BY_NAME()
+
+        self.create_switch('iarc', db=True)
+        with_waffle = ratingsbodies.RATINGS_BY_NAME()
+
+        # Test waffle off excludes ratings.
+        assert len(without_waffle) < len(with_waffle)
+
+    def test_ratings_by_name_lazy_translation(self):
+        generic_3_choice = ratingsbodies.RATINGS_BY_NAME()[6]
+        eq_(generic_3_choice[1], 'Generic - 3+')
+
+    def test_ratings_has_ratingsbody(self):
+        eq_(ratingsbodies.GENERIC_3.ratingsbody, ratingsbodies.GENERIC)
+        eq_(ratingsbodies.CLASSIND_L.ratingsbody, ratingsbodies.CLASSIND)
+        eq_(ratingsbodies.ESRB_E.ratingsbody, ratingsbodies.ESRB)
+        eq_(ratingsbodies.USK_0.ratingsbody, ratingsbodies.USK)
+        eq_(ratingsbodies.PEGI_3.ratingsbody, ratingsbodies.PEGI)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1238,8 +1238,8 @@ class WebappIndexer(MappingType, Indexable):
         for cr in obj.content_ratings.all():
             for region in cr.get_region_slugs():
                 content_ratings.setdefault(region, []).append({
-                    'body': cr.get_body().name,
-                    'name': cr.get_rating().name,
+                    'body': unicode(cr.get_body().name),
+                    'name': unicode(cr.get_rating().name),
                     'description': unicode(cr.get_rating().description),
                 })
 


### PR DESCRIPTION
- Don't concatenate lazy strings in constants.
- Add waffling for ratingsbodies constants.
- Evaluate content ratings lazy strings when indexing Webapps.
- ratingsbodies constants tests.
- More consistent type coercion of `restricted` in developer forms.

![screen shot 2013-11-05 at 12 38 09 pm](https://f.cloud.github.com/assets/674727/1477378/357536e4-465a-11e3-914d-0afc27508e2b.png)

![screen shot 2013-11-05 at 12 38 12 pm](https://f.cloud.github.com/assets/674727/1477377/349f3332-465a-11e3-9e41-1574178a23d0.png)
