### PR TITLE
fix next steps page, iarc form layout, missing interactives columns

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1158,6 +1158,9 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
     def is_public(self):
         return self.status == amo.STATUS_PUBLIC and not self.disabled_by_user
 
+    def is_public_waiting(self):
+        return self.status == amo.STATUS_PUBLIC_WAITING
+
     def is_incomplete(self):
         return self.status == amo.STATUS_NULL
 

--- a/media/css/devreg/content_ratings.styl
+++ b/media/css/devreg/content_ratings.styl
@@ -38,6 +38,21 @@
     }
 }
 
+#ratings-edit {
+    .iarc-sec-code {
+        th {
+            width: 100px;
+        }
+        tr {
+            display: block;
+            margin-bottom: 13px;
+        }
+        input {
+            margin-right: 5px;
+        }
+    }
+}
+
 /* Copied and modified from Fireplace detail styles. */
 $box-green = #00b963;
 $box-blue = #00d5ff;

--- a/migrations/695_rating-interactives-fix.sql
+++ b/migrations/695_rating-interactives-fix.sql
@@ -1,0 +1,2 @@
+ALTER TABLE webapps_rating_interactives
+    ADD COLUMN `has_social_networking` bool NOT NULL;

--- a/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
+++ b/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
@@ -88,30 +88,30 @@
                 <th>
                   <label for="{{ form.submission_id.auto_id }}">
                     {{ _('Submission ID') }}
-                    {{ tip(None,
-                           _('The submission ID can be found on the certificate sent to you.
-                              It is a numeric value like &quot;14&quot;.')) }}
+                    {{ required() }}
                   </label>
-                  {{ required() }}
                 </th>
                 <td>
                   {{ form.submission_id }}
                   {{ form.submission_id.errors }}
+                  {{ tip(None,
+                           _('The submission ID can be found on the certificate sent to you.
+                              It is a numeric value like &quot;14&quot;.')) }}
                 </td>
               </tr>
               <tr>
                 <th>
                   <label for="{{ form.security_code.auto_id }}">
                     {{ _('Security Code') }}
-                    {{ tip(None,
-                           _('The security code can be found on the certificate sent to you.
-                              It is a mix of letters and numbers like &quot;AB12CD3&quot;.')) }}
+                    {{ required() }}
                   </label>
-                  {{ required() }}
                 </th>
                 <td>
                   {{ form.security_code }}
                   {{ form.security_code.errors }}
+                  {{ tip(None,
+                           _('The security code can be found on the certificate sent to you.
+                              It is a mix of letters and numbers like &quot;AB12CD3&quot;.')) }}
                 </td>
               </tr>
             </tbody>

--- a/mkt/submit/tests/test_views.py
+++ b/mkt/submit/tests/test_views.py
@@ -1025,6 +1025,7 @@ class TestNextSteps(amo.tests.TestCase):
         self.user = UserProfile.objects.get(username='regularuser')
         assert self.client.login(username=self.user.email, password='password')
         self.webapp = Webapp.objects.get(id=337141)
+        self.webapp.update(status=amo.STATUS_PENDING)
         self.url = reverse('submit.app.done', args=[self.webapp.app_slug])
 
     def test_200(self, **kw):


### PR DESCRIPTION
- Next steps page (under iarc waffle) was calling `is_public_waiting` when that method didn't exist.
- Fix form (form with security code/IARC ID) layout on content ratings page
- Was missing `has_social_networking` column for `webapps_rating_interactives`
  ![screen shot 2013-11-12 at 12 36 53 pm](https://f.cloud.github.com/assets/674727/1525873/e0c12a18-4bdb-11e3-81d8-cbcf087c9f72.png)
