### PR TITLE
put content ratings for regions other than BR/DE under waffle (bug 943646)

### DIFF
--- a/mkt/constants/regions.py
+++ b/mkt/constants/regions.py
@@ -149,7 +149,9 @@ class DE(REGION):
     default_currency = 'EUR'
     default_language = 'de'
     mcc = 262
-    ratingsbody = ratingsbodies.USK
+    # TODO: change to GENERIC on IARC deploy (switch_is_active('iarc')).
+    # ratingsbody = ratingsbodies.USK
+    ratingsbody = ratingsbodies.GENERIC
 
 
 class ME(REGION):
@@ -254,11 +256,20 @@ SPECIAL_REGION_IDS = sorted(x.id for x in SPECIAL_REGIONS)
 # Regions not including worldwide.
 REGION_IDS = sorted(REGIONS_CHOICES_ID_DICT.keys())[1:]
 
-# Regions that have ratings bodies.
-ALL_REGIONS_WITH_CONTENT_RATINGS = [x for x in ALL_REGIONS if x.ratingsbody]
-
-# Regions without ratings bodies and fallback to the GENERIC rating body.
-ALL_REGIONS_WO_CONTENT_RATINGS = (set(ALL_REGIONS) -
-                                  set(ALL_REGIONS_WITH_CONTENT_RATINGS))
-
 GENERIC_RATING_REGION_SLUG = 'generic'
+
+def ALL_REGIONS_WITH_CONTENT_RATINGS():
+    """Regions that have ratings bodies."""
+    import waffle
+
+    if waffle.switch_is_active('iarc'):
+        return [x for x in ALL_REGIONS if x.ratingsbody]
+
+    # Only require content ratings in Brazil/Germany without IARC switch.
+    return [BR, DE]
+
+def ALL_REGIONS_WO_CONTENT_RATINGS():
+    """
+    Regions without ratings bodies and fallback to the GENERIC rating body.
+    """
+    return set(ALL_REGIONS) - set(ALL_REGIONS_WITH_CONTENT_RATINGS())

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -68,7 +68,7 @@ def toggle_game(app):
     """
     if not Webapp.category('games'):
         return
-    for region in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS:
+    for region in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS():
         if app.listed_in(category='games'):
             if app.content_ratings_in(region):
                 aer = app.addonexcludedregion.filter(region=region.id)
@@ -764,7 +764,7 @@ class RegionForm(forms.Form):
         games = Webapp.category('games')
 
         if games and self.product.categories.filter(id=games.id).exists():
-            for region in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS:
+            for region in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS():
                 if not self.product.content_ratings_in(region):
                     disabled_regions.add(region.id)
 

--- a/mkt/developers/management/commands/migrate_geodata.py
+++ b/mkt/developers/management/commands/migrate_geodata.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         paid_types = amo.ADDON_PREMIUMS + (amo.ADDON_FREE_INAPP,)
 
         games_cat = Webapp.category('games')
-        content_region_ids = [x.id for x in ALL_REGIONS_WITH_CONTENT_RATINGS]
+        content_region_ids = [x.id for x in ALL_REGIONS_WITH_CONTENT_RATINGS()]
 
         apps = Webapp.objects.all()
         for app in apps:

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -211,7 +211,8 @@ class TestRegionForm(amo.tests.WebappTestCase):
         eq_(form.initial['enable_new_regions'], True)
 
     def test_unrated_games_already_excluded(self):
-        regions = [x.id for x in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS]
+        regions = [x.id for x in
+                   mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS()]
         for region in regions:
             self.app.addonexcludedregion.create(region=region)
 
@@ -620,7 +621,7 @@ class TestAdminSettingsForm(TestAdmin):
         form.save(self.webapp)
 
         excluded_regions = [
-            x.id for x in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS
+            x.id for x in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS()
         ]
 
         # After the form was saved, it should be excluded in Brazil.

--- a/mkt/submit/tests/test_views.py
+++ b/mkt/submit/tests/test_views.py
@@ -968,7 +968,7 @@ class TestDetails(TestSubmit):
         r = self.client.post(self.url, self.get_dict(categories=[games.id]))
         self.assertNoFormErrors(r)
         self.assertSetEqual(AER.objects.values_list('region', flat=True),
-            [x.id for x in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS])
+            [x.id for x in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS()])
 
     def test_other_categories_are_not_excluded(self):
         # Keep the category around for good measure.

--- a/mkt/webapps/api.py
+++ b/mkt/webapps/api.py
@@ -283,7 +283,7 @@ class AppSerializer(serializers.ModelSerializer):
         if not games:
             return
 
-        for region in ALL_REGIONS_WITH_CONTENT_RATINGS:
+        for region in ALL_REGIONS_WITH_CONTENT_RATINGS():
             if (self.product.listed_in(region) and
                 not self.product.content_ratings_in(region)):
 

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -1224,6 +1224,7 @@ class TestContentRating(amo.tests.WebappTestCase):
 
     def setUp(self):
         self.app = self.get_app()
+        self.create_switch('iarc')
 
     @mock.patch.object(mkt.regions.BR, 'ratingsbody',
                        mkt.ratingsbodies.CLASSIND)
@@ -1626,6 +1627,8 @@ class TestWebappIndexer(amo.tests.TestCase):
     @mock.patch.object(mkt.regions.VE, 'ratingsbody', None)
     @mock.patch.object(mkt.regions.RS, 'ratingsbody', None)
     def test_extract_content_ratings_generic_fallback(self):
+        self.create_switch('iarc')
+
         # These ones shouldn't appear, they are associated w/ region.
         ContentRating.objects.create(
             addon=self.app, ratings_body=mkt.ratingsbodies.CLASSIND.id,


### PR DESCRIPTION
**Problem:**
- some iarc waffle leak with regions+content-ratings. some games in regions other than germany/brazil are disabled due to no content rating, but for now they should be enabled.
- non brazil/germany apps are displaying content ratings on consumer pages
- germany is set to USK, but it should be set to Generic content ratings body

**Implementation:**
- put some `mkt/constants/regions.py` constants under a 'iarc' waffle switch
- in app resource, don't send content ratings for non-brazil/germany regions at `dehydrate` stage 
## Some PR Discussion

ngoke: Thanks for catching the bad logic.

`cvan: re: hide the "For ages 7+" in the header`

I can try to stop it at the API level. That way we don't have to revert/revert changes on Fireplace when as we flip the IARC switches.

`I don't understand this code. why are we checking explicitly for mkt.ratingsbodies.GENERIC?`

The Generic content rating body is special. All regions that don't fall under CLASSIND/ESRB/PEGI/USK are pigeonholed into Generic. Instead of:

```
{'us': {#esrb rating}, 'pe': {#generic rating}, 'me': {#generic rating}, 'rs': {#generic rating}, etc}
```

We can shorten the data structure:

```
{'us': {# esrb rating}, 'generic': {#generic rating}
```

And on Fireplace, if the region isn't found, it falls back to Generic.

`can you show me where we're enforcing that?`

We are enforcing it in `mkt.regions` in the `ratingsbody` attributes. But I prematurely flipped the switch on having Germany show `USK` ratings. Fortunately, there are no USK ratings so it'll fall back to Generic.

This patch fixes some things while the switch is off (only show Brazil + Germany ratings, force Germany to Generic).
