### PR TITLE
Don't allow other HTTP methods than POST for Abuse API (bug 945822)

### DIFF
--- a/mkt/abuse/api.py
+++ b/mkt/abuse/api.py
@@ -52,7 +52,7 @@ class AppAbuseSerializer(BaseAbuseSerializer):
 
 
 class BaseAbuseViewSet(CORSMixin, generics.CreateAPIView,
-                       viewsets.ModelViewSet):
+                       viewsets.GenericViewSet):
     cors_allowed_methods = ['post']
     throttle_classes = (AbuseThrottle,)
     throttle_scope = 'user'
@@ -61,7 +61,7 @@ class BaseAbuseViewSet(CORSMixin, generics.CreateAPIView,
                               RestAnonymousAuthentication]
     permission_classes = (AllowAny,)
 
-    def create(self, request, *a, **kw):
+    def create(self, request, *args, **kwargs):
         fail = check_potatocaptcha(request.DATA)
         if fail:
             return fail
@@ -72,7 +72,7 @@ class BaseAbuseViewSet(CORSMixin, generics.CreateAPIView,
         else:
             request.DATA['reporter'] = None
         request.DATA['ip_address'] = request.META.get('REMOTE_ADDR', '')
-        return viewsets.ModelViewSet.create(self, request, *a, **kw)
+        return super(BaseAbuseViewSet, self).create(request, *args, **kwargs)
 
     def post_save(self, obj, created=False):
         obj.send()

--- a/mkt/abuse/tests/test_resources.py
+++ b/mkt/abuse/tests/test_resources.py
@@ -81,6 +81,10 @@ class AbuseResourceTests(object):
         eq_(len(mail.outbox), 1)
         assert self.default_data['text'] in mail.outbox[0].body
 
+    def test_get(self):
+        res = self.client.get(self.list_url)
+        eq_(res.status_code, 405)
+
     def test_send(self):
         res, data = self._call()
         self._test_success(res, data)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=945822
