### PR TITLE
fix deleting apps that have content ratings (bug 945466)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -383,6 +383,10 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
 
         id = self.id
 
+        # Tell IARC this app is delisted from the set_iarc_storefront_datat.
+        if self.type == amo.ADDON_WEBAPP:
+            self.set_iarc_storefront_data(disable=True)
+
         previews = list(Preview.objects.filter(addon__id=id)
                         .values_list('id', flat=True))
         if self.highest_status or self.status:
@@ -449,8 +453,6 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
         # `mkt.webapps.tasks.unindex_webapps.delay([id])`
         if not self.type == amo.ADDON_WEBAPP:
             tasks.unindex_addons.delay([id])
-        else:
-            self.set_iarc_storefront_data(disable=True)
 
         return True
 

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -750,6 +750,14 @@ class TestWebapp(amo.tests.TestCase):
         am.update(manifest=json.dumps(manifest))
         eq_(app.reload().is_offline, True)
 
+    @mock.patch('mkt.webapps.models.Webapp.set_iarc_storefront_data')
+    def test_delete_with_iarc(self, storefront_mock):
+        self.create_switch('iarc')
+        app = app_factory(rated=True)
+        app.delete()
+        eq_(app.status, amo.STATUS_DELETED)
+        assert storefront_mock.called
+
 
 class DeletedAppTests(amo.tests.ESTestCase):
 


### PR DESCRIPTION
Was trying to set IARC storefront data (which fetches the app) after the app was deleted. No likey.

```
DoesNotExist: Addon matching query does not exist.

Stacktrace (most recent call last):

  File "django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "newrelic/hooks/framework_django.py", line 485, in wrapper
    return wrapped(*args, **kwargs)
  File "amo/decorators.py", line 157, in wrapper
    return f(*args, **kw)
  File "amo/decorators.py", line 149, in wrapper
    return f(*args, **kw)
  File "addons/decorators.py", line 33, in wrapper
    return f(request, addon, *args, **kw)
  File "amo/decorators.py", line 32, in wrapper
    return func(request, *args, **kw)
  File "mkt/developers/decorators.py", line 49, in wrapper
    return fun()
  File "mkt/developers/decorators.py", line 28, in <lambda>
    *args, **kw)
  File "amo/decorators.py", line 51, in wrapper
    return f(request, *args, **kw)
  File "mkt/developers/views.py", line 158, in delete
    addon.delete(msg='Removed via devhub', reason=reason)
  File "django/db/transaction.py", line 224, in inner
    return func(*args, **kwargs)
  File "addons/models.py", line 453, in delete
    self.set_iarc_storefront_data(disable=True)
  File "mkt/webapps/models.py", line 1172, in set_iarc_storefront_data
    delocalized_self = Addon.objects.get(pk=self.pk)
  File "django/db/models/manager.py", line 131, in get
    return self.get_query_set().get(*args, **kwargs)
  File "django/db/models/query.py", line 366, in get
    % self.model._meta.object_name)
```
