### PR TITLE
handle empty values in iarc xml resp (bug 939883)

### DIFF
--- a/lib/iarc/client.py
+++ b/lib/iarc/client.py
@@ -94,7 +94,7 @@ MOCK_GET_APP_INFO = '''<?xml version="1.0" encoding="utf-16"?>
         <FIELD NAME="company" TYPE="string" VALUE="Mozilla" />
         <FIELD NAME="platform" TYPE="string" VALUE="Firefox" />
         <FIELD NAME="rating_PEGI" TYPE="string" VALUE="16+" />
-        <FIELD NAME="descriptors_PEGI" TYPE="string" VALUE="Language, Online" />
+        <FIELD NAME="descriptors_PEGI" TYPE="string" />
         <FIELD NAME="rating_USK" TYPE="string" VALUE="12+" />
         <FIELD NAME="descriptors_USK" TYPE="string" VALUE="Explizite Sprache" />
         <FIELD NAME="rating_ESRB" TYPE="string" VALUE="Mature 17+" />

--- a/lib/iarc/tests/test_utils_.py
+++ b/lib/iarc/tests/test_utils_.py
@@ -104,11 +104,10 @@ class TestXMLParser(amo.tests.TestCase):
         eq_(data['ratings'][ratingsbodies.GENERIC], ratingsbodies.GENERIC_16)
 
         # Test descriptors.
-        self.assertSetEqual(data['descriptors'],
-                            ['has_generic_lang', 'has_usk_lang',
-                             'has_esrb_strong_lang',
-                             'has_classind_sex_content', 'has_classind_lang',
-                             'has_pegi_lang', 'has_pegi_online'])
+        self.assertSetEqual(
+            data['descriptors'],
+            ['has_generic_lang', 'has_usk_lang', 'has_esrb_strong_lang',
+             'has_classind_sex_content', 'has_classind_lang'])
 
         # Test interactives.
         self.assertSetEqual(data['interactives'],

--- a/lib/iarc/utils.py
+++ b/lib/iarc/utils.py
@@ -54,6 +54,9 @@ class IARC_Parser(object):
             interactives = []
 
             for k, v in row.items():
+                if not v:
+                    continue
+
                 # Get ratings body constant.
                 ratings_body = RATINGS_BODY_MAPPING.get(
                     k.split('_')[-1].lower(), ratingsbodies.GENERIC)

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -1073,7 +1073,7 @@ class PreloadTestPlanForm(happyforms.Form):
 
 class IARCGetAppInfoForm(happyforms.Form):
     submission_id = forms.CharField()
-    security_code = forms.CharField()
+    security_code = forms.CharField(max_length=10)
 
     def clean_submission_id(self):
         submission_id = (


### PR DESCRIPTION
```
AttributeError: 'NoneType' object has no attribute 'split'

Stacktrace (most recent call last):

  File "django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "newrelic/hooks/framework_django.py", line 485, in wrapper
    return wrapped(*args, **kwargs)
  File "amo/decorators.py", line 157, in wrapper
    return f(*args, **kw)
  File "amo/decorators.py", line 149, in wrapper
    return f(*args, **kw)
  File "waffle/decorators.py", line 36, in _wrapped_view
    return view(request, *args, **kwargs)
  File "addons/decorators.py", line 33, in wrapper
    return f(request, addon, *args, **kw)
  File "amo/decorators.py", line 32, in wrapper
    return func(request, *args, **kw)
  File "mkt/developers/decorators.py", line 49, in wrapper
    return fun()
  File "mkt/developers/decorators.py", line 28, in <lambda>
    *args, **kw)
  File "mkt/developers/views.py", line 320, in content_ratings_edit
    form.save(addon)
  File "mkt/developers/forms.py", line 1102, in save
    data = lib.iarc.utils.IARC_XML_Parser().parse_string(resp)
  File "lib/iarc/utils.py", line 133, in parse_string
    return self.parse(StringIO.StringIO(string))
  File "lib/iarc/utils.py", line 118, in parse
    data = self._process_iarc_items(data)
  File "lib/iarc/utils.py", line 74, in _process_iarc_items
    [s.strip() for s in v.split(',')])
```
