### PR TITLE
use app name to verify iarc getappinfo response (bug 941228)

### DIFF
--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -749,6 +749,11 @@ class TestAdminSettingsForm(TestAdmin):
 
 class TestIARCGetAppInfoForm(amo.tests.WebappTestCase):
 
+    def setUp(self):
+        super(TestIARCGetAppInfoForm, self).setUp()
+        self.app.name = 'Twitter'
+        self.app.save()
+
     def test_good(self):
         with self.assertRaises(IARCInfo.DoesNotExist):
             self.app.iarc_info
@@ -790,3 +795,12 @@ class TestIARCGetAppInfoForm(amo.tests.WebappTestCase):
         assert form.is_valid(), form.errors
         with self.assertRaises(django_forms.ValidationError):
             form.save('app')  # Just pass string to avoid making a Webapp obj.
+
+    def test_wrong_app_mismatch(self):
+        self.app.name = 'YouTwitFace'
+        self.app.save()
+        form = forms.IARCGetAppInfoForm({'submission_id': 1,
+                                         'security_code': 'a'})
+        assert form.is_valid(), form.errors
+        with self.assertRaises(django_forms.ValidationError):
+            form.save(self.app)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1156,7 +1156,7 @@ class Webapp(Addon):
             return
 
         with amo.utils.no_translation(self.default_locale):
-            delocalized_self = Addon.objects.get(pk=self.pk)
+            delocalized_self = Webapp.objects.get(pk=self.pk)
 
         xmls = []
         for cr in self.content_ratings.all():


### PR DESCRIPTION
IARC seems to be allowing one security code for use with different submission IDs. It's akin to them giving us a password, 'bob123', and telling us it works for 'bob' (bob/bob123), but then it also works for 'alice' (alice/bob123). That's bad.

As a weak measure, I at least verify that the app's name in the `GetAppInfo` response is the same as the app trying to attain the content rating.
