### PR TITLE
Fix RestSharedSecretAuthentication, make it use the real request (bug 943471)

### DIFF
--- a/mkt/api/authentication.py
+++ b/mkt/api/authentication.py
@@ -221,8 +221,10 @@ class RestSharedSecretAuthentication(BaseAuthentication,
     """SharedSecretAuthentication suitable for DRF."""
 
     def authenticate(self, request):
-        result = self.is_authenticated(request)
-
+        result = self.is_authenticated(request._request)
+        user = getattr(request._request, 'user', None)
+        if user:
+            request._user = user
         if not (result and request.user):
             return None
         return (request.user, None)

--- a/mkt/webpay/resources.py
+++ b/mkt/webpay/resources.py
@@ -8,7 +8,7 @@ import commonware.log
 import django_filters
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.response import Response
@@ -48,7 +48,7 @@ log = commonware.log.getLogger('z.webpay')
 class PreparePayView(CORSMixin, MarketplaceView, GenericAPIView):
     authentication_classes = [RestOAuthAuthentication,
                               RestSharedSecretAuthentication]
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
     cors_allowed_methods = ['post']
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=943471

Explanation:
- `SharedSecretAuthentication` was using the proxy, so DRF's request proxy had amo_user and user set, but not the real request underneath
- `_prepare_pay()` needs a real request and not DRF's proxy.
- Since we dont usually deal with the real request in DRF views, everything was mostly fine in the rest of our code.
