### PR TITLE
WIP: create separate China queue for apps pending in China (bug 937988)

### DIFF
--- a/apps/access/acl.py
+++ b/apps/access/acl.py
@@ -102,7 +102,13 @@ def check_addon_ownership(request, addon, viewer=False, dev=False,
                                 addonuser__role__in=roles).exists()
 
 
-def check_reviewer(request, only=None):
+def check_reviewer(request, only=None, region=None):
+    if only == 'app' and region is not None:
+        # This is for reviewers in special regions (e.g., China).
+        from mkt.regions.utils import parse_region
+        region_slug = parse_region(region).slug.upper()
+        return action_allowed(request, 'Apps', 'ReviewRegion%s' % region_slug)
+
     addon = action_allowed(request, 'Addons', 'Review')
     app = action_allowed(request, 'Apps', 'Review')
     persona = action_allowed(request, 'Personas', 'Review')

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -51,7 +51,7 @@ def _view_on_get(request):
             acl.action_allowed(request, 'ReviewerTools', 'View'))
 
 
-def reviewer_required(only=None):
+def reviewer_required(only=None, region=None):
     """Requires the user to be logged in as a reviewer or admin, or allows
     someone with rule 'ReviewerTools:View' for GET requests.
 
@@ -70,7 +70,8 @@ def reviewer_required(only=None):
         @login_required
         @functools.wraps(f)
         def wrapper(request, *args, **kw):
-            if acl.check_reviewer(request, only) or _view_on_get(request):
+            if (acl.check_reviewer(request, only, region=kw.get('region')) or
+                _view_on_get(request)):
                 return f(request, *args, **kw)
             else:
                 raise PermissionDenied

--- a/media/css/devreg/notification.styl
+++ b/media/css/devreg/notification.styl
@@ -1,0 +1,57 @@
+@import 'lib';
+
+#notification {
+    border-box();
+    background-color: #3b3b3b;
+    bottom: -62px;
+    color: #fff;
+    cursor: pointer;
+    font-family: "MozTT", $open-stack;
+    grain();
+    height: 62px;
+    left: 0;
+    line-height: 42px; // height less padding.
+    margin: 0 auto;
+    padding: 10px 15px;
+    position: fixed;
+    right: 0;
+    // If this duration is increased update the duration in notification.js
+    // to ensure hiding the notification only happens when transition is complete.
+    transition-duration(.3s);
+    // Using bottom here rather than translateY as the latter causes problems
+    // on FF b2g (bug 886334)
+    transition-property(bottom);
+    width: 100%;
+    z-index: 9999;
+    &.show {
+        bottom: 0;
+        transition-duration(.3s);
+        transition-property(bottom);
+    }
+    &.hidden {
+        display: none;
+    }
+    &.good {
+        background-color: #003b00;
+    }
+    &.bad {
+        background-color: #3b0000;
+    }
+}
+
+#notification-content {
+    display: inline-block;
+    line-height: 1.5;
+    vertical-align: middle;
+    b {
+      text-transform: uppercase;
+      color: #0995b0;
+  }
+}
+
+@media (min-width: 600px) {
+    #notification {
+        border-radius: 4px 4px 0 0;
+        max-width: 600px;
+    }
+}

--- a/media/css/devreg/reviewers.styl
+++ b/media/css/devreg/reviewers.styl
@@ -1407,3 +1407,44 @@ span.currently_viewing_warning {
         position: relative;
     }
 }
+
+.regional-queue {
+    min-width: 860px;
+    .action {
+        text-align: right;
+    }
+    .addon-row a.button {
+        border: 0;
+        display: inline-block;
+        font-size: inherit;
+        height: 35px;
+        line-height: 35px;
+        min-width: 80px;
+        padding: 0 10px;
+
+        &.approve {
+            background: $button-green-dark;
+
+            &:hover {
+                background: $button-green-light;
+            }
+        }
+        &.reject, &.duplicate, &.flag {
+            background: $button-red-dark;
+
+            &:hover {
+                background: $button-red-light;
+            }
+        }
+        &:hover {
+            color: $white;
+        }
+        &.disabled, &.disabled:hover {
+            background: #c1c5ca;
+            color: #919497;
+        }
+        + a.button {
+            margin-left: 10px;
+        }
+    }
+}

--- a/media/js/mkt/reviewers.js
+++ b/media/js/mkt/reviewers.js
@@ -12,10 +12,12 @@ require(['prefetchManifest']);
         z.body.addClass('desktop');
     }
 
-     // Reviewer tool search.
+    // Reviewer tool search.
     initAdvancedMobileSearch();
     initMobileMenus();
     initClearSearch();
+
+    initRegionalQueue();
 
     if ($('.theme-search').length) {
         initSearch(true);
@@ -228,4 +230,43 @@ function syncPrettyMobileForm() {
             $('.multi-val', $valSelectField).length ? gettext('Any') :
                                                       firstPrettyVal);
     });
+}
+
+
+function initRegionalQueue() {
+    if (!$('.regional-queue').length) {
+        return;
+    }
+
+    // POST to the API to approve/reject an app in a regional queue.
+    z.doc.on('click', '.approve, .reject', _pd(function(e) {
+        var $this = $(this);
+        var $tr = $this.closest('tr');
+        var $buttons = $tr.find('.button');
+        var url = $tr.data('actionUrl');
+        var approved = $this.data('action') == 'approve';
+
+        $buttons.addClass('disabled');
+
+        $.post(url, {'approved': approved}).success(function() {
+            var appName = $tr.find('.app-name').text();
+            var fmt = {app: appName};
+            var msg;
+            var classes;
+            if (approved) {
+                msg = format(gettext('Approved app: {app}'), fmt);
+                classes = 'good';
+            } else {
+                msg = format(gettext('Rejected app: {app}'), fmt);
+                classes = 'bad';
+            }
+            require('notification')({message: msg, timeout: 1000, classes: classes});
+            $tr.hide();
+        }).error(function() {
+            var msg = approved ? gettext('Error approving app') :
+                                 gettext('Error rejecting app');
+            require('notification')({message: msg, timeout: 1000});
+            $buttons.removeClass('disabled');
+        });
+    }));
 }

--- a/media/js/zamboni/editors.js
+++ b/media/js/zamboni/editors.js
@@ -265,8 +265,13 @@ function initDailyMessage(doc) {
 
 
 function initQueue() {
-    var url = $('#addon-queue').attr('data-url'),
-        addon_ids = $.map($('.addon-row'), function(el) {
+    var $q = $('#addon-queue[data-url]');
+    if (!$q.length) {
+        return;
+    }
+
+    var url = $q.attr('data-url');
+    var addon_ids = $.map($('.addon-row'), function(el) {
             return $(el).attr('data-addon');
         });
     if(!(('localStorage' in window) && window.localStorage['dont_poll'])) {

--- a/migrations/700-add-appsreviewregioncn.sql
+++ b/migrations/700-add-appsreviewregioncn.sql
@@ -1,0 +1,6 @@
+INSERT INTO groups (name, rules, created, modified, notes)
+    VALUES ('China Reviewers', 'Apps:ReviewRegionCN', NOW(), NOW(),
+            'Reviewers in China are able to approve/reject apps in China.');
+
+UPDATE groups SET rules=CONCAT(rules, ',Apps:ReviewRegionCN')
+    WHERE name IN ('Staff', 'Senior App Reviewers');

--- a/mkt/asset_bundles.py
+++ b/mkt/asset_bundles.py
@@ -24,6 +24,7 @@ CSS = {
         'css/devreg/buttons.styl',
 
         # Popups, Modals, Tooltips.
+        'css/devreg/notification.styl',
         'css/devreg/overlay.styl',
         'css/devreg/popups.styl',
         'css/devreg/device.styl',

--- a/mkt/regions/tests/test_utils_.py
+++ b/mkt/regions/tests/test_utils_.py
@@ -1,4 +1,4 @@
-from nose.tools import eq_, assert_raises
+from nose.tools import eq_
 
 from mkt.constants import regions
 from mkt.regions.utils import parse_region
@@ -7,7 +7,9 @@ from mkt.regions.utils import parse_region
 def test_parse_region():
     eq_(parse_region('worldwide'), regions.WORLDWIDE)
     eq_(parse_region('br'), regions.BR)
+    eq_(parse_region('brazil'), regions.BR)
+    eq_(parse_region('bRaZiL'), regions.BR)
     eq_(parse_region('7'), regions.BR)
     eq_(parse_region(7), regions.BR)
     eq_(parse_region(regions.BR), regions.BR)
-    assert_raises(KeyError, parse_region, '')
+    eq_(parse_region(''), None)

--- a/mkt/regions/utils.py
+++ b/mkt/regions/utils.py
@@ -14,4 +14,12 @@ def parse_region(region):
         return regions.REGIONS_CHOICES_ID_DICT[int(region)]
     else:
         # Look up the region by slug.
-        return regions.REGIONS_DICT[region]
+        region_by_slug = regions.REGIONS_DICT.get(region)
+        if region_by_slug is not None:
+            return region_by_slug
+
+        # Look up the region by name.
+        region_lower = region.lower()
+        for region in regions.ALL_REGIONS:
+            if unicode(region.name).lower() == region_lower:
+                return region

--- a/mkt/reviewers/forms.py
+++ b/mkt/reviewers/forms.py
@@ -311,3 +311,30 @@ class ApiReviewersSearchForm(ApiSearchForm):
             return 'any'
 
         return amo.STATUS_CHOICES_API_LOOKUP.get(status, amo.STATUS_PENDING)
+
+
+class ApproveRegionForm(happyforms.Form):
+    """TODO: Use a DRF serializer."""
+    approve = forms.BooleanField(required=False)
+
+    def __init__(self, *args, **kw):
+        self.app = kw.pop('app')
+        self.region = kw.pop('region')
+        super(ApproveRegionForm, self).__init__(*args, **kw)
+
+    def save(self):
+        approved = self.cleaned_data['approve']
+
+        if approved:
+            status = amo.STATUS_PUBLIC
+            # Make it public in the previously excluded region.
+            self.app.addonexcludedregion.filter(
+                region=self.region.id).delete()
+        else:
+            status = amo.STATUS_REJECTED
+
+        value, changed = self.app.geodata.set_status(
+            self.region, status, save=True)
+
+        if changed:
+            self.app.save()

--- a/mkt/reviewers/helpers.py
+++ b/mkt/reviewers/helpers.py
@@ -41,6 +41,8 @@ def reviewers_breadcrumbs(context, queue=None, items=None):
                   'moderated': _('Moderated Reviews'),
                   'reviewing': _('Reviewing'),
 
+                  'region': _('Regional Queues'),
+
                   'pending_themes': _('Pending Themes'),
                   'flagged_themes': _('Flagged Themes'),
                   'rereview_themes': _('Update Themes')}

--- a/mkt/reviewers/templates/reviewers/base.html
+++ b/mkt/reviewers/templates/reviewers/base.html
@@ -14,6 +14,7 @@
   </a>
 </h1>
 
+{% block pillnav %}
   {% if action_allowed('Apps', 'Review') and action_allowed('Personas', 'Review') %}
     <nav class="pill-nav">
       {# Duplicate if statement because eventually there will be three tabs.
@@ -34,6 +35,7 @@
       {% endif %}
     </nav>
   {% endif %}
+{% endblock %}
 {% endblock %}
 
 {% block extrahead %}

--- a/mkt/reviewers/templates/reviewers/base_minimal.html
+++ b/mkt/reviewers/templates/reviewers/base_minimal.html
@@ -1,0 +1,41 @@
+{% extends 'reviewers/base.html' %}
+{% from 'site/helpers/form_row.html' import form_row %}
+
+{% block breadcrumbs %}
+  {{ reviewers_breadcrumbs(queue=tab) }}
+{% endblock %}
+
+{% block pillnav %}
+{% endblock %}
+
+{% block site_header_title %}
+  {% if action_allowed('Apps', 'Review') or action_allowed('Personas', 'Review') %}
+    <div id="site-nav">
+      <div class="pad">
+        <nav class="menu-nav app-nav no-img" role="navigation">
+          <ul>
+            <li class="slim">
+              <a href="{{ url('reviewers.home') }}">
+                &#11013;&nbsp; {{ _('Back to Reviewer Tools') }}</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
+
+{% block queue_menu %}
+{% endblock %}
+
+{% block log_menu %}
+{% endblock %}
+
+{% block queues_overlay %}
+{% endblock %}
+
+{% block logs_overlay %}
+{% endblock %}
+
+{# Do not show "Message of the Day." #}
+{% set motd = '' %}

--- a/mkt/reviewers/templates/reviewers/includes/macros.html
+++ b/mkt/reviewers/templates/reviewers/includes/macros.html
@@ -63,3 +63,30 @@
     </form>
   </div>
 {% endmacro %}
+
+{% macro app_flags(app) %}
+  {% if app.is_packaged %}
+    <div class="sprite-reviewer sprite-reviewer-packaged-app" title="{{ _('Packaged App') }}"></div>
+    {% if app.latest_version.is_privileged %}
+      <div class="sprite-reviewer sprite-reviewer-privileged-app" title="{{ _('Privileged App') }}"></div>
+    {% endif %}
+  {% endif %}
+  {% if app.status == amo.STATUS_BLOCKED %}
+    <div class="sprite-reviewer sprite-reviewer-blocked" title="{{ _('Blocklisted App') }}"></div>
+  {% endif %}
+
+  {% if app.premium_type == amo.ADDON_PREMIUM_INAPP %}
+    <div class="sprite-reviewer sprite-reviewer-premium inapp" title="{{ _('Premium with In-App') }}"></div>
+  {% elif app.premium_type == amo.ADDON_FREE_INAPP %}
+    <div class="sprite-reviewer sprite-reviewer-premium free inapp" title="{{ _('Free with In-App') }}"></div>
+  {% elif app.is_premium() %}
+    <div class="sprite-reviewer sprite-reviewer-premium" title="{{ _('Premium App') }}"></div>
+  {% endif %}
+
+  {% if app.current_version.has_info_request %}
+    <div class="sprite-reviewer sprite-reviewer-info" title="{{ _('More Information Requested') }}"></div>
+  {% endif %}
+  {% if app.current_version.has_editor_comment %}
+    <div class="sprite-reviewer sprite-reviewer-editor" title="{{ _('Contains Editor Comment') }}"></div>
+  {% endif %}
+{% endmacro %}

--- a/mkt/reviewers/templates/reviewers/queue.html
+++ b/mkt/reviewers/templates/reviewers/queue.html
@@ -42,32 +42,7 @@
               <tr data-addon="{{ qa.app.id }}" class="addon-row" id="addon-{{ qa.app.id }}">
                 <td><div class="addon-locked"></div></td>
                 <td class="app-name"><a href="{{ url('reviewers.apps.review', qa.app.app_slug) }}">{{ qa.app.name }}</a></td>
-                <td class="flags">{# Flags #}
-                  {% if qa.app.is_packaged %}
-                    <div class="sprite-reviewer sprite-reviewer-packaged-app" title="{{ _('Packaged App') }}"></div>
-                    {% if qa.app.latest_version.is_privileged %}
-                      <div class="sprite-reviewer sprite-reviewer-privileged-app" title="{{ _('Privileged App') }}"></div>
-                    {% endif %}
-                  {% endif %}
-                  {% if qa.app.status == amo.STATUS_BLOCKED %}
-                    <div class="sprite-reviewer sprite-reviewer-blocked" title="{{ _('Blocklisted App') }}"></div>
-                  {% endif %}
-
-                  {% if qa.app.premium_type == amo.ADDON_PREMIUM_INAPP %}
-                    <div class="sprite-reviewer sprite-reviewer-premium inapp" title="{{ _('Premium with In-App') }}"></div>
-                  {% elif qa.app.premium_type == amo.ADDON_FREE_INAPP %}
-                    <div class="sprite-reviewer sprite-reviewer-premium free inapp" title="{{ _('Free with In-App') }}"></div>
-                  {% elif qa.app.is_premium() %}
-                    <div class="sprite-reviewer sprite-reviewer-premium" title="{{ _('Premium App') }}"></div>
-                  {% endif %}
-
-                  {% if qa.app.current_version.has_info_request %}
-                    <div class="sprite-reviewer sprite-reviewer-info" title="{{ _('More Information Requested') }}"></div>
-                  {% endif %}
-                  {% if qa.app.current_version.has_editor_comment %}
-                    <div class="sprite-reviewer sprite-reviewer-editor" title="{{ _('Contains Editor Comment') }}"></div>
-                  {% endif %}
-                </td>
+                <td class="flags">{{ app_flags(qa.app) }}</td>
                 <td class="waiting-time">{{ qa.created|timelabel }}</td>
                 <td>{{ device_list(qa.app) }}</td>
                 {% if DESKTOP %}

--- a/mkt/reviewers/templates/reviewers/queue_region.html
+++ b/mkt/reviewers/templates/reviewers/queue_region.html
@@ -1,0 +1,62 @@
+{% extends 'reviewers/base_minimal.html' %}
+{% from 'reviewers/includes/macros.html' import app_flags with context %}
+{% from 'site/helpers/form_row.html' import form_row %}
+
+{% block breadcrumbs %}
+  {{ reviewers_breadcrumbs(items=[(None, _('Regional Queues')),
+                                  (None, region.name)]) }}
+{% endblock %}
+
+{% set page_title = _('{region} Review Queue').format(region=region.name) %}
+
+{% block title %}
+  {{ page_title }} | {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h1>{{ page_title }}</h1>
+
+  <section id="queue-island" class="island search-toggle">
+    {% if addons %}
+      <table id="addon-queue" class="data-grid items regional-queue">
+        <thead>
+          <tr class="listing-header">
+            <th>{{ sort_link(_('App'), 'name')|safe }}</th>
+            <th>{{ _('Flags') }}</th>
+            <th class="waiting-time">{{ sort_link(_('Waiting Time'), date_sort or 'created')|safe }}</th>
+            <th>{{ _('Devices') }}</th>
+            <th class="payments">{{ _('Payments') }}</th>
+            <th class="action">&nbsp;</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for qa in addons %}
+            <tr data-addon="{{ qa.app.id }}" class="addon-row" id="addon-{{ qa.app.id }}"
+                data-action-url="{{ url('approve-region', qa.app.id, region.slug) }}">
+              <td class="app-name"><a href="{{ qa.app.get_url_path(src='queue-region-' + region.slug) }}" target="_blank">{{ qa.app.name }}</a></td>
+              <td class="flags">{{ app_flags(qa.app) }}</td>
+              <td class="waiting-time">{{ qa.created|timelabel }}</td>
+              <td>{{ device_list(qa.app) }}</td>
+              <td class="payments">{{ amo.ADDON_PREMIUM_TYPES[qa.app.premium_type] }}</td>
+              <td class="action">
+                <a class="button approve" data-action="approve">{{ _('Approve') }}</button>
+                <a class="button reject" data-action="reject">{{ _('Reject') }}</button>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      {{ no_results() }}
+    {% endif %}
+
+    {% if queue_counts[tab] == 0 %}
+      <div class="no-results">
+        {{ _('There are currently no items of this type to review.') }}
+      </div>
+    {% else %}
+      <div class="impala-paginator">{{ pager|impala_paginator }}</div>
+      <div class="mobile-paginator hidden">{{ pager|mobile_impala_paginator }}</div>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/mkt/reviewers/tests/test_api.py
+++ b/mkt/reviewers/tests/test_api.py
@@ -264,3 +264,67 @@ class TestApiReviewer(BaseOAuth, ESTestCase):
         res = self.client.get(self.url + ({'dev': 'android'},))
         eq_(res.status_code, 200)
         eq_(len(res.json['objects']), 1)
+
+
+class TestApproveRegion(RestOAuth):
+    fixtures = fixture('user_2519', 'webapp_337141')
+
+    def url(self, **kwargs):
+        kw = {'pk': '337141', 'region': 'cn'}
+        kw.update(kwargs)
+        return reverse('approve-region', kwargs=kw)
+
+    def test_verbs(self):
+        self.grant_permission(self.profile, 'Apps:ReviewRegionCN')
+        self._allowed_verbs(self.url(), ['post'])
+
+    def test_anon(self):
+        res = self.anon.post(self.url())
+        eq_(res.status_code, 403)
+
+    def test_bad_webapp(self):
+        self.grant_permission(self.profile, 'Apps:ReviewRegionCN')
+        res = self.client.post(self.url(pk='999'))
+        eq_(res.status_code, 404)
+
+    def test_webapp_not_pending_in_region(self):
+        self.grant_permission(self.profile, 'Apps:ReviewRegionCN')
+        res = self.client.post(self.url())
+        eq_(res.status_code, 404)
+
+    def test_good_but_no_permission(self):
+        res = self.client.post(self.url())
+        eq_(res.status_code, 403)
+
+    def test_good_webapp_but_wrong_region_permission(self):
+        self.grant_permission(self.profile, 'Apps:ReviewRegionCN')
+
+        app = Webapp.objects.get(id=337141)
+        app.geodata.set_status('cn', amo.STATUS_PENDING, save=True)
+
+        res = self.client.post(self.url(region='br'))
+        eq_(res.status_code, 403)
+
+    def test_good_rejected(self):
+        self.grant_permission(self.profile, 'Apps:ReviewRegionCN')
+
+        app = Webapp.objects.get(id=337141)
+        app.geodata.set_status('cn', amo.STATUS_PENDING, save=True)
+
+        res = self.client.post(self.url())
+        eq_(res.status_code, 200)
+        obj = json.loads(res.content)
+        eq_(obj['approved'], False)
+        eq_(app.geodata.reload().get_status('cn'), amo.STATUS_REJECTED)
+
+    def test_good_approved(self):
+        self.grant_permission(self.profile, 'Apps:ReviewRegionCN')
+
+        app = Webapp.objects.get(id=337141)
+        app.geodata.set_status('cn', amo.STATUS_PENDING, save=True)
+
+        res = self.client.post(self.url(), data=json.dumps({'approve': '1'}))
+        eq_(res.status_code, 200)
+        obj = json.loads(res.content)
+        eq_(obj['approved'], True)
+        eq_(app.geodata.reload().get_status('cn'), amo.STATUS_PUBLIC)

--- a/mkt/reviewers/urls.py
+++ b/mkt/reviewers/urls.py
@@ -17,6 +17,8 @@ url_patterns = patterns('',
     url(r'^$', views.route_reviewer, name='reviewers'),
     url(r'^apps/queue/$', views.queue_apps,
         name='reviewers.apps.queue_pending'),
+    url(r'^apps/queue/region/(?P<region>[^ /]+)?$', views.queue_region,
+        name='reviewers.apps.queue_region'),
     url(r'^apps/queue/rereview/$', views.queue_rereview,
         name='reviewers.apps.queue_rereview'),
     url(r'^apps/queue/updates/$', views.queue_updates,
@@ -86,6 +88,8 @@ url_patterns = patterns('',
 
 api_patterns = patterns('',
     url(r'^', include(reviewers_api.urls)),  # The API.
+    url(r'^reviewers/app/(?P<pk>[^/<>"\']+)/approve/(?P<region>[^ /]+)?$',
+        api.ApproveRegion.as_view(), name='approve-region'),
     url(r'^reviewers/reviewing', api.ReviewingView.as_view(),
-        name='reviewing-list')
+        name='reviewing-list'),
 )


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=937988
https://bugzilla.mozilla.org/show_bug.cgi?id=922252
# Screenshot

![](http://f.cl.ly/items/431J301K0712030S0G1V/Screen%20Shot%202013-11-14%20at%204.26.26%20PM.png)
# Summary

All apps listed in the China Review Queue:
- approved by an app reviewer (e.g., Lisa, Andrew)
- made public
- not disabled by the user 
- not in the Escalation Queue
- marked as pending in China by the developer (see [bug 922252](https://bugzilla.mozilla.org/show_bug.cgi?id=922252))

A China Reviewer (with the `Apps:ReviewRegionCN` permission) clicks the link to "View" the app's public detail page where he/she can test/install/inspect the contents of the `.manifest`/`.zip`, etc. The Reviewer then clicks "Approve" or "Reject," which then removes the app row from the table.

This is the MVP to get Chinese apps reviewed in the Marketplace. I'm sure there are many, many more options that could be presented to the reviewers. But if there's anything crucial I'm missing let me know. (/cc @clouserw)
# TODO
- Tests
- Provide an accurate "Waiting Time" (if we determine this is something we want; /cc @clouserw)
