### PR TITLE
update status after getting rating (bug 939249)

### DIFF
--- a/mkt/developers/forms_payments.py
+++ b/mkt/developers/forms_payments.py
@@ -28,7 +28,7 @@ from .models import AddonPaymentAccount, PaymentAccount
 log = commonware.log.getLogger('z.devhub')
 
 
-def _restore_app(app, save=True):
+def _restore_app_status(app, save=True):
     """
     Restore an incomplete app to its former status. The app will be marked
     as its previous status or PENDING if it was never reviewed.
@@ -265,8 +265,9 @@ class PremiumForm(DeviceTypeForm, happyforms.Form):
             except AddonPremium.DoesNotExist:
                 pass
 
-            if self.addon.status == amo.STATUS_NULL:
-                _restore_app(self.addon, save=False)
+            if (self.addon.status == amo.STATUS_NULL and
+                self.addon.is_fully_complete()):
+                _restore_app_status(self.addon, save=False)
 
             is_paid = False
 
@@ -537,7 +538,8 @@ class BangoAccountListForm(happyforms.Form):
                 RereviewQueue.flag(
                     self.addon, amo.LOG.REREVIEW_PREMIUM_TYPE_UPGRADE)
 
-            _restore_app(self.addon)
+            if self.addon.is_fully_complete():
+                _restore_app_status(self.addon)
 
 
 class PaymentCheckForm(happyforms.Form):

--- a/mkt/developers/templates/developers/apps/listing/items.html
+++ b/mkt/developers/templates/developers/apps/listing/items.html
@@ -6,19 +6,21 @@
   <div class="item addon" data-addonid="{{ addon.id }}">
     <div class="info">
       {{ dev_heading(addon, amo) }}
+
       {% if addon.is_incomplete() %}
         <p class="incomplete">
-          {# is_complete doesn't check for payments/ratings.
-             Thus is_incomplete + is_complete == needs payments/ratings #}
-          {% if not addon.is_complete()[0] %}
+          {% set complete = addon.is_fully_complete() %}
+          {% if not complete[1].details %}
             {{ _("This app's submission process has not been fully completed.") }}
-          {% else %}
-            {% if waffle.switch('iarc') and not addon.is_rated() %}
-              {{ _('This app needs to get a content rating.') }}
-            {% endif %}
-            {% if addon.needs_payment() and not addon.has_payment_account()  %}
-              {{ _('This app needs a payment account set up.') }}
-            {% endif %}
+          {% endif %}
+
+          {% if not complete[1].content_ratings %}
+            {# Don't worry, the waffle is handled in is_fully_complete(). #}
+            {{ _('This app needs to get a content rating.') }}
+          {% endif %}
+
+          {% if not complete[1].payments %}
+            {{ _('This app needs a payment account set up.') }}
           {% endif %}
         </p>
       {% else %}


### PR DESCRIPTION
After submitting an app, get a content rating.

Look at your app.

Now back look at me.

Your app is now pending.
- `Webapp.set_content_ratings` checks if payment info is done (if the app is premium) before setting status. 
- Likewise for payments, check for content ratings info before updating status.
