### PR TITLE
fixed home theme hovercard displaying 0 users (bug 912170)

### DIFF
--- a/apps/addons/templates/addons/impala/persona_grid.html
+++ b/apps/addons/templates/addons/impala/persona_grid.html
@@ -13,7 +13,7 @@
           <h3>{{ addon.name }}</h3>
         </a>
         <div class="more adu">
-          {{ _('{0} users')|f(addon.average_daily_users|numberfmt) }}
+          {{ _('{0} users')|f(addon.persona.popularity|numberfmt) }}
         </div>
       </div>
     </li>


### PR DESCRIPTION
referers to [bug 912170](https://bugzil.la/912170).
This uniformizes [the way persona popularity is displayed](https://github.com/mozilla/zamboni/blob/master/apps/addons/templates/addons/macros.html#L27).
