### PR TITLE
content ratings ES result reverse-compat with old ES results (bug 943371)

### DIFF
--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import json
 
 from django.contrib.auth.models import AnonymousUser
 
@@ -18,7 +19,8 @@ from mkt.constants import ratingsbodies, regions
 from mkt.site.fixtures import fixture
 from mkt.webapps.api import AppSerializer
 from mkt.webapps.models import Installed, Webapp, WebappIndexer
-from mkt.webapps.utils import es_app_to_dict, get_supported_locales
+from mkt.webapps.utils import (dehydrate_content_rating, es_app_to_dict,
+                               get_supported_locales)
 from users.models import UserProfile
 from versions.models import Version
 
@@ -151,6 +153,19 @@ class TestAppSerializer(amo.tests.TestCase):
         eq_(res['content_ratings']['interactive_elements'],
             [{'label': 'shares-info', 'name': 'Shares Info'},
              {'label': 'social-networking', 'name': 'Social Networking'}])
+
+    def test_dehydrate_content_rating_old_es(self):
+        """Test dehydrate works with old ES mapping."""
+        self.create_switch('iarc')
+
+        rating = dehydrate_content_rating(
+            [json.dumps({'body': u'CLASSIND',
+                         'slug': u'0',
+                         'description': u'General Audiences',
+                         'name': u'0+',
+                         'body_slug': u'classind'})])
+        eq_(rating, {})
+
 
 class TestAppSerializerPrices(amo.tests.TestCase):
     fixtures = fixture('user_2519')

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils import translation
@@ -184,8 +186,13 @@ def dehydrate_content_rating(rating):
     """
     {body.id, rating.id} to translated {rating labels, names, descriptions}.
     """
-    body = mkt.ratingsbodies.dehydrate_ratings_body(
-        mkt.ratingsbodies.RATINGS_BODIES[int(rating['body'])])
+    try:
+        body = mkt.ratingsbodies.dehydrate_ratings_body(
+            mkt.ratingsbodies.RATINGS_BODIES[int(rating['body'])])
+    except TypeError:
+        # Legacy ES format (bug 943371).
+        return {}
+
     rating = mkt.ratingsbodies.dehydrate_rating(
         body.ratings[int(rating['rating'])])
 


### PR DESCRIPTION
gracefully fail or recover when met with old ES results.
