### PR TITLE
show right ratings in the right regions (bug 931948)

### DIFF
--- a/mkt/constants/regions.py
+++ b/mkt/constants/regions.py
@@ -63,8 +63,7 @@ class US(REGION):
     slug = 'us'
     mcc = 310
     weight = 1
-    # TODO: Don't flip these until we deploy IARC (bug 931948).
-    # ratingsbody = ratingsbodies.ESRB
+    ratingsbody = ratingsbodies.ESRB
 
 
 class UK(REGION):
@@ -73,7 +72,7 @@ class UK(REGION):
     slug = 'uk'
     default_currency = 'GBP'
     mcc = 235
-    # ratingsbody = ratingsbodies.PEGI
+    ratingsbody = ratingsbodies.PEGI
 
 
 class BR(REGION):
@@ -93,7 +92,7 @@ class SPAIN(REGION):
     default_currency = 'EUR'
     default_language = 'es'
     mcc = 214
-    # ratingsbody = ratingsbodies.PEGI
+    ratingsbody = ratingsbodies.PEGI
 
 
 class CO(REGION):
@@ -121,7 +120,7 @@ class PL(REGION):
     default_currency = 'PLN'
     default_language = 'pl'
     mcc = 260
-    # ratingsbody = ratingsbodies.PEGI
+    ratingsbody = ratingsbodies.PEGI
 
 
 class MX(REGION):
@@ -140,7 +139,7 @@ class HU(REGION):
     default_currency = 'HUF'
     default_language = 'hu'
     mcc = 216
-    # ratingsbody = ratingsbodies.PEGI
+    ratingsbody = ratingsbodies.PEGI
 
 
 class DE(REGION):
@@ -178,7 +177,7 @@ class GR(REGION):
     default_currency = 'EUR'
     default_language = 'el'
     mcc = 202
-    # ratingsbody = ratingsbodies.PEGI
+    ratingsbody = ratingsbodies.PEGI
 
 
 class PE(REGION):

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1013,16 +1013,17 @@ class Webapp(Addon):
         content_ratings = {}
         for cr in self.content_ratings.all():
             body = cr.get_body()
-            rating = cr.get_rating()
-            for _region in cr.get_region_slugs():
-                rating = {
+            rating_class = cr.get_rating()
+            for region in cr.get_region_slugs():
+                rating_serialized = {
                     'body': body.id,
-                    'rating': rating.id
+                    'rating': rating_class.id
                 }
                 if not es:
-                    rating = dehydrate_content_rating(rating)
+                    rating_serialized = dehydrate_content_rating(
+                        rating_serialized)
 
-                content_ratings[_region] = rating
+                content_ratings[region] = rating_serialized
         return content_ratings
 
     def get_descriptors(self, es=False):


### PR DESCRIPTION
![screen shot 2013-11-20 at 12 46 27 pm](https://f.cloud.github.com/assets/674727/1586151/dc596c7a-5224-11e3-93b0-7297782ee476.png)

See no problem in flipping certain ratings bodies on in certain regions.
