### PR TITLE
add `Webapp.is_offline` and `?offline=True|False` to search API (bug 937698)

### DIFF
--- a/docs/api/topics/search.rst
+++ b/docs/api/topics/search.rst
@@ -46,6 +46,11 @@ Search
     :param optional languages: Filters apps by a supported language. Language
         codes should be provided in ISO 639-1 format, using a comma-separated
         list if supplying multiple languages.
+    :type offline: string
+    :param optional languages: Filters by whether the app works offline or not.
+        'True' to show offline-capable apps; 'False' to show apps requiring
+        online support; any other value will show all apps unfiltered by
+        offline support.
     :type languages: string
     :param optional region: Filters apps by a supported region. A region
         code should be provided in ISO 3166 format (e.g., `pl`). If not

--- a/mkt/search/forms.py
+++ b/mkt/search/forms.py
@@ -98,6 +98,8 @@ class ApiSearchForm(forms.Form):
         widget=forms.CheckboxSelectMultiple(),
         label=_lazy(u'App type'), choices=APP_TYPE_CHOICES)
     manifest_url = forms.CharField(required=False, label=_lazy('Manifest URL'))
+    offline = forms.NullBooleanField(required=False,
+        label=_lazy('Works offline'))
     languages = forms.CharField(required=False,
         label=_lazy('Supported languages'))
 

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -116,6 +116,22 @@ class TestSearchFilters(BaseOAuth):
         qs = self._filter(self.req, {'manifest_url': url})
         ok_({'term': {'manifest_url': url}} in qs['filter']['and'])
 
+    def test_offline(self):
+        """Ensure we are filtering by offline-capable apps."""
+        qs = self._filter(self.req, {'offline': 'True'})
+        ok_({'term': {'is_offline': True}} in qs['filter']['and'])
+
+    def test_online(self):
+        """Ensure we are filtering by apps that require online access."""
+        qs = self._filter(self.req, {'offline': 'False'})
+        ok_({'term': {'is_offline': False}} in qs['filter']['and'])
+
+    def test_offline_and_online(self):
+        """Ensure we are not filtering by offline/online by default."""
+        qs = self._filter(self.req, {})
+        ok_({'term': {'is_offline': True}} not in qs['filter']['and'])
+        ok_({'term': {'is_offline': False}} not in qs['filter']['and'])
+
     def test_languages(self):
         qs = self._filter(self.req, {'languages': 'fr'})
         ok_({'in': {'supported_locales': ['fr']}} in qs['filter']['and'])

--- a/mkt/search/views.py
+++ b/mkt/search/views.py
@@ -101,6 +101,8 @@ def _filter_search(request, qs, query, filters=None, sorting=None,
         qs = qs.filter(app_type__in=query['app_type'])
     if query.get('manifest_url'):
         qs = qs.filter(manifest_url=query['manifest_url'])
+    if query.get('offline') is not None:
+        qs = qs.filter(is_offline=query.get('offline'))
     if query.get('languages'):
         langs = [x.strip() for x in query['languages'].split(',')]
         qs = qs.filter(supported_locales__in=langs)

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -75,6 +75,7 @@ def app_to_dict(app, region=None, profile=None, request=None):
         'icons': dict([(icon_size,
                         app.get_icon_url(icon_size))
                        for icon_size in (16, 48, 64, 128)]),
+        'is_offline': app.is_offline,
         'is_packaged': app.is_packaged,
         'manifest_url': app.get_manifest_url(),
         'payment_required': False,
@@ -171,8 +172,8 @@ def es_app_to_dict(obj, region=None, profile=None, request=None):
     app = Webapp(app_slug=obj.app_slug, is_packaged=is_packaged)
 
     attrs = ('created', 'current_version', 'default_locale', 'homepage',
-             'manifest_url', 'previews', 'ratings', 'status', 'support_email',
-             'support_url', 'weekly_downloads')
+             'is_offline', 'manifest_url', 'previews', 'ratings', 'status',
+             'support_email', 'support_url', 'weekly_downloads')
     data = dict((a, getattr(obj, a, None)) for a in attrs)
 
     if getattr(obj, 'content_ratings', None):
@@ -187,11 +188,10 @@ def es_app_to_dict(obj, region=None, profile=None, request=None):
         'categories': [c for c in obj.category],
         'content_ratings': {
             'ratings': getattr(obj, 'content_ratings', []),
-            'descriptors':
-                dehydrate_descriptors(getattr(obj, 'content_descriptors', [])),
-            'interactive_elements':
-                dehydrate_interactives(getattr(obj, 'interactive_elements',
-                                       [])),
+            'descriptors': dehydrate_descriptors(
+                getattr(obj, 'content_descriptors', [])),
+            'interactive_elements': dehydrate_interactives(
+                getattr(obj, 'interactive_elements', [])),
         },
         'description': get_attr_lang(src, 'description', obj.default_locale),
         'device_types': [DEVICE_TYPES[d].api_name for d in src.get('device')],


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=937698

<dl>
<dt><code>/api/v1/fireplace/search/?offline=True</code></dt>
<dd>show apps offering graceful offline support</dd>
<dt><code>/api/v1/fireplace/search/?offline=False</code></dt>
<dd>show apps requiring online connection</dd>
<dt><code>/api/v1/fireplace/search/</code></dt>
<dd>show all apps (regardless of offline/online support)</dd>
</dl>


PotatoSearch™ Fireplace patch to land after this bad boy gets merged in.
