### PR TITLE
Only allow paid conversion for supported devices (bug 938716)

### DIFF
--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -77,12 +77,10 @@
             {% set has_multiple_paid_platforms = paid_platforms|length > 1 %}
             <div class="paid tab {{ 'active' if is_paid }}">
               <h2 id="paid-tab-header">
-                {%- if no_paid -%}
+                {%- if cannot_be_paid -%}
                   <a href="#"
-                     {% if not has_multiple_paid_platforms -%}
                        class="tooltip disabled"
-                       title="{{ _('Paid mode requires that your app only supports Firefox OS.') }}"
-                     {%- endif -%}
+                       title="{{ _('Paid mode requires that your app only supports:') }} {{ paid_platform_names|join(', ') }}"
                     >{{ _('Paid / In-app') }}</a>
                 {%- else -%}
                   <a href="#">{{ _('Paid / In-app') }}</a>
@@ -90,12 +88,16 @@
               </h2>
               <div class="error">{{ form.errors.paid_platforms }}</div>
               {%- for item in paid_platforms -%}
-                {{ button(form, item, can_change=has_multiple_paid_platforms) }}
+                {{ button(form, item, can_change=has_multiple_paid_platforms and is_paid) }}
               {%- endfor %}
-              {% if not is_paid and not no_paid or has_multiple_paid_platforms %}
+              {% if not is_paid and not cannot_be_paid %}
                 <div id="paid-tab-save" class="update-payment-type">
                   <button data-type="paid">{{ _('Change to Paid') }}</button>
                   {{ _('Changing to Paid will put your app back into review.') }}
+                </div>
+              {% else %}
+                <div id="compat-save-button" class="hidden update-payment-type">
+                  <button>{{ _('Save Changes') }}</button>
                 </div>
               {% endif %}
               <div class="helpful-links">

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -789,6 +789,25 @@ class TestPayments(amo.tests.TestCase):
         eq_(len(pqr('#paid-android-mobile input[type="checkbox"]')), 0)
         eq_(len(pqr('#paid-android-tablet input[type="checkbox"]')), 0)
 
+    def test_cannot_be_paid_with_android_payments(self):
+        self.create_flag('android-payments')
+        for device_type in (amo.DEVICE_GAIA,
+                            amo.DEVICE_MOBILE, amo.DEVICE_TABLET):
+            self.webapp.addondevicetype_set.get_or_create(
+                device_type=device_type.id)
+        res = self.client.get(self.url)
+        eq_(res.status_code, 200)
+        eq_(res.context['cannot_be_paid'], False)
+
+    def test_cannot_be_paid_without_android_payments(self):
+        for device_type in (amo.DEVICE_GAIA,
+                            amo.DEVICE_MOBILE, amo.DEVICE_TABLET):
+            self.webapp.addondevicetype_set.get_or_create(
+                device_type=device_type.id)
+        res = self.client.get(self.url)
+        eq_(res.status_code, 200)
+        eq_(res.context['cannot_be_paid'], True)
+
 
 class TestRegions(amo.tests.TestCase):
     fixtures = ['base/apps', 'base/users', 'webapps/337141-steamcube']


### PR DESCRIPTION
Fix ups for bug 938716
- This renames no_paid to cannot_be_paid so it's less likely to be confused with not_paid.
- Show the tooltip when not all platforms support paid which is more like how this used to work without the android-payments flag.
- Add a save button like we have for free (it's shown only when changes are made).
