### PR TITLE
Bug 912491 (Fix file viewer permissions.)

### DIFF
--- a/apps/files/utils.py
+++ b/apps/files/utils.py
@@ -420,6 +420,10 @@ def copy_over(source, dest):
     if os.path.exists(dest) and os.path.isdir(dest):
         shutil.rmtree(dest)
     shutil.copytree(source, dest)
+    # mkdtemp will set the directory permissions to 700
+    # for the webserver to read them, we need 755
+    os.chmod(dest, stat.S_IRWXU | stat.S_IRGRP |
+             stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
     shutil.rmtree(source)
 
 


### PR DESCRIPTION
tmpfile.mkdtemp creates a directory with 700 permissions,
then shutil.copytree copies the 700 over to "dest". This directory is
then unreadable by the webserver.
