### PR TITLE
try to prefill initial iarc form data (bug 939883)

### DIFF
--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -1195,3 +1195,15 @@ class TestContentRatings(amo.tests.TestCase):
 
         for i, name in enumerate(doc('.name')):
             eq_(name.text, ratings[i].ratingsbody.name)
+
+    def test_edit_iarc_app_form(self):
+        r = content_ratings_edit(self.req, app_slug=self.app.app_slug)
+        doc = pq(r.content)
+        assert not doc('#id_submission_id').attr('value')
+        assert not doc('#id_security_code').attr('value')
+
+        self.app.set_iarc_info(1234, 'abcd')
+        r = content_ratings_edit(self.req, app_slug=self.app.app_slug)
+        doc = pq(r.content)
+        eq_(doc('#id_submission_id').attr('value'), '1234')
+        eq_(doc('#id_security_code').attr('value'), 'abcd')

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -57,7 +57,7 @@ from mkt.developers.utils import check_upload
 from mkt.developers.tasks import run_validator, save_test_plan
 from mkt.submit.forms import AppFeaturesForm, NewWebappVersionForm
 from mkt.webapps.tasks import _update_manifest, update_manifests
-from mkt.webapps.models import Webapp
+from mkt.webapps.models import IARCInfo, Webapp
 
 from . import forms, tasks
 
@@ -305,7 +305,15 @@ def content_ratings(request, addon_id, addon):
 @waffle_switch('iarc')
 @dev_required
 def content_ratings_edit(request, addon_id, addon):
-    form = IARCGetAppInfoForm(request.POST or None)
+    initial = {}
+    try:
+        app_info = addon.iarc_info
+        initial['submission_id'] = app_info.submission_id
+        initial['security_code'] = app_info.security_code
+    except IARCInfo.DoesNotExist:
+        pass
+
+    form = IARCGetAppInfoForm(data=request.POST or None, initial=initial)
 
     if request.method == 'POST' and form.is_valid():
         try:


### PR DESCRIPTION
"upon clicking edit previoulsy entered content rating is not pre-filled"

Set `initial` on IARCAppInfo form.
