### PR TITLE
descriptors mapping and set iarc descriptors on response (bug 935679)

### DIFF
--- a/lib/iarc/tests/test_utils_.py
+++ b/lib/iarc/tests/test_utils_.py
@@ -1,14 +1,16 @@
 from django.test.utils import override_settings
 
-import test_utils
 from nose.tools import eq_
+
+import amo.tests
 
 from lib.iarc.client import get_iarc_client
 from lib.iarc.utils import IARC_XML_Parser, render_xml
+
 from mkt.constants import ratingsbodies
 
 
-class TestRenderAppInfo(test_utils.TestCase):
+class TestRenderAppInfo(amo.tests.TestCase):
 
     def setUp(self):
         self.template = 'get_app_info.xml'
@@ -27,7 +29,7 @@ class TestRenderAppInfo(test_utils.TestCase):
         assert not '<FIELD NAME="platform"' in xml
 
 
-class TestXMLParser(test_utils.TestCase):
+class TestXMLParser(amo.tests.TestCase):
 
     def setUp(self):
         self.client = get_iarc_client('service')
@@ -52,15 +54,16 @@ class TestXMLParser(test_utils.TestCase):
         eq_(data['ratings'][ratingsbodies.GENERIC], ratingsbodies.GENERIC_16)
 
         # Test descriptors.
-        # TODO: When these turn into constant classes update this.
-        eq_(data['descriptors']['Generic'], 'Language')
-        eq_(data['descriptors']['USK'], 'Explizite Sprache')
-        eq_(data['descriptors']['CLASSIND'],
-            u'Cont\xe9udo Sexual, Linguagem Impr\xf3pria')
-        eq_(data['descriptors']['ESRB'], 'Strong Language')
-        eq_(data['descriptors']['PEGI'], 'Language, Online')
+        eq_(data['descriptors'][ratingsbodies.GENERIC], ['has_generic_lang'])
+        eq_(data['descriptors'][ratingsbodies.USK], ['has_usk_lang'])
+        eq_(data['descriptors'][ratingsbodies.ESRB], [u'has_esrb_strong_lang'])
+        self.assertSetEqual(
+            data['descriptors'][ratingsbodies.CLASSIND],
+            [u'has_classind_sex_content', u'has_classind_lang'])
+        self.assertSetEqual(data['descriptors'][ratingsbodies.PEGI],
+                            ['has_pegi_lang', 'has_pegi_online'])
 
         # Test interactives.
-        self.assertSetEqual(set(data['interactives']),
-                            set(['shares_info', 'shares_location',
-                                 'social_networking', 'users_interact']))
+        self.assertSetEqual(data['interactives'],
+                            ['shares_info', 'shares_location',
+                             'social_networking', 'users_interact'])

--- a/lib/iarc/utils.py
+++ b/lib/iarc/utils.py
@@ -94,18 +94,18 @@ class IARC_XML_Parser(XMLParser):
         descriptors = {}
 
         for k, v in data['ROW'].items():
+            # Get ratings body constant.
+            ratings_body = RATINGS_BODY_MAPPING.get(
+                k.split('_')[-1], ratingsbodies.GENERIC)
+
             if k.startswith('rating_'):
-                rating_body = k.split('_')[-1]
-                # Get ratings body constants.
-                rb_key = RATINGS_BODY_MAPPING.get(
-                    rating_body, ratingsbodies.GENERIC)
-                rb_val = RATINGS_MAPPING[rb_key].get(
-                    v, RATINGS_MAPPING[rb_key]['default'])
-                ratings[rb_key] = rb_val
+                ratings[ratings_body] = RATINGS_MAPPING[ratings_body].get(
+                    v, RATINGS_MAPPING[ratings_body]['default'])
             elif k.startswith('descriptors_'):
-                # TODO: Convert to ratings descriptor classes.
-                rating_body = k.split('_')[-1]
-                descriptors[rating_body] = v
+                native_descs = filter(None, [s.strip() for s in v.split(',')])
+                descriptors[ratings_body] = filter(None, [
+                    DESC_MAPPING[ratings_body].get(desc)
+                    for desc in native_descs])
             else:
                 d[k] = v
 
@@ -184,3 +184,117 @@ RATINGS_MAPPING = {
         'default': ratingsbodies.USK_0,
     },
 }
+
+DESC_MAPPING = {
+    # All values will be capitalized and prepended with '%s_' % RATINGS_BODY in
+    # a loop.
+    ratingsbodies.CLASSIND: {
+        u'Viol\xEAncia': 'violence',
+        u'Viol\xEAncia Extrema': 'violence_extreme',
+        u'Cont\xE9udo Sexual': 'sex_content',
+        u'Nudez': 'nudity',
+        u'Sexo': 'sex_content',
+        u'Sexo Expl\xEDcito': 'sex_explicit',
+        u'Drogas': 'drugs',
+        u'Drogas L\xEDcitas': 'drugs_legal',
+        u'Drogas Il\xEDcitas': 'drugs_illegal',
+        u'Linguagem Impr\xF3pria': 'lang',
+        u'Atos Crim\xEDnosos': 'criminal_acts',
+        u'Conte\xFAdo Impactante': 'shocking',
+        u'N\xE3o h\xE1 inadequa\xE7\xF5es': 'no_descs',
+    },
+
+    ratingsbodies.ESRB: {
+        u'Alcohol Reference': 'alcohol',
+        u'Blood': 'blood',
+        u'Blood and Gore': 'blood_gore',
+        u'Crude Humor': 'crude_humor',
+        u'Drug Reference': 'drug_ref',
+        u'Fantasy Violence': 'fantasy_violence',
+        u'Intense Violence': 'intense_violence',
+        u'Language': 'lang',
+        u'Mild Blood': 'mild_blood',
+        u'Mild Fantasy Violence': 'mild_fantasy_violence',
+        u'Mild Language': 'mild_lang',
+        u'Mild Violence': 'mild_violence',
+        u'Nudity': 'nudity',
+        u'Partial Nudity': 'partial_nudity',
+        u'Real Gambling': 'real_gambling',
+        u'Sexual Content': 'sex_content',
+        u'Sexual Themes': 'sex_themes',
+        u'Simulated Gambling': 'sim_gambling',
+        u'Strong Language': 'strong_lang',
+        u'Strong Sexual Content': 'strong_sex_content',
+        u'Suggestive Themes': 'suggestive',
+        u'Tobacco Reference': 'tobacco_ref',
+        u'Use of Alcohol': 'alcohol_use',
+        u'Use of Drugs': 'drug_use',
+        u'Use of Tobacco': 'tobacco_use',
+        u'Violence': 'violence',
+        u'Violent References': 'violence_ref',
+        u'No Descriptors': 'no_descs',
+        u'Comic Mischief ': 'comic_mischief',
+        u'Alcohol and Tobacco Reference': 'alcohol_tobacco_ref',
+        u'Drug and Alcohol Reference': 'drug_alcohol_ref',
+        u'Use of Alcohol and Tobacco': 'alcohol_tobacco_ref',
+        u'Use of Drug and Alcohol': 'drug_alcohol_use',
+        u'Drug and Tobacco Reference': 'drug_tobacco_ref',
+        u'Drug, Alcohol and Tobacco Reference': 'drug_alcohol_tobacco_ref',
+        u'Use of Drug and Tobacco': 'drug_tobacco_use',
+        u'Use of Drug, Alcohol and Tobacco': 'drug_alcohol_tobacco_use',
+        u'Scary Themes': 'scary',
+        u'Hate Speech': 'hate_speech',
+        u'Crime': 'crime',
+        u'Criminal Instruction': 'crime_instruct',
+    },
+
+    ratingsbodies.GENERIC: {
+        u'Alcohol Reference': 'alcohol_ref',
+        u'Blood': 'blood',
+        u'Blood and Gore': 'blood_gore',
+        u'Crude Humor': 'crude_humor',
+        u'Drug Reference': 'drug_ref',
+        u'Fantasy Violence': 'fantasy_violence',
+        u'Intense Violence': 'intense_violence',
+        u'Language': 'lang',
+        u'Mild Blood': 'mild_blood',
+        u'Mild Fantasy Violence': 'mild_fantasy_violence',
+        u'Mild Language': 'mild_lang',
+        u'Mild Violence': 'mild_violence',
+        u'Nudity': 'nudity',
+        u'Partial Nudity': 'partial_nudity',
+        u'Real Gambling': 'real_gambling',
+        u'Sexual Content': 'sex_content',
+        u'Sexual Themes': 'sex_themes',
+        u'Simulated Gambling': 'sim_gambling',
+        u'Strong Language': 'strong_lang',
+        u'Strong Sexual Content': 'strong_sex_content',
+        u'Suggestive Themes': 'suggestive',
+    },
+
+    ratingsbodies.PEGI: {
+        u'Violence': 'violence',
+        u'Language': 'lang',
+        u'Fear': 'scary',
+        u'Sex': 'sex_content',
+        u'Drugs': 'drugs',
+        u'Discrimination': 'discrimination',
+        u'Gambling': 'gambling',
+        u'Online': 'online',
+        u'No Descriptors': 'no_descs',
+    },
+
+    ratingsbodies.USK: {
+        u'\xC4ngstigende Inhalte': 'scary',
+        u'Erotik/Sexuelle Inhalte': 'sex_content',
+        u'Explizite Sprache': 'lang',
+        u'Diskriminierung': 'discrimination',
+        u'Drogen': 'drugs',
+        u'Gewalt': 'violence',
+    },
+}
+
+for body, mappings in DESC_MAPPING.items():
+    for native_desc, desc_slug in mappings.items():
+        DESC_MAPPING[body][native_desc] = 'has_{0}_{1}'.format(
+            body.name, desc_slug).lower()

--- a/migrations/692-rating-descs-fix.sql
+++ b/migrations/692-rating-descs-fix.sql
@@ -1,0 +1,3 @@
+ALTER TABLE webapps_rating_descriptors
+    ADD COLUMN `has_classind_nudity` bool NOT NULL,
+    DROP COLUMN `has_classind_sexual_content`;

--- a/mkt/constants/ratingdescriptors.py
+++ b/mkt/constants/ratingdescriptors.py
@@ -5,33 +5,47 @@ from tower import ugettext_lazy as _lazy
 
 # WARNING: When adding a new rating descriptor here also include a migration.
 #
-# WARNING: Order matters here. Don't re-order these or alphabetize them. If you
-# add new ones put them on the end.
-#
 # These are used to dynamically generate the field list for the
 # RatingDescriptors django model in mkt.webapps.models.
 RATING_DESCS = OrderedDict([
-    ('USK_NO_DESCS', {
-        'name': _lazy('No Descriptors'),
+    # ngoke can read Porchugeeze.
+    ('CLASSIND_VIOLENCE', {
+        'name': _lazy('Violence'),
     }),
-    ('USK_SCARY', {
-        'name': _lazy('Frightening Content'),
+    ('CLASSIND_VIOLENCE_EXTREME', {
+        'name': _lazy('Extreme Violence'),
     }),
-    ('USK_SEX_CONTENT', {
-        'name': _lazy('Sexual Content'),
+    ('CLASSIND_NUDITY', {
+        'name': _lazy('Nudity'),
     }),
-    ('USK_LANG', {
+    ('CLASSIND_SEX_CONTENT', {
+        # L10n: `Sex` as in sexual, not as in gender.
+        'name': _lazy('Sex'),
+    }),
+    ('CLASSIND_SEX_EXPLICIT', {
+        'name': _lazy('Explicit Sex'),
+    }),
+    ('CLASSIND_DRUGS', {
+        'name': _lazy('Drugs'),
+    }),
+    ('CLASSIND_DRUGS_LEGAL', {
+        'name': _lazy('Legal Drugs'),
+    }),
+    ('CLASSIND_DRUGS_ILLEGAL', {
+        'name': _lazy('Illegal Drugs'),
+    }),
+    ('CLASSIND_LANG', {
         # L10n: `Language` as in foul language.
         'name': _lazy('Language'),
     }),
-    ('USK_DISCRIMINATION', {
-        'name': _lazy('Discrimination'),
+    ('CLASSIND_CRIMINAL_ACTS', {
+        'name': _lazy('Criminal Acts'),
     }),
-    ('USK_DRUGS', {
-        'name': _lazy('Drugs'),
+    ('CLASSIND_SHOCKING', {
+        'name': _lazy('Shocking Content'),
     }),
-    ('USK_VIOLENCE', {
-        'name': _lazy('Violence'),
+    ('CLASSIND_NO_DESCS', {
+        'name': _lazy('No Descriptors'),
     }),
     ('ESRB_ALCOHOL', {
         'name': _lazy('Alcohol Reference'),
@@ -165,7 +179,7 @@ RATING_DESCS = OrderedDict([
         'name': _lazy('Language'),
     }),
     ('PEGI_SCARY', {
-        'name': _lazy('Scary'),
+        'name': _lazy('Fear'),
     }),
     ('PEGI_SEX_CONTENT', {
         # L10n: `Sex` as in sexual, not as in gender.
@@ -184,45 +198,6 @@ RATING_DESCS = OrderedDict([
         'name': _lazy('Online'),
     }),
     ('PEGI_NO_DESCS', {
-        'name': _lazy('No Descriptors'),
-    }),
-    # ngoke can read Porchugeeze.
-    ('CLASSIND_VIOLENCE', {
-        'name': _lazy('Violence'),
-    }),
-    ('CLASSIND_VIOLENCE_EXTREME', {
-        'name': _lazy('Extreme Violence'),
-    }),
-    ('CLASSIND_SEXUAL_CONTENT', {
-        'name': _lazy('Sexual Content'),
-    }),
-    ('CLASSIND_SEX_CONTENT', {
-        # L10n: `Sex` as in sexual, not as in gender.
-        'name': _lazy('Sex'),
-    }),
-    ('CLASSIND_SEX_EXPLICIT', {
-        'name': _lazy('Explicit Sex'),
-    }),
-    ('CLASSIND_DRUGS', {
-        'name': _lazy('Drugs'),
-    }),
-    ('CLASSIND_DRUGS_LEGAL', {
-        'name': _lazy('Legal Drugs'),
-    }),
-    ('CLASSIND_DRUGS_ILLEGAL', {
-        'name': _lazy('Illegal Drugs'),
-    }),
-    ('CLASSIND_LANG', {
-        # L10n: `Language` as in foul language.
-        'name': _lazy('Language'),
-    }),
-    ('CLASSIND_CRIMINAL_ACTS', {
-        'name': _lazy('Criminal Acts'),
-    }),
-    ('CLASSIND_SHOCKING', {
-        'name': _lazy('Shocking Content'),
-    }),
-    ('CLASSIND_NO_DESCS', {
         'name': _lazy('No Descriptors'),
     }),
     # Generic ratings same as ESRB, except less drugs/alcohol/tobacco.
@@ -289,5 +264,27 @@ RATING_DESCS = OrderedDict([
     }),
     ('GENERIC_SUGGESTIVE', {
         'name': _lazy('Suggestive Themes'),
+    }),
+    ('USK_NO_DESCS', {
+        'name': _lazy('No Descriptors'),
+    }),
+    ('USK_SCARY', {
+        'name': _lazy('Frightening Content'),
+    }),
+    ('USK_SEX_CONTENT', {
+        'name': _lazy('Sexual Content'),
+    }),
+    ('USK_LANG', {
+        # L10n: `Language` as in foul language.
+        'name': _lazy('Language'),
+    }),
+    ('USK_DISCRIMINATION', {
+        'name': _lazy('Discrimination'),
+    }),
+    ('USK_DRUGS', {
+        'name': _lazy('Drugs'),
+    }),
+    ('USK_VIOLENCE', {
+        'name': _lazy('Violence'),
     }),
 ])

--- a/mkt/constants/ratinginteractives.py
+++ b/mkt/constants/ratinginteractives.py
@@ -5,9 +5,6 @@ from tower import ugettext_lazy as _lazy
 
 # WARNING: When adding a new interactive element here also include a migration.
 #
-# WARNING: Order matters here. Don't re-order these or alphabetize them. If you
-# add new ones put them on the end.
-#
 # These are used to dynamically generate the field list for the
 # RatingInteractives django model in mkt.webapps.models.
 RATING_INTERACTIVES = OrderedDict([

--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -127,7 +127,7 @@ class GENERIC(RATING_BODY):
     The generic game ratings body (used in Germany, for example).
     """
     id = 1
-    name = _lazy(u'Generic')
+    name = 'Generic'
     description = ''  # No comment.
 
     ratings = (GENERIC_3, GENERIC_7, GENERIC_12, GENERIC_16, GENERIC_18)

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -1001,8 +1001,8 @@ class IARCGetAppInfoForm(happyforms.Form):
 
         if ratings:
             app.set_content_ratings(data.get('ratings', {}))
+            app.set_descriptors(data.get('descriptors', []))
             app.set_interactives(data.get('interactives', []))
-            # TODO: Also save the rating descriptors.
         else:
             msg = _('Content rating record not found.')
             self._errors['submission_id'] = self.error_class([msg])

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -951,13 +951,32 @@ class Webapp(Addon):
 
             {<ratingsbodies class>: <rating class>, ...}
 
-
         """
         for ratings_body, rating in data.items():
             cr, created = self.content_ratings.safer_get_or_create(
                 ratings_body=ratings_body.id, defaults={'rating': rating.id})
             if not created:
                 cr.update(rating=rating.id)
+
+    def set_descriptors(self, data):
+        """
+        Sets IARC rating descriptors on this app.
+
+        This overwrites or creates elements, it doesn't delete and expects data
+        of the form:
+
+            [<has_descriptor_1>, <has_descriptor_6>]
+
+        """
+        create_kwargs = {}
+        for desc in mkt.ratingdescriptors.RATING_DESCS.keys():
+            has_desc_attr = 'has_%s' % desc.lower()
+            create_kwargs[has_desc_attr] = has_desc_attr in data
+
+        rd, created = RatingDescriptors.objects.get_or_create(
+            addon=self, defaults=create_kwargs)
+        if not created:
+            rd.update(**create_kwargs)
 
     def set_interactives(self, data):
         """
@@ -967,7 +986,6 @@ class Webapp(Addon):
         of the form:
 
             [<interactive name 1>, <interactive name 2>]
-
 
         """
         create_kwargs = {}


### PR DESCRIPTION
- Create mapping from IARC response's descriptor names to our descriptor names.
- Maps their native language descriptor names to our RatingDescriptors field names (e.g. esrb -> blood -> has_esrb_blood)
- Set descriptor on their response from the IARC get app info form.
- Found that order doesn't matter in the descriptors/interactives constants since no signatures.
