### PR TITLE
Reviews translate admin 764462

### DIFF
--- a/apps/editors/templates/editors/queue.html
+++ b/apps/editors/templates/editors/queue.html
@@ -84,7 +84,7 @@
             <h3>
               <a href="{{ review.instance.addon.get_url_path() }}">
                 {{ review.instance.addon.name }}</a>
-              {%- if review.instance.title %}: {{ review.instance.title }}{% endif %}
+              {%- if review.instance.title %}: <span>{{ review.instance.title }}</span>{% endif %}
             </h3>
             <p>
             {% trans user=review.instance.user|user_link, date=review.instance.created|datetime,
@@ -92,6 +92,11 @@
               by {{ user }} on {{ date }}
               {{ stars }} ({{ locale }})
             {% endtrans %}
+            {% if waffle.switch('reviews-translate') %}
+              &middot;
+              <a class="translate"
+                 href="{{ shared_url('reviews.translate', review.instance.addon, review.instance.id, LANG) }}">{{ _('translate') }}</a>
+            {% endif %}
             </p>
             <p class="description">{{ review.instance.body|nl2br }}</p>
             <ul class="reviews-flagged-reasons">

--- a/apps/reviews/tests/test_views.py
+++ b/apps/reviews/tests/test_views.py
@@ -540,7 +540,7 @@ class TestTranslate(ReviewTest):
         self.create_switch('reviews-translate', db=True)
         self.user = UserProfile.objects.get(username='jbalogh')
         self.review = Review.objects.create(addon=self.addon, user=self.user,
-                                            body='yes')
+                                            title='or', body='yes')
 
     def test_regular_call(self):
         review = self.review
@@ -565,7 +565,7 @@ class TestTranslate(ReviewTest):
         url = shared_url('reviews.translate', review.addon, review.id, 'fr')
         r = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(r.status_code, 200)
-        eq_(r.content, 'oui')
+        eq_(r.content, '{"body": "oui", "title": "oui"}')
 
     @mock.patch('waffle.switch_is_active', lambda x: True)
     @mock.patch('reviews.views.requests')

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1515,10 +1515,13 @@ GOOGLE_ANALYTICS_CREDENTIALS = {}
 #Which domain to access GA stats for. If not set, defaults to DOMAIN.
 GOOGLE_ANALYTICS_DOMAIN = None
 
+# Used for general web API access.
+GOOGLE_API_CREDENTIALS = ''
+
 # Google translate settings.
 GOOGLE_TRANSLATE_API_URL = 'https://www.googleapis.com/language/translate/v2'
 GOOGLE_TRANSLATE_REDIRECT_URL = (
-    'https://translate.google.com/#auto/%(lang)s/%(text)s')
+    'https://translate.google.com/#auto/{lang}/{text}')
 
 # Domain to allow cross-frame requests from for privacy policy and TOS.
 BROWSERID_DOMAIN = 'login.persona.org'

--- a/media/css/zamboni/editors.css
+++ b/media/css/zamboni/editors.css
@@ -440,6 +440,19 @@ div.editor-stats-table > div.editor-stats-dark {
     border-top: 0;
 }
 
+#reviews-flagged h3 span {
+    display: inline;
+    font: inherit;
+}
+
+#reviews-flagged .translate.loading-submit:after {
+    background: url("../../img/zamboni/loading-white.gif") no-repeat;
+    content: "";
+    display: inline-block;
+    height: 16px;
+    width: 16px;
+}
+
 #reviews-flagged .reviews-flagged-reasons {
     background-color: #FFE4E4;
     border-radius: 10px;

--- a/media/js/impala/reviews.js
+++ b/media/js/impala/reviews.js
@@ -142,26 +142,3 @@ $(document).ready(function() {
             .append('<input type="hidden" name="detailed" value="1">').submit();
     }));
 });
-
-
-$(function () {
-    // Click to translate.
-    $('#page').delegate('.review .translate', 'click', _pd(function(event) {
-        var $this = $(this);
-        // Flag when translated.
-        if ($this.data('translated')) {
-            return;
-        }
-        $this.data('translated', true);
-        // Find text target.
-        $target = $this.parent().siblings('.description');
-        // Retrieve the translation and insert it into the target.
-        $.get($this.attr('href'), function(response, status) {
-            if (status == 'success') {
-                $target.text(response);
-            } else {
-                console.error(status);
-            }
-        }, 'text');
-    }));
-});

--- a/media/js/zamboni/editors.js
+++ b/media/js/zamboni/editors.js
@@ -450,4 +450,41 @@ function initPerformanceStats() {
 
 }
 
-
+// Editors review translations.
+$(function () {
+    // Click to translate.
+    $('#reviews-flagged').delegate('.review-flagged .translate', 'click', _pd(function(event) {
+        var $this = $(this);
+        // Flag when translated.
+        if ($this.data('translated')) {
+            return;
+        }
+        $this.data('translated', true);
+        $this.addClass('loading-submit');
+        // Find text target.
+        var $title = $this.closest('p').siblings('h3').find('span');
+        var $body = $this.closest('p').siblings('.description');
+        // Retrieve the translation and insert it into the target.
+        $.get($this.attr('href'), function(response, status) {
+            if (status == 'success') {
+                var data = JSON.parse(response);
+                if (data.title) {
+                    $title.text(data.title);
+                }
+                if (data.body) {
+                    $body.text(data.body);
+                }
+            } else {
+                console.error(status);
+            }
+        }, 'text')
+        .always(function() {
+            $this.removeClass('loading-submit');
+        })
+        .error(function(status) {
+            $body.append('<p><small class="error">' +
+                         gettext('Error loading translation') +
+                         '</small></p>');
+        });
+    }));
+});


### PR DESCRIPTION
This solves the [bug 764462](https://bugzilla.mozilla.org/show_bug.cgi?id=764462) after being reopened.
**Public users**: text from review is translation via a redirection (no more ajax and Google API call).
**Admin users**: click to translate replaces the text (see the screenshots).
#### Before clicking:

![before clicking translate](https://f.cloud.github.com/assets/145172/1565769/47b89f6a-5084-11e3-8ef6-e8a6c015ad90.png)
#### After clicking:

![waiting for translation](https://f.cloud.github.com/assets/145172/1566333/99cfd846-508d-11e3-9996-9350cac29627.png)
#### When translation is retrieved:

![after clicking translate](https://f.cloud.github.com/assets/145172/1565770/4a360606-5084-11e3-929c-d7a4f99c02ad.png)
#### If some error occured:

![error translating](https://f.cloud.github.com/assets/145172/1566517/3f2e482a-5090-11e3-8d67-b8ee8c8dc846.png)
