### PR TITLE
Updated "Editors' Guide" URL in queue.html (bug 920289)

### DIFF
--- a/apps/editors/templates/editors/queue.html
+++ b/apps/editors/templates/editors/queue.html
@@ -181,7 +181,7 @@
 {{ _('Helpful Links:') }}
 <a href="{{ url('devhub.docs', doc_name='policies') }}">{{ _('Add-on Policy') }}</a>
 |
-<a href="http://wiki.mozilla.org/Update:Editors">{{ _("Editors' Guide") }}</a>
+<a href="https://wiki.mozilla.org/AMO:Editors/EditorGuide">{{ _("Editors' Guide") }}</a>
 </div>
 
 <div class="popup" id="popup-notes" data-url="{{ url('editors.queue_version_notes') }}"></div>

--- a/mkt/reviewers/templates/reviewers/queue.html
+++ b/mkt/reviewers/templates/reviewers/queue.html
@@ -92,7 +92,7 @@
 
   <p id="helpfulLinks">
     {{ _('Helpful Links:') }}
-    <a href="http://wiki.mozilla.org/Update:Editors">{{ _("Editors' Guide") }}</a>
+    <a href="https://wiki.mozilla.org/AMO:Editors/EditorGuide">{{ _("Editors' Guide") }}</a>
   </p>
 
   {% include "reviewers/includes/search_results.html" %}


### PR DESCRIPTION
Second attempt at fixing the "Editors' Guide" URL (see pull request #1367, bug [920289](https://bugzil.la/920289))
