### PR TITLE
add a amo/mkt flag to allow reindexing both concurrently #880698

### DIFF
--- a/apps/addons/cron.py
+++ b/apps/addons/cron.py
@@ -95,7 +95,7 @@ def _update_addons_current_version(data, **kw):
 @cronjobs.register
 def update_addon_average_daily_users():
     """Update add-ons ADU totals."""
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('amo')
     cursor = connections[multidb.get_slave()].cursor()
     q = """SELECT
                addon_id, AVG(`count`)
@@ -140,7 +140,7 @@ def _update_addon_average_daily_users(data, **kw):
 @cronjobs.register
 def update_daily_theme_user_counts():
     """Store the day's theme popularity counts into ThemeUserCount."""
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('amo')
     d = Persona.objects.values_list('addon', 'popularity').order_by('id')
 
     date = datetime.now().strftime('%M-%d-%y')

--- a/apps/amo/cron.py
+++ b/apps/amo/cron.py
@@ -236,7 +236,7 @@ def weekly_downloads():
     """
     Update 7-day add-on download counts.
     """
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('amo')
     cursor = connection.cursor()
     cursor.execute("""
         SELECT addon_id, SUM(count) AS weekly_count

--- a/apps/stats/cron.py
+++ b/apps/stats/cron.py
@@ -21,7 +21,7 @@ cron_log = commonware.log.getLogger('z.cron')
 @cronjobs.register
 def update_addons_collections_downloads():
     """Update addons+collections download totals."""
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('amo')
 
     d = (AddonCollectionCount.objects.values('addon', 'collection')
          .annotate(sum=Sum('count')))
@@ -46,7 +46,7 @@ def update_collections_total():
 @cronjobs.register
 def update_global_totals(date=None):
     """Update global statistics totals."""
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('amo')
 
     if date:
         date = datetime.datetime.strptime(date, '%Y-%m-%d').date()
@@ -99,7 +99,7 @@ def addon_total_contributions():
 
 @cronjobs.register
 def index_latest_stats(index=None, aliased=True):
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('amo')
     latest = UpdateCount.search(index).order_by('-date').values_dict()
     if latest:
         latest = latest[0]['date']

--- a/lib/es/models.py
+++ b/lib/es/models.py
@@ -1,11 +1,79 @@
 from django.db import models
+from django.utils import timezone
+
+
+class ReindexingManager(models.Manager):
+    """Used to flag when an elasticsearch reindexing is occuring."""
+
+    def _flag_reindexing(self, site, new_index, old_index, alias):
+        """Flag the database for a reindex on the given site."""
+        if self._is_reindexing(site):
+            return  # Already flagged.
+
+        return self.create(new_index=new_index,
+                           old_index=old_index,
+                           alias=alias,
+                           site=site)
+
+    def flag_reindexing_amo(self, new_index, old_index, alias):
+        """Flag the database for an AMO reindex."""
+        return self._flag_reindexing('amo', new_index, old_index, alias)
+
+    def flag_reindexing_mkt(self, new_index, old_index, alias):
+        """Flag the database for a MKT reindex."""
+        return self._flag_reindexing('mkt', new_index, old_index, alias)
+
+    def _unflag_reindexing(self, site):
+        """Unflag the database for a reindex on the given site."""
+        self.filter(site=site).delete()
+
+    def unflag_reindexing_amo(self):
+        """Unflag the database for an AMO reindex."""
+        self._unflag_reindexing('amo')
+
+    def unflag_reindexing_mkt(self):
+        """Unflag the database for a MKT reindex."""
+        self._unflag_reindexing('mkt')
+
+    def _is_reindexing(self, site):
+        """Return True if a reindexing is occuring for the given site."""
+        return self.filter(site=site).exists()
+
+    def is_reindexing_amo(self):
+        """Return True if a reindexing is occuring on AMO."""
+        return self._is_reindexing('amo')
+
+    def is_reindexing_mkt(self):
+        """Return True if a reindexing is occuring on MKT."""
+        return self._is_reindexing('mkt')
+
+    def get_indices(self, index):
+        """Return the indices associated with an alias.
+
+        If we are reindexing, there should be two indices returned.
+
+        """
+        try:
+            reindex = self.get(alias=index)
+            # Yes. Let's reindex on both indexes.
+            return [idx for idx in reindex.new_index, reindex.old_index
+                    if idx is not None]
+        except Reindexing.DoesNotExist:
+            return [index]
 
 
 class Reindexing(models.Model):
-    start_date = models.DateTimeField()
+    SITE_CHOICES = (
+        ('amo', 'AMO'),
+        ('mkt', 'MKT'),
+    )
+    start_date = models.DateTimeField(default=timezone.now)
     old_index = models.CharField(max_length=255, null=True)
     new_index = models.CharField(max_length=255)
     alias = models.CharField(max_length=255)
+    site = models.CharField(max_length=3, choices=SITE_CHOICES)
+
+    objects = ReindexingManager()
 
     class Meta:
         db_table = 'zadmin_reindexing'

--- a/lib/es/tests/test_models.py
+++ b/lib/es/tests/test_models.py
@@ -1,0 +1,104 @@
+import mock
+from nose.tools import eq_
+
+import amo.tests
+from lib.es.models import Reindexing
+
+
+class TestReindexManager(amo.tests.TestCase):
+
+    def test_flag_reindexing(self):
+        assert Reindexing.objects.filter(site='foo').count() == 0
+
+        # Flagging for the first time.
+        res = Reindexing.objects._flag_reindexing('foo', 'bar', 'baz', 'quux')
+        eq_(Reindexing.objects.filter(site='foo').count(), 1)
+        eq_(res.site, 'foo')
+        eq_(res.new_index, 'bar')
+        eq_(res.old_index, 'baz')
+        eq_(res.alias, 'quux')
+
+        # Flagging for the second time.
+        res = Reindexing.objects._flag_reindexing('foo', 'bar', 'baz', 'quux')
+        assert Reindexing.objects.filter(site='foo').count() == 1
+        assert res is None
+
+    @mock.patch('lib.es.models.ReindexingManager._flag_reindexing')
+    def test_flag_reindexing_amo(self, flag_reindexing_mock):
+        Reindexing.objects.flag_reindexing_amo('bar', 'baz', 'quux')
+        assert flag_reindexing_mock.called_with([
+            ('amo', 'bar', 'baz', 'quux')])
+
+    @mock.patch('lib.es.models.ReindexingManager._flag_reindexing')
+    def test_flag_reindexing_mkt(self, flag_reindexing_mock):
+        # This test doesn't run with AMO settings, no idea why.
+        Reindexing.objects.flag_reindexing_mkt('bar', 'baz', 'quux')
+        assert flag_reindexing_mock.called_with([
+            ('mkt', 'bar', 'baz', 'quux')])
+
+    def test_unflag_reindexing(self):
+        assert Reindexing.objects.filter(site='foo').count() == 0
+
+        # Unflagging unflagged database does nothing.
+        Reindexing.objects._unflag_reindexing('foo')
+        assert Reindexing.objects.filter(site='foo').count() == 0
+
+        # Flag, then unflag.
+        Reindexing.objects.create(site='foo', new_index='bar', old_index='baz',
+                                  alias='quux')
+        assert Reindexing.objects.filter(site='foo').count() == 1
+
+        Reindexing.objects._unflag_reindexing('foo')
+        assert Reindexing.objects.filter(site='foo').count() == 0
+
+        # Unflagging another site doesn't clash.
+        Reindexing.objects.create(site='bar', new_index='bar', old_index='baz',
+                                  alias='quux')
+        Reindexing.objects._unflag_reindexing('foo')
+        assert Reindexing.objects.filter(site='bar').count() == 1
+
+    @mock.patch('lib.es.models.ReindexingManager._unflag_reindexing')
+    def test_unflag_reindexing_amo(self, unflag_reindexing_mock):
+        Reindexing.objects.unflag_reindexing_amo()
+        assert unflag_reindexing_mock.called_with([('amo')])
+
+    @mock.patch('lib.es.models.ReindexingManager._unflag_reindexing')
+    def test_unflag_reindexing_mkt(self, unflag_reindexing_mock):
+        # This test doesn't run with AMO settings, no idea why.
+        Reindexing.objects.unflag_reindexing_mkt()
+        assert unflag_reindexing_mock.called_with([('mkt')])
+
+    def test_is_reindexing(self):
+        assert Reindexing.objects.filter(site='foo').count() == 0
+        assert not Reindexing.objects._is_reindexing('foo')
+
+        Reindexing.objects.create(site='foo', new_index='bar', old_index='baz',
+                                  alias='quux')
+        assert Reindexing.objects._is_reindexing('foo')
+
+        # Reindexing on another site doesn't clash.
+        assert not Reindexing.objects._is_reindexing('bar')
+
+    @mock.patch('lib.es.models.ReindexingManager._is_reindexing')
+    def test_is_reindexing_amo(self, is_reindexing_mock):
+        Reindexing.objects.is_reindexing_amo()
+        assert is_reindexing_mock.called_with([('amo')])
+
+    @mock.patch('lib.es.models.ReindexingManager._is_reindexing')
+    def test_is_reindexing_mkt(self, is_reindexing_mock):
+        # This test doesn't run with AMO settings, no idea why.
+        Reindexing.objects.is_reindexing_mkt()
+        assert is_reindexing_mock.called_with([('mkt')])
+
+    def test_get_indices(self):
+        # Not reindexing.
+        assert Reindexing.objects.filter(alias='foo').count() == 0
+        assert Reindexing.objects.get_indices('foo') == ['foo']
+
+        # Reindexing on 'foo'.
+        Reindexing.objects.create(site='foo', new_index='bar', old_index='baz',
+                                  alias='quux')
+        assert Reindexing.objects.get_indices('quux') == ['bar', 'baz']
+
+        # Doesn't clash on other sites.
+        assert Reindexing.objects.get_indices('other') == ['other']

--- a/migrations/705-reindexing-add-site.sql
+++ b/migrations/705-reindexing-add-site.sql
@@ -1,0 +1,1 @@
+ALTER TABLE zadmin_reindexing ADD COLUMN site varchar(3) NOT NULL;

--- a/mkt/stats/cron.py
+++ b/mkt/stats/cron.py
@@ -15,7 +15,7 @@ cron_log = commonware.log.getLogger('mkt.cron')
 
 @cronjobs.register
 def index_latest_mkt_stats(index=None, aliased=True):
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('mkt')
     yesterday = datetime.date.today() - datetime.timedelta(days=1)
 
     try:

--- a/mkt/webapps/cron.py
+++ b/mkt/webapps/cron.py
@@ -26,7 +26,7 @@ log = commonware.log.getLogger('z.cron')
 @cronjobs.register
 def update_weekly_downloads():
     """Update the weekly "downloads" from the users_install table."""
-    raise_if_reindex_in_progress()
+    raise_if_reindex_in_progress('mkt')
     interval = datetime.datetime.today() - datetime.timedelta(days=7)
     counts = (Installed.objects.values('addon')
                                .filter(created__gte=interval,

--- a/mkt/webapps/tests/test_crons.py
+++ b/mkt/webapps/tests/test_crons.py
@@ -13,7 +13,7 @@ from nose.tools import eq_
 import amo
 import amo.tests
 from addons.models import Addon
-from lib.es.management.commands.reindex import flag_database, unflag_database
+from lib.es.utils import flag_reindexing_mkt, unflag_reindexing_mkt
 from users.models import UserProfile
 
 import mkt
@@ -55,7 +55,7 @@ class TestWeeklyDownloads(amo.tests.TestCase):
         self.add_install(user=UserProfile.objects.get(pk=10482),
                          created=datetime.today() - timedelta(days=2))
 
-        flag_database('new', 'old', 'alias')
+        flag_reindexing_mkt('new', 'old', 'alias')
         try:
             # Should fail.
             self.assertRaises(CommandError, update_weekly_downloads)
@@ -65,7 +65,7 @@ class TestWeeklyDownloads(amo.tests.TestCase):
             os.environ['FORCE_INDEXING'] = '1'
             update_weekly_downloads()
         finally:
-            unflag_database()
+            unflag_reindexing_mkt()
             del os.environ['FORCE_INDEXING']
 
         eq_(self.get_webapp().weekly_downloads, 2)


### PR DESCRIPTION
This fixes bug #880698.

A ReindexingManager has been added to lib.es.models.Reindexing to group all the reindexing logic.
Functions are still imported from lib.es.utils as a convenience and a central point, abstracting the ReindexingManager stuff.

This is based on the previous PR (to be merged): https://github.com/mozilla/zamboni/pull/1433, only the https://github.com/magopian/zamboni/commit/48cd83a7ed44c152f175aff485e6830b014b5504 commit is related to this issue.

There's a glitch in the matrix I can't figure: https://github.com/magopian/zamboni/commit/48cd83a7ed44c152f175aff485e6830b014b5504#diff-3824d5c71612e823bbe939d7ea8b3032R33

For some reason, if there's a "_mkt" in the test name, it just won't be detected/run when using AMO settings (but will when using MKT settings). Changing the name to something else (like "_market") will solve the issue, and all the tests will then run (even with the AMO settings).

If anyone has an idea, just let me know ;)
