### PR TITLE
various small docs improvements, typos, fixes...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# You can set these variables from the command line.
+DJANGO = python manage.py
+SETTINGS = settings_local
+
+.PHONY: help docs test test_force_db tdd test_failed update update_landfill reindex reindex_mkt
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  docs             to builds the docs for Zamboni"
+	@echo "  test             to run all the test suite"
+	@echo "  test_force_db    to run all the test suite with a new database"
+	@echo "  tdd              to run all the test suite, but stop on the first error"
+	@echo "  test_failed      to rerun the failed tests from the previous run"
+	@echo "  update           to run a full update (git, pip, schematic, landfill)"
+	@echo "  reindex          to reindex everything in elasticsearch, for AMO"
+	@echo "  reindex_mkt      to reindex everything in elasticsearch, for marketplace"
+	@echo "Check the Makefile to know exactly what each target is doing. If you see a "
+	@echo "target using something like $(SETTINGS), you can make it use another value:"
+	@echo "  make SETTINGS=settings_mkt docs"
+
+docs:
+	$(MAKE) -C docs html
+
+test:
+	$(DJANGO) test --settings=$(SETTINGS) --noinput --logging-clear-handlers --with-id $(ARGS)
+
+test_force_db:
+	FORCE_DB=1 $(DJANGO) test --settings=$(SETTINGS) --noinput --logging-clear-handlers --with-id $(ARGS)
+
+tdd:
+	$(DJANGO) test --settings=$(SETTINGS) --noinput --failfast --pdb --with-id $(ARGS)
+
+test_failed:
+	$(DJANGO) test --settings=$(SETTINGS) --noinput --logging-clear-handlers --with-id --failed $(ARGS)
+
+update:
+	git checkout master && git pull && git submodule update --init --recursive
+	pushd vendor && git pull && git submodule update --init && popd
+	pip install --no-deps --exists-action=w --download-cache=/tmp/pip-cache -r requirements/dev.txt
+	schematic migrations
+
+update_landfill: update
+	$(DJANGO) install_landfill --settings=$(SETTINGS) $(ARGS)
+
+reindex:
+	$(DJANGO) reindex --settings=$(SETTINGS) $(ARGS)
+
+reindex_mkt:
+	$(DJANGO) reindex_mkt --settings=$(SETTINGS) $(ARGS)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,12 +76,24 @@ Running Tests
     great most of the time.  See the docs for more stuff you can do with
     :mod:`nose and logging <nose.plugins.logcapture>`.
 
+There's also a few useful makefile targets like ``test``, ``tdd`` and
+``test_force_db``::
+
+    make test
+
 
 Building Docs
 ~~~~~~~~~~~~~
 
-* If you're working on the docs, use ``make loop`` to keep your built pages
-  up-to-date.
+To simply build the docs::
+
+    make docs
+
+If you're working on the docs, use ``make loop`` to keep your built pages
+up-to-date::
+
+    cd docs
+    make loop
 
 
 Indices and tables

--- a/docs/topics/django.rst
+++ b/docs/topics/django.rst
@@ -77,7 +77,12 @@ You can find lots of goodies on http://www.b-list.org/weblog/categories/django/.
 Migrations
 ----------
 
-We're going to use `South <http://south.aeracode.org/>`_.  Here's the
-`Quick Start Guide <http://south.aeracode.org/wiki/QuickStartGuide>`_, the
-`tutorial <http://south.aeracode.org/wiki/Tutorial1>`__, and the rest of the
-`South docs <http://south.aeracode.org/wiki/Documentation>`_.
+We're using Schematic_ which is a really simple migration tool to apply SQL
+migrations to your databases.
+
+Migrations are all stored in the ``migrations/`` folder, and are applied like
+so::
+
+    schematic migrations/
+
+.. _Schematic: https://github.com/mozilla/schematic

--- a/docs/topics/hacking/testing.rst
+++ b/docs/topics/hacking/testing.rst
@@ -31,7 +31,7 @@ for the full set, but some common ones are:
 
 * ``--noinput`` tells Django not to ask about creating or destroying test
   databases.
-* ``--loggging-clear-handlers`` tells nose that you don't want to see any
+* ``--logging-clear-handlers`` tells nose that you don't want to see any
   logging output.  Without this, our debug logging will spew all over your
   console during test runs.  This can be useful for debugging, but it's not that
   great most of the time.  See the docs for more stuff you can do with
@@ -40,6 +40,30 @@ for the full set, but some common ones are:
 Our continuous integration server adds some additional flags for other features
 (for example, coverage statistics).  To see what those commands are check out
 the build script at :src:`scripts/build.sh`.
+
+There are a few useful makefile targets that you can use:
+
+Run all the tests using your ``settings_local.py`` file::
+
+    make test
+
+If you need to rebuild the database::
+
+    make test_force_db
+
+To fail and stop running tests on the first failure::
+
+    make tdd
+
+If you wish to add arguments, or run a specific test, overload the variables
+(check the Makefile for more information)::
+
+    make SETTINGS=settings_mkt ARGS='--verbosity 2 zamboni.apps.amo.tests.test_url_prefix:MiddlewareTest.test_get_app' test
+
+Those targets include some useful options, like the ``--with-id`` which allows
+you to re-run only the tests failed from the previous run::
+
+    make test_failed
 
 
 Database Setup

--- a/docs/topics/install-zamboni/advanced-installation.rst
+++ b/docs/topics/install-zamboni/advanced-installation.rst
@@ -81,6 +81,36 @@ The ``REDIS_BACKEND`` is parsed like ``CACHE_BACKEND`` if you need something
 other than the default settings.
 
 
+-------
+Node.js
+-------
+
+`Node.js <http://nodejs.org/>`_ is needed for Stylus and LESS, which in turn
+are needed to precompile the CSS files.
+
+If you want to serve the CSS files from another domain than the webserver, you
+will need to precompile them. Otherwise you can have them compiled on the fly,
+using javascript in your browser, if you set ``LESS_PREPROCESS = False`` in
+your local settings.
+
+First, we need to install node and npm::
+
+    brew install node
+    curl http://npmjs.org/install.sh | sh
+
+Optionally make the local scripts available on your path if you don't already
+have this in your profile::
+
+    export PATH="./node_modules/.bin/:${PATH}"
+
+Not working?
+ * If you're having trouble installing node, try
+   http://shapeshed.com/journal/setting-up-nodejs-and-npm-on-mac-osx/.  You
+   need brew, which we used earlier.
+ * If you're having trouble with npm, check out the README on
+   https://github.com/isaacs/npm
+
+
 ----------
 Stylus CSS
 ----------
@@ -103,8 +133,12 @@ LESS CSS
 We're slowing switching over from regular CSS to LESS.  You can learn more about
 LESS at http://lesscss.org.
 
-If you are serving your CSS from the same domain as the page, you don't
-need to do anything.  Otherwise, see "Installing LESS (alternative)" below.
+If you already ran ``npm install`` you don't need to do anything more.
+
+In your ``settings_local.py`` (or ``settings_local_mkt.py``) ensure you are
+pointing to the correct executable for ``less``::
+
+    LESS_BIN = path('node_modules/less/bin/lessc')
 
 You can make the CSS live refresh on save by adding ``#!watch`` to the URL or by
 adding the following to your ``settings_local.py``::
@@ -116,43 +150,3 @@ If you want syntax highlighting, try:
  * emacs: http://jdhuntington.com/emacs/less-css-mode.el
  * TextMate: https://github.com/appden/less.tmbundle
  * Coda: http://groups.google.com/group/coda-users/browse_thread/thread/b3327b0cb893e439?pli=1
-
-
-Installing LESS (alternative)
-*****************************
-
-You only need to do this if your CSS is being served from a separate domain, or
-if you're using zamboni in production and running the build scripts.
-
-If you aren't serving your CSS from the same domain as zamboni, you'll need
-to install node so that we can compile it on the fly.
-
-First, we need to install node, npm and LESS::
-
-    brew install node
-    curl http://npmjs.org/install.sh | sh
-
-Install all of zamboni's dependencies locally::
-
-    cd zamboni
-    npm install
-
-Make the local scripts available on your path if you don't already have this in
-your profile::
-
-    export PATH="./node_modules/.bin/:${PATH}"
-
-If you type ``lessc``, it should say "lessc: no input files."
-
-Next, add this to your settings_local.py::
-
-    LESS_PREPROCESS = True
-    LESS_BIN = 'lessc'
-
-Make sure ``LESS_BIN`` is correct.
-
-Not working?
- * If you're having trouble installing node, try http://shapeshed.com/journal/setting-up-nodejs-and-npm-on-mac-osx/.  You need brew, which we used earlier.
- * If you're having trouble with npm, check out the README on https://github.com/isaacs/npm
- * If you can't run LESS after installing, make sure it's in your PATH.  You should be
-   able to type "lessc", and have "lessc: no input files" returned.

--- a/docs/topics/install-zamboni/elasticsearch.rst
+++ b/docs/topics/install-zamboni/elasticsearch.rst
@@ -34,14 +34,21 @@ Settings
 .. literalinclude:: /../scripts/elasticsearch/elasticsearch.yml
 
 We use a custom analyzer for indexing add-on names since they're a little
-different from normal text. To get the same results as our servers, put this in
-your elasticsearch.yml (available at
-:src:`scripts/elasticsearch/elasticsearch.yml`)
+different from normal text.
 
-Once installed, we can configure Elasticsearch. Zamboni has a ```config.yml```
-in the ```scripts/elasticsearch/``` directory. If on OSX, copy that file into
-```/usr/local/Cellar/elasticsearch/x.x.x/config/```. On Linux, the directory is
-```/etc/elasticsearch/```.
+To get the same results as our servers, configure Elasticsearch by copying the
+:src:`scripts/elasticsearch/elasticsearch.yml` (available in the
+``scripts/elasticsearch/`` folder of your install) to your system:
+
+* If on OSX, copy that file into
+  ``/usr/local/Cellar/elasticsearch/*/config/``.
+* On Linux, the directory is ``/etc/elasticsearch/``.
+
+.. note::
+
+   If you are on a linux box, make sure to comment out the 4 lines relevant to
+   the path configuration, unless it corresponds to an existing
+   ``/usr/local/var`` folder and you want it to be stored there.
 
 If you don't do this your results will be slightly different, but you probably
 won't notice.
@@ -49,27 +56,36 @@ won't notice.
 Launching and Setting Up
 ------------------------
 
-Launch the Elasticsearch service. If you used homebrew, `brew info
-elasticsearch` will show you the commands to launch. If you used aptitude,
-Elasticsearch will come with an start-stop daemon in /etc/init.d.
+Launch the Elasticsearch service. If you used homebrew, ``brew info
+elasticsearch`` will show you the commands to launch. If you used aptitude,
+Elasticsearch will come with a start-stop daemon in /etc/init.d.
 
 Zamboni has commands that sets up mappings and indexes objects such as add-ons
-and apps for you. Setting up the mappings is analagous defining the structure
-of a table, indexing is analagous to storing rows.
+and apps for you. Setting up the mappings is analagous to defining the
+structure of a table, indexing is analagous to storing rows.
 
 For AMO, this will set up all indexes and start the indexing processeses::
 
-    ./manage.py reindex --settings=your_local_mkt_settings
+    ./manage.py reindex --settings=your_local_amo_settings
 
 For Marketplace, use this to only create the apps index and index apps::
 
     ./manage.py reindex_mkt --settings=your_local_mkt_settings
 
+Or you could use the makefile target (using the ``settings_local.py`` file)::
+
+    make reindex
+
+If you need to use another settings file and add arguments::
+
+    make SETTINGS=settings_amo ARGS='--with-stats --wipe --force' reindex
+
+
 Indexing
 --------
 
-Zamboni has other indexing commands. It is worth nothing the index is
-maintained incrementally through post_save and post_delete hooks.::
+Zamboni has other indexing commands. It is worth noting that the index is
+maintained incrementally through post_save and post_delete hooks::
 
     ./manage.py cron reindex_addons  # Index all the add-ons.
 
@@ -94,15 +110,15 @@ Querying Elasticsearch in Django
 We use `elasticutils <http://github.com/mozilla/elasticutils>`_, a Python
 library that gives us a search API to elasticsearch.
 
-We attach elasticutils to Django models with a mixin. This lets us do things like
-`.search()` which returns an object which acts a lot like Django's ORM's object
-manager. `.filter(**kwargs)` can be run on this search object.::
+We attach elasticutils to Django models with a mixin. This lets us do things
+like ``.search()`` which returns an object which acts a lot like Django's ORM's
+object manager. ``.filter(**kwargs)`` can be run on this search object::
 
     query_results = list(
         MyModel.search().filter(my_field=a_str.lower())
         .values_dict('that_field'))
 
-On Marketplace, apps use ```mkt/webapps/models:WebappIndexer``` as its
+On Marketplace, apps use ``mkt/webapps/models:WebappIndexer`` as its
 interface to Elasticsearch. Search is done a little differently using
 this and results are a list of ``WebappIndexer`` objects::
 
@@ -111,7 +127,7 @@ this and results are a list of ``WebappIndexer`` objects::
 Testing with Elasticsearch
 --------------------------
 
-All test cases using Elasticsearch should inherit from `amo.tests.ESTestCase`.
+All test cases using Elasticsearch should inherit from ``amo.tests.ESTestCase``.
 All such tests will be skipped by the test runner unless::
 
     RUN_ES_TESTS = True

--- a/docs/topics/install-zamboni/installation.rst
+++ b/docs/topics/install-zamboni/installation.rst
@@ -212,6 +212,7 @@ you want it.
 Any file that looks like ``settings_local*`` is for local use only; it will be
 ignored by git.
 
+
 Database
 --------
 
@@ -302,6 +303,7 @@ configured your settings and database, you're good to go.
 To choose which site you want to run, use the `settings` command line
 argument to pass in a local settings file you created above.
 
+
 Run The Add-ons Server
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -344,6 +346,7 @@ example::
     SITE_URL = 'http://localhost:8000'
     STATIC_URL = SITE_URL + '/'  # STATIC_URL must have a trailing slash.
 
+
 Create an Admin User
 --------------------
 
@@ -385,10 +388,31 @@ Or to run AMO's tests::
 
     ./manage.py test --settings=settings_local_amo
 
+There are a few useful makefile targets that you can use, the simplest one
+being::
+
+    make test
+
+Please check the :doc:`../hacking/testing` page for more information on
+the other available targets.
+
 .. _updating:
+
 
 Updating
 --------
+
+To run a full update of zamboni (including source files, pip requirements and
+database migrations)::
+
+    make update
+
+Use the following if you also wish to prefill your database with the data from
+landfill::
+
+    make update_landfill
+
+If you want to do it manually, then check the following steps:
 
 This updates zamboni::
 

--- a/docs/topics/oauth.rst
+++ b/docs/topics/oauth.rst
@@ -17,7 +17,7 @@ The OAuth "dance" involves a number of steps:
 2. The app sends the user with the *Request Token* to an authorization page.
 3. The app requests an *Access Token* with the user-authorized *Request Token*.
 
-Each of these reuqests must contain various OAuth headers, request parameters
+Each of these requests must contain various OAuth headers, request parameters
 and be signed in a specific manner.
 
 This is detailed in our api tests in ``_oauth_flow``.

--- a/docs/topics/payments.rst
+++ b/docs/topics/payments.rst
@@ -69,3 +69,6 @@ marketplace with the host::
     SOLITUDE_HOSTS = ('http://mock-solitude.paas.allizom.org/',)
 
 You will also want to ensure that the URL ``/mozpay/`` routes to WebPay.
+
+
+.. _PayPal developer site: https://developer.paypal.com/

--- a/docs/topics/template.rst
+++ b/docs/topics/template.rst
@@ -46,5 +46,5 @@ snippet:
 
     {% block title %}{{ page_title(_('My Unique Title')) }}{% endblock %}
 
-.. _Jingo: http://jbalogh.me/projects/jingo/
+.. _Jingo: http://jingo.readthedocs.org/en/latest/
 .. _AMO: https://addons.mozilla.org/en-US/firefox/


### PR DESCRIPTION
The last commit is adding a Makefile, and adding a few notes to the docs listing a few targets.

In my opinion (and others' too: http://www.jeffknupp.com/blog/2013/11/15/supercharge-your-python-developers/) it's a good idea to have a Makefile around with the most used commands, for a few reasons:
- ease of use, handy shortcuts
- local "documentation": what's the usual way of running tests? Let's check the Makefile (or the docs, but then, information might be spread around a few pages)
- when starting with a new project, even if you didn't read the documentation yet, you can still do the main tasks (run tests, update, reindex...)

I even go a step further on my own libs by adding a target that creates the virtualenv (locally). Eg: https://github.com/magopian/django-data-exports/blob/master/Makefile#L3

I'd love to add more targets to this file as I discover more menial and repetitive tasks/commands, please let me know if you think of any!
