### PR TITLE
rename app/file status terms on mkt only (bug 895560)

### DIFF
--- a/apps/constants/base.py
+++ b/apps/constants/base.py
@@ -43,6 +43,16 @@ STATUS_CHOICES = {
     STATUS_BLOCKED: _(u'Blocked'),
 }
 
+
+# Marketplace app status terms.
+MKT_STATUS_CHOICES = STATUS_CHOICES.copy()
+MKT_STATUS_CHOICES[STATUS_PUBLIC] = _(u'Published')
+MKT_STATUS_CHOICES[STATUS_PUBLIC_WAITING] = _(u'Approved but unpublished')
+
+# Marketplace file status terms.
+MKT_STATUS_FILE_CHOICES = MKT_STATUS_CHOICES.copy()
+MKT_STATUS_FILE_CHOICES[STATUS_DISABLED] = _(u'Obsolete')
+
 # We need to expose nice values that aren't localisable.
 STATUS_CHOICES_API = {
     STATUS_NULL: 'incomplete',

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -348,10 +348,14 @@ class Version(amo.models.ModelBase):
 
     @property
     def status(self):
+        status_choices = amo.STATUS_CHOICES
+        if settings.MARKETPLACE:
+            status_choices = amo.MKT_STATUS_FILE_CHOICES
+
         if settings.MARKETPLACE and self.deleted:
-            return [amo.STATUS_CHOICES[amo.STATUS_DELETED]]
+            return [status_choices[amo.STATUS_DELETED]]
         else:
-            return [amo.STATUS_CHOICES[f.status] for f in self.all_files]
+            return [status_choices[f.status] for f in self.all_files]
 
     @property
     def statuses(self):

--- a/mkt/constants/apps.py
+++ b/mkt/constants/apps.py
@@ -1,5 +1,6 @@
 from tower import ugettext_lazy as _
 
+
 INSTALL_TYPE_USER = 0
 INSTALL_TYPE_REVIEWER = 1
 INSTALL_TYPE_DEVELOPER = 2

--- a/mkt/developers/helpers.py
+++ b/mkt/developers/helpers.py
@@ -108,7 +108,7 @@ def add_version_modal(context, title, action, upload_url, action_label):
 def status_choices(addon):
     """Return a dict like STATUS_CHOICES customized for the addon status."""
     # Show "awaiting full review" for unreviewed files on that track.
-    choices = dict(amo.STATUS_CHOICES)
+    choices = dict(amo.MKT_STATUS_CHOICES)
     if addon.status in (amo.STATUS_NOMINATED, amo.STATUS_LITE_AND_NOMINATED,
                         amo.STATUS_PUBLIC):
         choices[amo.STATUS_UNREVIEWED] = choices[amo.STATUS_NOMINATED]

--- a/mkt/developers/templates/developers/apps/listing/items.html
+++ b/mkt/developers/templates/developers/apps/listing/items.html
@@ -29,7 +29,7 @@
                 <span class="{{ mkt_status_class(addon) }}"><b>{{ _('Disabled') }}</b></span>
               {% else %}
                 <span class="{{ mkt_status_class(addon) }}">
-                  <b>{{ amo.STATUS_CHOICES[addon.status] }}</b></span>
+                  <b>{{ amo.MKT_STATUS_CHOICES[addon.status] }}</b></span>
               {% endif %}
             </a>
           </li>

--- a/mkt/developers/tests/test_helpers.py
+++ b/mkt/developers/tests/test_helpers.py
@@ -13,10 +13,11 @@ import amo.tests
 from amo.urlresolvers import reverse
 from amo.tests.test_helpers import render
 from addons.models import Addon
-from mkt.developers import helpers
 from files.models import File, Platform
 from users.models import UserProfile
 from versions.models import Version
+
+from mkt.developers import helpers
 
 
 def test_hub_page_title():
@@ -172,37 +173,37 @@ class TestDevFilesStatus(amo.tests.TestCase):
     def test_unreviewed_lite(self):
         self.addon.status = amo.STATUS_LITE
         self.file.status = amo.STATUS_UNREVIEWED
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_UNREVIEWED])
+        self.expect(amo.MKT_STATUS_CHOICES[amo.STATUS_UNREVIEWED])
 
     def test_unreviewed_public(self):
         self.addon.status = amo.STATUS_PUBLIC
         self.file.status = amo.STATUS_UNREVIEWED
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_NOMINATED])
+        self.expect(amo.MKT_STATUS_CHOICES[amo.STATUS_NOMINATED])
 
     def test_unreviewed_nominated(self):
         self.addon.status = amo.STATUS_NOMINATED
         self.file.status = amo.STATUS_UNREVIEWED
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_NOMINATED])
+        self.expect(amo.MKT_STATUS_CHOICES[amo.STATUS_NOMINATED])
 
     def test_unreviewed_lite_and_nominated(self):
         self.addon.status = amo.STATUS_LITE_AND_NOMINATED
         self.file.status = amo.STATUS_UNREVIEWED
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_NOMINATED])
+        self.expect(amo.MKT_STATUS_CHOICES[amo.STATUS_NOMINATED])
 
     def test_reviewed_lite(self):
         self.addon.status = amo.STATUS_LITE
         self.file.status = amo.STATUS_LITE
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_LITE])
+        self.expect(amo.MKT_STATUS_CHOICES[amo.STATUS_LITE])
 
     def test_reviewed_public(self):
         self.addon.status = amo.STATUS_PUBLIC
         self.file.status = amo.STATUS_PUBLIC
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_PUBLIC])
+        self.expect(amo.MKT_STATUS_CHOICES[amo.STATUS_PUBLIC])
 
     def test_disabled(self):
         self.addon.status = amo.STATUS_PUBLIC
         self.file.status = amo.STATUS_DISABLED
-        self.expect(amo.STATUS_CHOICES[amo.STATUS_DISABLED])
+        self.expect(amo.MKT_STATUS_CHOICES[amo.STATUS_DISABLED])
 
 
 class TestDevAgreement(amo.tests.TestCase):

--- a/mkt/developers/tests/test_views_versions.py
+++ b/mkt/developers/tests/test_views_versions.py
@@ -320,7 +320,7 @@ class TestVersionPackaged(amo.tests.WebappTestCase):
         eq_(version.count(), 1)
         # Test that the status of the "deleted" version is STATUS_DELETED.
         eq_(str(version[0].status[0]),
-            str(amo.STATUS_CHOICES[amo.STATUS_DELETED]))
+            str(amo.MKT_STATUS_CHOICES[amo.STATUS_DELETED]))
 
     def test_anonymous_delete_redirects(self):
         self.client.logout()

--- a/mkt/lookup/templates/lookup/app_summary.html
+++ b/mkt/lookup/templates/lookup/app_summary.html
@@ -63,7 +63,7 @@
         <dt>{{ _('Submitted') }}</dt>
         <dd>{{ app.created|babel_datetime }}</dd>
         <dt>{{ _('Status') }}</dt>
-        <dd>{{ amo.STATUS_CHOICES[app.status] }}</dd>
+        <dd>{{ amo.MKT_STATUS_CHOICES[app.status] }}</dd>
         <dt>{{ _('Abuse Reports') }}</dt>
         <dd>{{ abuse_reports }}</dd>
         <dt>{{ _('Permissions') }}</dt>
@@ -129,7 +129,7 @@
               {% with file = v.files.latest() %}
                 <td><a href="{{ v.all_files[0].get_url_path('') }}" class="download">
                   {{ file.filename }} ({{ file.id }}, {{ file.size|filesizeformat }})</a></td>
-                <td>{{ amo.STATUS_CHOICES[file.status] }}</td>
+                <td>{{ amo.MKT_STATUS_CHOICES[file.status] }}</td>
               {% endwith %}
             </tr>
           {% endfor %}

--- a/mkt/reviewers/forms.py
+++ b/mkt/reviewers/forms.py
@@ -10,15 +10,15 @@ from jinja2.filters import do_filesizeformat
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 import amo
-import mkt.constants.reviewers as rvw
 from addons.models import AddonDeviceType, Persona
 from amo.utils import raise_required
 from editors.forms import NonValidatingChoiceField, ReviewLogForm
 from editors.models import CannedResponse, ReviewerScore
+
+import mkt.constants.reviewers as rvw
 from mkt.api.forms import CustomNullBooleanSelect
 from mkt.reviewers.utils import ReviewHelper
 from mkt.search.forms import ApiSearchForm
-
 
 from .models import ThemeLock
 from .tasks import approve_rereview, reject_rereview, send_mail
@@ -31,7 +31,7 @@ log = logging.getLogger('z.reviewers.forms')
 STATUS_CHOICES = [('any', _lazy(u'Any Status'))]
 for status in amo.WEBAPPS_UNLISTED_STATUSES + (amo.STATUS_PUBLIC,):
     STATUS_CHOICES.append((amo.STATUS_CHOICES_API[status],
-                           amo.STATUS_CHOICES[status]))
+                           amo.MKT_STATUS_CHOICES[status]))
 
 
 class ReviewAppAttachmentForm(happyforms.Form):

--- a/mkt/reviewers/templates/reviewers/includes/details.html
+++ b/mkt/reviewers/templates/reviewers/includes/details.html
@@ -19,7 +19,7 @@
       {% endif %}
     </dd>
     <dt>{{ _('Status') }}</dt>
-    <dd{% if product.status == amo.STATUS_BLOCKED %} class="warn"{% endif %}>{{ amo.STATUS_CHOICES[product.status] }}
+    <dd{% if product.status == amo.STATUS_BLOCKED %} class="warn"{% endif %}>{{ amo.MKT_STATUS_CHOICES[product.status] }}
       {% if product.in_rereview_queue() %}&middot; <b id="queue-rereview">{{ _('In re-review queue') }}</b>{% endif %}
       {% if product.in_escalation_queue() %}&middot; <b id="queue-escalation">{{ _('In escalation queue') }}</b>{% endif %}
     </dd>

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -26,7 +26,7 @@
       <li class="currently_viewing_warning"></li>
       <li>
         <ul>
-          <li><b>{{ _('Status') }}</b>: {{ amo.STATUS_CHOICES[product.status] }}</li>
+          <li><b>{{ _('Status') }}</b>: {{ amo.MKT_STATUS_CHOICES[product.status] }}</li>
           {% if product.in_rereview_queue() %}
             <li>&middot; <b id="queue-rereview">{{ _('In re-review queue') }}</b></li>
           {% endif %}

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -396,7 +396,7 @@ def _review(request, addon, version):
                   num_pages=num_pages, count=count,
                   flags=Review.objects.filter(addon=addon, flag=True),
                   form=form, canned=canned, is_admin=is_admin,
-                  status_types=amo.STATUS_CHOICES, show_diff=show_diff,
+                  status_types=amo.MKT_STATUS_CHOICES, show_diff=show_diff,
                   allow_unchecking_files=allow_unchecking_files,
                   actions=actions, actions_minimal=actions_minimal,
                   tab=queue_type, product_attrs=product_attrs,

--- a/mkt/reviewers/views_themes.py
+++ b/mkt/reviewers/views_themes.py
@@ -70,7 +70,7 @@ def themes_list(request, flagged=False, rereview=False):
         'flagged': flagged,
         'pager': pager,
         'rereview': rereview,
-        'STATUS_CHOICES': amo.STATUS_CHOICES,
+        'STATUS_CHOICES': amo.MKT_STATUS_CHOICES,
         'search_form': search_form,
         'tab': ('rereview_themes' if rereview else
                 'flagged_themes' if flagged else 'pending_themes'),

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -2158,8 +2158,7 @@ class Geodata(amo.models.ModelBase):
 for region in mkt.regions.SPECIAL_REGIONS:
     help_text = _('{region} approval status').format(region=region.name)
     field = models.PositiveIntegerField(help_text=help_text,
-                                        choices=amo.STATUS_CHOICES.items(),
-                                        db_index=True, default=0)
+        choices=amo.MKT_STATUS_CHOICES.items(), db_index=True, default=0)
     field.contribute_to_class(Geodata, 'region_%s_status' % region.slug)
 
     help_text = _('{region} nomination date').format(region=region.name)


### PR DESCRIPTION
- Copy `amo.STATUS_CHOICES` to `amo.MKT_STATUS_CHOICES`.
- Create a `MKT_STATUS_FILE_CHOICES`` that changes 'Disabled by Mozilla' to 'Obsolete'.
- Change all instances of `amo.STATUS_CHOICES` to `amo.MKT_STATUS_CHOICES` in `mkt` codebase.
- Change `versions.Version.status` to detect `settings.MARKETPLACE` to display `amo.MKT_STATUS_FILE_CHOICES`
