### PR TITLE
Support Server Name Indication (bug 875142)

### DIFF
--- a/docs/topics/install-zamboni/installation.rst
+++ b/docs/topics/install-zamboni/installation.rst
@@ -40,7 +40,7 @@ The following command will install the required development files on Ubuntu or,
 if you're running a recent version, you can `install them automatically
 <apt:python-dev,python-virtualenv,libxml2-dev,libxslt1-dev,libmysqlclient-dev,libmemcached-dev>`_::
 
-    sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev libmemcached-dev libssl-dev swig
+    sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev libmemcached-dev libssl-dev swig openssl
 
 On versions 12.04 and later, you will need to install a patched version of
 M2Crypto instead of the version from PyPI.::

--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -8,5 +8,8 @@ PIL==1.1.7
 # Temporary.
 M2Crypto==0.20.2
 
+# To get SNI support in requests (needed by the app validator).
+pyOpenSSL==0.13.1
+
 # For the addon validator, including C speedups.
 simplejson==2.3.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -63,11 +63,13 @@ monolith.client==0.9
 moz-addon-packager==1.0.1
 mozpay==2.0.0
 m2secret==0.1.1
+ndg-httpsclient==0.3.2
 nose==1.3.0
 newrelic==2.4.0.4
 oauth2==1.5.211
 oauthlib==0.4.0
 ordereddict==1.1
+pyasn1==0.1.7
 PyBrowserID==0.6
 pyelasticsearch==0.6
 pyes==0.16.0
@@ -83,7 +85,7 @@ rdflib==3.0.0
 recaptcha-client==1.0.5
 receipts==0.2.6
 redis==2.7.6
-requests==1.2.0
+requests==2.0.0
 schematic==0.2
 #signing_clients==0.1.7
 six==1.3.0


### PR DESCRIPTION
requests 2.0.0 has SNI support if the correct dependencies are installed, and doesn't have the breakage with persona that 1.2.3 had. Unfortunately we can't directly use the latest, 2.0.1, because of https://github.com/kennethreitz/requests/issues/1732

See also the old PR from @kumar303, which we never merged because of the persona breakage: #888
