### PR TITLE
Prevent reverse from returning unversioned API URLs; ensure that API-Status: Deprecated is correctly returned; assume API-Version: 1 in unversioned URLs (bug 944343)

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1618,3 +1618,7 @@ IARC_SUBMISSION_ENDPOINT = ''
 
 # The payment providers supported.
 PAYMENT_PROVIDERS = []
+
+# The currently-recommended version of the API. Any requests to versions older
+# than this will include the `API-Status: Deprecated` header.
+API_CURRENT_VERSION = 1

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -1019,4 +1019,4 @@ class TestLargeTextField(TestCase):
         field = LargeTextField(view_name='app-privacy-policy-detail')
         field.context = {'request': None}
         url = field.field_to_native(app, None)
-        eq_(url, '/api/apps/app/337141/privacy/')
+        self.assertApiUrlEqual(url, '/apps/app/337141/privacy/')

--- a/mkt/api/urls.py
+++ b/mkt/api/urls.py
@@ -30,5 +30,9 @@ from django.conf.urls import include, patterns, url
 urlpatterns = patterns('',
     url('^v2/', include('mkt.api.v2.urls')),
     url('^v1/', include('mkt.api.v1.urls')),
-    url('', include('mkt.api.v1.urls')),
+
+    # Necessary for backwards-compatibility. We assume that this always means
+    # API version 1. The namespace ensures that no URLS are ever reversed to
+    # this pattern. Yummycake because we already ate the tastypie.
+    url('', include('mkt.api.v1.urls', namespace='yummycake')),
 )

--- a/mkt/collections/tests/test_views.py
+++ b/mkt/collections/tests/test_views.py
@@ -240,6 +240,7 @@ class TestCollectionViewSetListing(BaseCollectionViewSetTest):
         eq_(data['meta']['previous'], None)
         eq_(data['meta']['offset'], 0)
         next = urlparse(data['meta']['next'])
+        ok_(next.path.startswith('/api/v1'))
         eq_(next.path, self.list_url)
         eq_(QueryDict(next.query).dict(), {u'limit': u'3', u'offset': u'3'})
 
@@ -252,6 +253,7 @@ class TestCollectionViewSetListing(BaseCollectionViewSetTest):
         eq_(data['meta']['total_count'], 4)
         eq_(data['meta']['limit'], 3)
         prev = urlparse(data['meta']['previous'])
+        ok_(prev.path.startswith('/api/v1'))
         eq_(next.path, self.list_url)
         eq_(QueryDict(prev.query).dict(), {u'limit': u'3', u'offset': u'0'})
         eq_(data['meta']['offset'], 3)

--- a/mkt/ratings/tests/test_resources.py
+++ b/mkt/ratings/tests/test_resources.py
@@ -84,7 +84,7 @@ class TestRatingResource(RestOAuth, amo.tests.AMOPaths):
         eq_(data['user']['can_rate'], True)
         eq_(data['user']['has_rated'], True)
         eq_(len(data['objects']), 1)
-        eq_(data['objects'][0]['app'], '/api/apps/app/337141/')
+        self.assertApiUrlEqual(data['objects'][0]['app'], '/apps/app/337141/')
         eq_(data['objects'][0]['body'], rev.body)
         eq_(data['objects'][0]['created'],
             rev.created.replace(microsecond=0).isoformat())

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -134,11 +134,11 @@ class TestWebapp(amo.tests.TestCase):
 
     def test_get_api_url(self):
         webapp = Webapp(app_slug='woo', pk=1)
-        eq_(webapp.get_api_url(), '/api/apps/app/woo/')
+        self.assertApiUrlEqual(webapp.get_api_url(), '/apps/app/woo/')
 
     def test_get_api_url_pk(self):
         webapp = Webapp(pk=1)
-        eq_(webapp.get_api_url(pk=True), '/api/apps/app/1/')
+        self.assertApiUrlEqual(webapp.get_api_url(pk=True), '/apps/app/1/')
 
     def test_get_stats_url(self):
         webapp = Webapp(app_slug='woo')


### PR DESCRIPTION
The problem here is that some reverses for API endpoints were not including a specific version in the returned URL, so any requests on those URLs were returning `API-Status: Deprecated`. A few changes were made here:
- Added an `API_CURRENT_VERSION` setting.
- Assume that unprefixed requests to the API (`/api/foo` vs. `/api/v1/foo`) are attempting to access v1 of the API.
- Add a namespace to the unprefixed URL pattern to ensure that nothing gets reversed to it.
- Change `APIVersionMiddleware` to only apply `API-Status: Deprecated` when `request.API_VERSION` is less than `settings.API_CURRENT_VERSION`.
- Add assertion that allows tests against URLs returned by the API to be done in a version-agnostic way.

A bug will be filed to provide a smarter way to reverse against a specific API version (defaulting to `request.API_VERSION`).

r? @diox @ashort @robhudson @cvan @mattbasta

This is a blocker for release today, so haste is appreciated!
