### PR TITLE
allow existing pending apps to be approved (bug 939936)

### DIFF
--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1071,7 +1071,11 @@ class Webapp(Addon):
         if not waffle.switch_is_active('iarc'):
             return
 
-        iarc_info = self.iarc_info  # Should have 1-to-1 IARC info already.
+        try:
+            iarc_info = self.iarc_info
+        except IARCInfo.DoesNotExist:
+            # App wasn't rated by IARC, return.
+            return
 
         with amo.utils.no_translation(self.default_locale):
             delocalized_self = Addon.objects.get(pk=self.pk)

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -634,6 +634,10 @@ class TestWebapp(amo.tests.TestCase):
         eq_(data['rating_system'], 'PEGI')
         eq_(data['descriptors'], 'Fear')
 
+    def test_set_iarc_storefront_data_not_rated_by_iarc(self):
+        self.create_switch('iarc')
+        assert not app_factory().set_iarc_storefront_data()
+
     def test_has_payment_account(self):
         app = app_factory()
         assert not app.has_payment_account()


### PR DESCRIPTION
...without an iarc content rating
- Catches 1-1 IARCInfo.DoesNotExist error
