### PR TITLE
in-app flag on app rev queue (bug 930707)

### DIFF
--- a/media/css/devreg/reviewers.styl
+++ b/media/css/devreg/reviewers.styl
@@ -216,6 +216,24 @@ nav.paginator {
 }
 .sprite-reviewer-premium {
     background-position: -32px 0;
+
+    &.inapp:after {
+        color: $green;
+        content: '\002B';  // Plus sign.
+        font-size: 22px;
+        left: 10px;
+        position: absolute;
+        text-shadow: -1px 0 #000;
+        top: 1px;
+    }
+    &.free.inapp:before {
+        color: $green;
+        content: '\20E0';  // Prohibited sign.
+        font-size: 16px;
+        position: absolute;
+        right: 1px;
+        text-shadow: -1px 0 $ligt-gray;
+    }
 }
 .sprite-reviewer-info {
     background-position: -32px -16px;

--- a/mkt/reviewers/templates/reviewers/queue.html
+++ b/mkt/reviewers/templates/reviewers/queue.html
@@ -52,9 +52,15 @@
                   {% if qa.app.status == amo.STATUS_BLOCKED %}
                     <div class="sprite-reviewer sprite-reviewer-blocked" title="{{ _('Blocklisted App') }}"></div>
                   {% endif %}
-                  {% if qa.app.is_premium() %}
+
+                  {% if qa.app.premium_type == amo.ADDON_PREMIUM_INAPP %}
+                    <div class="sprite-reviewer sprite-reviewer-premium inapp" title="{{ _('Premium with In-App') }}"></div>
+                  {% elif qa.app.premium_type == amo.ADDON_FREE_INAPP %}
+                    <div class="sprite-reviewer sprite-reviewer-premium free inapp" title="{{ _('Free with In-App') }}"></div>
+                  {% elif qa.app.is_premium() %}
                     <div class="sprite-reviewer sprite-reviewer-premium" title="{{ _('Premium App') }}"></div>
                   {% endif %}
+
                   {% if qa.app.current_version.has_info_request %}
                     <div class="sprite-reviewer sprite-reviewer-info" title="{{ _('More Information Requested') }}"></div>
                   {% endif %}

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -329,6 +329,18 @@ class FlagsMixin(object):
         flags = tds('div.sprite-reviewer-premium')
         eq_(flags.length, 1)
 
+    def test_flag_free_inapp_app(self):
+        self.apps[0].update(premium_type=amo.ADDON_FREE_INAPP)
+        res = self.client.get(self.url)
+        tds = pq(res.content)('#addon-queue tbody tr td:nth-of-type(3)')
+        eq_(tds('div.sprite-reviewer-premium.inapp.free').length, 1)
+
+    def test_flag_premium_inapp_app(self):
+        self.apps[0].update(premium_type=amo.ADDON_PREMIUM_INAPP)
+        res = self.client.get(self.url)
+        tds = pq(res.content)('#addon-queue tbody tr td:nth-of-type(3)')
+        eq_(tds('div.sprite-reviewer-premium.inapp').length, 1)
+
     def test_flag_info(self):
         self.apps[0].current_version.update(has_info_request=True)
         res = self.client.get(self.url)


### PR DESCRIPTION
- Add a little green plus via `:after` to indicate in-app (text-shadow for visibility).

![screen shot 2013-11-08 at 9 38 07 am](https://f.cloud.github.com/assets/674727/1503046/a5574e6a-48a4-11e3-8353-dc870db8c510.png)
