### PR TITLE
call set_storefront_data before app goes live (bug 931945)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -56,9 +56,8 @@ from users.models import RequestUser
 
 import mkt
 from mkt.constants import regions
-from mkt.webapps.models import (
-    ContentRating, update_search_index as app_update_search_index,
-    WebappIndexer, Webapp)
+from mkt.webapps.models import (update_search_index as app_update_search_index,
+                                ContentRating, WebappIndexer, Webapp)
 from mkt.webapps.tasks import unindex_webapps
 
 
@@ -607,6 +606,9 @@ def app_factory(**kw):
     app = amo.tests.addon_factory(**kw)
     if waffle.switch_is_active('iarc') and kw.get('rated'):
         ContentRating.objects.create(addon=app, ratings_body=0, rating=0)
+        app.set_iarc_info(123, 'abc')
+        app.set_descriptors([])
+        app.set_interactives([])
     return app
 
 
@@ -863,11 +865,12 @@ def make_game(app, rated):
         type=amo.ADDON_WEBAPP)
     app.addoncategory_set.create(category=cat)
     if rated:
-        ContentRating.objects.get_or_create(
-            addon=app, ratings_body=mkt.ratingsbodies.CLASSIND.id,
-            rating=mkt.ratingsbodies.CLASSIND_18.id)
-        ContentRating.objects.get_or_create(
-            addon=app, ratings_body=mkt.ratingsbodies.CLASSIND.id,
-            rating=mkt.ratingsbodies.CLASSIND_L.id)
+        app.set_iarc_info(123, 'abc')
+        app.set_descriptors([])
+        app.set_interactives([])
+        app.set_content_ratings({
+            mkt.ratingsbodies.CLASSIND: mkt.ratingsbodies.CLASSIND_18,
+            mkt.ratingsbodies.ESRB: mkt.ratingsbodies.ESRB_A,
+        })
     app = app.reload()
     return app

--- a/lib/iarc/tests/test_utils_.py
+++ b/lib/iarc/tests/test_utils_.py
@@ -117,5 +117,5 @@ class TestXMLParser(amo.tests.TestCase):
 
         # Test interactives.
         self.assertSetEqual(data['interactives'],
-                            ['shares_info', 'shares_location',
-                             'social_networking', 'users_interact'])
+                            ['has_shares_info', 'has_shares_location',
+                             'has_social_networking', 'has_users_interact'])

--- a/lib/iarc/utils.py
+++ b/lib/iarc/utils.py
@@ -180,13 +180,14 @@ class IARC_JSON_Parser(JSONParser, IARC_Parser):
 # to the ratings body constants in mkt/constants/ratingsbodies. Likewise for
 # the descriptors.
 RATINGS_BODY_MAPPING = {
-    'CLASSIND': ratingsbodies.CLASSIND,
-    'ESRB': ratingsbodies.ESRB,
-    'Generic': ratingsbodies.GENERIC,
-    'PEGI': ratingsbodies.PEGI,
-    'USK': ratingsbodies.USK,
+    'classind': ratingsbodies.CLASSIND,
+    'esrb': ratingsbodies.ESRB,
+    'generic': ratingsbodies.GENERIC,
+    'pegi': ratingsbodies.PEGI,
+    'usk': ratingsbodies.USK,
     'default': ratingsbodies.GENERIC,
 }
+
 
 RATINGS_MAPPING = {
     ratingsbodies.CLASSIND: {
@@ -233,9 +234,9 @@ RATINGS_MAPPING = {
     },
 }
 
+
 DESC_MAPPING = {
-    # All values will be capitalized and prepended with '%s_' % RATINGS_BODY in
-    # a loop.
+    # All values will be prepended with 'has_%s_' % RATINGS_BODY later.
     ratingsbodies.CLASSIND: {
         u'Viol\xEAncia': 'violence',
         u'Viol\xEAncia Extrema': 'violence_extreme',
@@ -284,7 +285,7 @@ DESC_MAPPING = {
         u'Comic Mischief ': 'comic_mischief',
         u'Alcohol and Tobacco Reference': 'alcohol_tobacco_ref',
         u'Drug and Alcohol Reference': 'drug_alcohol_ref',
-        u'Use of Alcohol and Tobacco': 'alcohol_tobacco_ref',
+        u'Use of Alcohol and Tobacco': 'alcohol_tobacco_use',
         u'Use of Drug and Alcohol': 'drug_alcohol_use',
         u'Drug and Tobacco Reference': 'drug_tobacco_ref',
         u'Drug, Alcohol and Tobacco Reference': 'drug_alcohol_tobacco_ref',
@@ -333,6 +334,7 @@ DESC_MAPPING = {
     },
 
     ratingsbodies.USK: {
+        u'No Descriptors': 'no_descs',
         u'\xC4ngstigende Inhalte': 'scary',
         u'Erotik/Sexuelle Inhalte': 'sex_content',
         u'Explizite Sprache': 'lang',
@@ -342,7 +344,29 @@ DESC_MAPPING = {
     },
 }
 
+
 for body, mappings in DESC_MAPPING.items():
     for native_desc, desc_slug in mappings.items():
         DESC_MAPPING[body][native_desc] = 'has_{0}_{1}'.format(
-            body.name, desc_slug).lower()
+            body.iarc_name, desc_slug).lower()
+
+# Change {body: {'key': 'val'}} to {'val': 'key'}.
+REVERSE_DESC_MAPPING_BY_BODY = (
+    dict([(unicode(v), unicode(k)) for k, v in body_mapping.iteritems()])
+    for body, body_mapping in DESC_MAPPING.iteritems())
+REVERSE_DESC_MAPPING = {}
+for mapping in REVERSE_DESC_MAPPING_BY_BODY:
+    REVERSE_DESC_MAPPING.update(mapping)
+
+
+INTERACTIVES_MAPPING = {
+    'Users Interact': 'has_users_interact',
+    'Shares Info': 'has_shares_info',
+    'Shares Location': 'has_shares_location',
+    'Digital Purchases': 'has_digital_purchases',
+    'Social Networking': 'has_social_networking',
+    'Digital Content Portal': 'has_digital_content_portal',
+}
+
+REVERSE_INTERACTIVES_MAPPING = dict(
+    (v, k) for k, v in INTERACTIVES_MAPPING.iteritems())

--- a/media/css/devreg/status.styl
+++ b/media/css/devreg/status.styl
@@ -41,7 +41,7 @@
 .status-info {
     .status {
         display: block;
-        margin-bottom: 10px;
+        margin-bottom: 13px;
     }
     .island {
         margin: 20px 0;
@@ -53,6 +53,9 @@
         div[style]:first-child + p:last-child {
             margin: 15px 0 0;
         }
+    }
+    p:last-child {
+        margin-bottom: 13px;
     }
 }
 

--- a/migrations/699-rating-unique-together.sql
+++ b/migrations/699-rating-unique-together.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `webapps_contentrating` ADD UNIQUE index(`addon_id`, `ratings_body`);

--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -32,47 +32,72 @@ RATING_DESCS = {
 
 
 class RATING(object):
-    """Content rating."""
+    """
+    Content rating.
+
+    name -- how we name the rating, for translated display on all pages.
+    description -- for general translated display on consumer pages.
+    iarc_name -- how IARC names the rating, to talk with IARC.
+
+    slug -- for CSS classes, to create icons. Dynamic. generated for most.
+    """
 
 
 class RATING_BODY(object):
-    """Content rating body."""
+    """
+    Content rating body.
+
+    name -- for general translated display on all pages.
+    description -- for general translated display on all pages.
+    iarc_name -- how IARC names the ratings body, to talk with IARC.
+
+    ratings -- list of RATINGs associated with this body.
+
+    full_name -- in case we ever want to display the full translated name.
+    url -- in case we ever want to link to the ratings body page for more info.
+    """
 
 
 class CLASSIND_L(RATING):
     id = 0
     name = '0+'
     description = RATING_DESCS['0']
+    iarc_name = '0+'
 
 
 class CLASSIND_10(RATING):
     id = 1
     name = '10+'
     description = RATING_DESCS['10']
+    iarc_name = '10+'
 
 
 class CLASSIND_12(RATING):
     id = 2
     name = '12+'
     description = RATING_DESCS['12']
+    iarc_name = '12+'
 
 
 class CLASSIND_14(RATING):
     id = 3
     name = '14+'
     description = RATING_DESCS['14']
+    iarc_name = '14+'
 
 
 class CLASSIND_16(RATING):
     id = 4
     name = '16+'
     description = RATING_DESCS['16']
+    iarc_name = '16+'
 
 
 class CLASSIND_18(RATING):
     id = 5
     name = '18+'
     description = RATING_DESCS['18']
+    iarc_name = '18+'
 
 
 class CLASSIND(RATING_BODY):
@@ -82,6 +107,7 @@ class CLASSIND(RATING_BODY):
     id = 0
     name = 'CLASSIND'
     description = _lazy(u'Brazil')
+    iarc_name = 'CLASSIND'
 
     ratings = (CLASSIND_L, CLASSIND_10, CLASSIND_12, CLASSIND_14, CLASSIND_16,
                CLASSIND_18)
@@ -96,30 +122,35 @@ class GENERIC_3(RATING):
     id = 0
     name = '3+'
     description = RATING_DESCS['3']
+    iarc_name = '3+'
 
 
 class GENERIC_7(RATING):
     id = 1
     name = '7+'
     description = RATING_DESCS['7']
+    iarc_name = '7+'
 
 
 class GENERIC_12(RATING):
     id = 2
     name = '12+'
     description = RATING_DESCS['12']
+    iarc_name = '12+'
 
 
 class GENERIC_16(RATING):
     id = 3
     name = '16+'
     description = RATING_DESCS['16']
+    iarc_name = '16+'
 
 
 class GENERIC_18(RATING):
     id = 4
     name = '18+'
     description = RATING_DESCS['18']
+    iarc_name = '18+'
 
 
 class GENERIC(RATING_BODY):
@@ -127,8 +158,9 @@ class GENERIC(RATING_BODY):
     The generic game ratings body (used in Germany, for example).
     """
     id = 1
-    name = 'Generic'
+    name = _lazy('Generic')
     description = ''  # No comment.
+    iarc_name = 'Generic'
 
     ratings = (GENERIC_3, GENERIC_7, GENERIC_12, GENERIC_16, GENERIC_18)
 
@@ -139,36 +171,42 @@ class USK_0(RATING):
     id = 0
     name = '0+'
     description = RATING_DESCS['0']
+    iarc_name = '0+'
 
 
 class USK_6(RATING):
     id = 1
     name = '6+'
     description = RATING_DESCS['6']
+    iarc_name = '6+'
 
 
 class USK_12(RATING):
     id = 2
     name = '12+'
     description = RATING_DESCS['12']
+    iarc_name = '12+'
 
 
 class USK_16(RATING):
     id = 3
     name = '16+'
     description = RATING_DESCS['16']
+    iarc_name = '16+'
 
 
 class USK_18(RATING):
     id = 4
     name = '18+'
     description = RATING_DESCS['18']
+    iarc_name = '18+'
 
 
 class USK_REJECTED(RATING):
     id = 5
-    name = _lazy('Rejected')
+    name = _lazy('Rating Rejected')
     description = RATING_DESCS['X']
+    iarc_name = 'Rating Rejected'
 
 
 class USK(RATING_BODY):
@@ -179,6 +217,7 @@ class USK(RATING_BODY):
     id = 2
     name = 'USK'
     description = _lazy(u'Germany')
+    iarc_name = 'USK'
 
     ratings = (USK_0, USK_6, USK_12, USK_16, USK_18, USK_REJECTED)
 
@@ -190,8 +229,10 @@ class ESRB_E(RATING):
     """Everybody."""
     id = 0
     name = _lazy('Everyone')
-    slug = '0'
     description = RATING_DESCS['0']
+    iarc_name = 'Everyone'
+
+    slug = '0'
 
 
 class ESRB_10(RATING):
@@ -199,6 +240,7 @@ class ESRB_10(RATING):
     name = _lazy('Everyone 10+')  # L10n: `10+` is age ten and over.
     slug = '10'
     description = RATING_DESCS['10']
+    iarc_name = 'Everyone 10+'
 
 
 class ESRB_T(RATING):
@@ -206,6 +248,7 @@ class ESRB_T(RATING):
     name = _lazy('Teen')
     slug = '13'
     description = RATING_DESCS['13']
+    iarc_name = 'Teen'
 
 
 class ESRB_M(RATING):
@@ -213,6 +256,7 @@ class ESRB_M(RATING):
     name = _lazy('Mature 17+')  # L10n: `17+` is age seventeen and over.
     slug = '17'
     description = RATING_DESCS['17']
+    iarc_name = 'Mature 17+'
 
 
 class ESRB_A(RATING):
@@ -220,6 +264,7 @@ class ESRB_A(RATING):
     name = _lazy('Adults Only 18+')  # L10n: `18+` is age eighteen and over.
     slug = '18'
     description = RATING_DESCS['18']
+    iarc_name = 'Adults Only'
 
 
 class ESRB_RP(RATING):
@@ -227,6 +272,7 @@ class ESRB_RP(RATING):
     name = _lazy('Rating Pending')
     slug = 'pending'
     description = RATING_DESCS['18']
+    iarc_name = 'Rating Pending'
 
 
 class ESRB(RATING_BODY):
@@ -236,6 +282,7 @@ class ESRB(RATING_BODY):
     id = 3
     name = 'ESRB'
     description = _lazy(u'N. America')  # L10n: `N.` stands for North.
+    iarc_name = 'ESRB'
 
     ratings = (ESRB_E, ESRB_10, ESRB_T, ESRB_M, ESRB_A)
 
@@ -247,30 +294,35 @@ class PEGI_3(RATING):
     id = 0
     name = '3+'
     description = RATING_DESCS['3']
+    iarc_name = '3+'
 
 
 class PEGI_7(RATING):
     id = 1
     name = '7+'
     description = RATING_DESCS['7']
+    iarc_name = '7+'
 
 
 class PEGI_12(RATING):
     id = 2
     name = '12+'
     description = RATING_DESCS['12']
+    iarc_name = '12+'
 
 
 class PEGI_16(RATING):
     id = 3
     name = '16+'
     description = RATING_DESCS['16']
+    iarc_name = '16+'
 
 
 class PEGI_18(RATING):
     id = 4
     name = '18+'
     description = RATING_DESCS['18']
+    iarc_name = '18+'
 
 
 class PEGI(RATING_BODY):
@@ -280,6 +332,7 @@ class PEGI(RATING_BODY):
     id = 4
     name = 'PEGI'
     description = _lazy(u'Europe')
+    iarc_name = 'PEGI'
 
     ratings = (PEGI_3, PEGI_7, PEGI_12, PEGI_16, PEGI_18)
 

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -1101,7 +1101,6 @@ class IARCGetAppInfoForm(happyforms.Form):
         if data.get('ratings'):
             # We found a rating, so store the id and code for future use.
             app.set_iarc_info(iarc_id, iarc_code)
-
             app.set_content_ratings(data.get('ratings', {}))
             app.set_descriptors(data.get('descriptors', []))
             app.set_interactives(data.get('interactives', []))

--- a/mkt/developers/templates/developers/apps/status.html
+++ b/mkt/developers/templates/developers/apps/status.html
@@ -31,6 +31,11 @@
               <a href="{{ addon.get_dev_url('payments') }}">
                 {{- _('Set Up Payments') -}}
               </a>
+            {% elif waffle.switch('iarc') and not addon.is_rated() and addon.is_complete()[0] %}
+              {{ status(_('This app is <b>incomplete</b> because it is missing content ratings.')) }}
+              <a href="{{ addon.get_dev_url('ratings') }}">
+                {{- _('Set Up Content Ratings') -}}
+              </a>
             {% else %}
               {{ status(_('This app is <b>incomplete</b>.')|safe) }}
               <a href="{{ url('submit.app.resume', addon.app_slug) }}">
@@ -58,8 +63,8 @@
           {% elif addon.status == amo.STATUS_REJECTED %}
             {{ status(_('This app has been <b>rejected</b> by a Firefox Marketplace reviewer.')|safe) }}
           {% elif addon.status == amo.STATUS_PUBLIC_WAITING %}
-            {{ status(_('Your app has been <b>approved but is not public</b>.')|safe) }}
-            {{ _('It is awaiting your approval to make public.') }}
+            {{ status(_('Your app has been <b>approved but not yet published</b>.')|safe) }}
+            {{ _('This app is waiting for your approval to be published.') }}
           {% endif %}
           {% if not (addon.is_disabled or addon.is_incomplete()) %}
             <p><a href="https://developer.mozilla.org/en-US/docs/Apps/Marketplace_Review"
@@ -106,7 +111,7 @@
         {% if addon.status == amo.STATUS_PUBLIC_WAITING %}
           <form method="post" action="{{ addon.get_dev_url('publicise') }}">
             {{ csrf() }}
-            <p class="listing-footer"><button type="submit">{{ _('Make App public') }}</button></p>
+            <p class="listing-footer"><button type="submit">{{ _('Publish App') }}</button></p>
           </form>
         {% endif %}
       </div>

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -420,9 +420,11 @@ class TestPublicise(amo.tests.TestCase):
     def test_publicise_get(self):
         eq_(self.client.get(self.publicise_url).status_code, 405)
 
+    @mock.patch('mkt.webapps.models.Webapp.set_iarc_storefront_data')
     @mock.patch('mkt.webapps.models.Webapp.update_supported_locales')
     @mock.patch('mkt.webapps.models.Webapp.update_name_from_package_manifest')
-    def test_publicise(self, update_name, update_locales):
+    def test_publicise(self, update_name, update_locales, storefront_mock):
+        self.create_switch('iarc')
         res = self.client.post(self.publicise_url)
         eq_(res.status_code, 302)
         eq_(self.get_webapp().status, amo.STATUS_PUBLIC)
@@ -430,6 +432,7 @@ class TestPublicise(amo.tests.TestCase):
             amo.STATUS_PUBLIC)
         assert update_name.called
         assert update_locales.called
+        assert storefront_mock.called
 
     def test_status(self):
         res = self.client.get(self.status_url)

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -197,6 +197,9 @@ def publicise(request, addon_id, addon):
         addon.update_name_from_package_manifest()
         addon.update_supported_locales()
 
+        if waffle.switch_is_active('iarc'):
+            addon.set_iarc_storefront_data()
+
     return redirect(addon.get_dev_url('versions'))
 
 

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -269,6 +269,9 @@ class ReviewApp(ReviewBase):
             # Failsafe.
             return
 
+        if waffle.switch_is_active('iarc'):
+            self.addon.set_iarc_storefront_data()
+
         self.addon.sign_if_packaged(self.version.pk)
         # Save files first, because set_addon checks to make sure there
         # is at least one public file or it won't make the addon public.


### PR DESCRIPTION
**Notes**
- Uses `lib.iarc.client.Client.Set_Storefront_data`.
- Call `Webapp.set_iarc_storefront_data` on `process_public_immediately` on Reviewers side, and `publicise` on Developer side.
- "Deserialize" descriptors and interactive elements from our representation back to IARC by reversing the original mapping in `lib.iarc.utils`.
- Switch on `iarc` waffle in Reviewers `TestReviewApp` test suite.
- Fix status page to indicate whether an app needs a content rating.
- Define `iarc_name`s, strings on how the IARC represents Ratingsbodies and Ratings in ratingsbodies constants
