### PR TITLE
Follow up of 57d8ac7 : prevent duplicate params in pagination URLs (bug 945709)

### DIFF
--- a/mkt/api/paginator.py
+++ b/mkt/api/paginator.py
@@ -1,6 +1,7 @@
 import urlparse
 
 from django.http import QueryDict
+from django.utils.http import urlencode
 
 from rest_framework import serializers
 from rest_framework import pagination
@@ -20,9 +21,9 @@ class MetaSerializer(serializers.Serializer):
 
     def replace_query_params(self, url, params):
         (scheme, netloc, path, query, fragment) = urlparse.urlsplit(url)
-        query_dict = QueryDict(query).copy()
+        query_dict = QueryDict(query).dict()
         query_dict.update(params)
-        query = query_dict.urlencode()
+        query = urlencode(query_dict)
         return urlparse.urlunsplit((scheme, netloc, path, query, fragment))
 
     def get_offset_link_for_page(self, page, number):

--- a/mkt/api/tests/test_paginator.py
+++ b/mkt/api/tests/test_paginator.py
@@ -43,7 +43,7 @@ class TestMetaSerializer(TestCase):
 
         next = urlparse(serialized['next'])
         eq_(next.path, self.url)
-        eq_(QueryDict(next.query).dict(), {'limit': '3', 'offset': '3'})
+        eq_(QueryDict(next.query), QueryDict('limit=3&offset=3'))
 
     def test_third_page_of_four(self):
         data = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
@@ -58,11 +58,11 @@ class TestMetaSerializer(TestCase):
 
         prev = urlparse(serialized['previous'])
         eq_(prev.path, self.url)
-        eq_(QueryDict(prev.query).dict(), {'limit': '2', 'offset': '2'})
+        eq_(QueryDict(prev.query), QueryDict('limit=2&offset=2'))
 
         next = urlparse(serialized['next'])
         eq_(next.path, self.url)
-        eq_(QueryDict(next.query).dict(), {'limit': '2', 'offset': '6'})
+        eq_(QueryDict(next.query), QueryDict('limit=2&offset=6'))
 
     def test_fourth_page_of_four(self):
         data = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
@@ -77,7 +77,7 @@ class TestMetaSerializer(TestCase):
 
         prev = urlparse(serialized['previous'])
         eq_(prev.path, self.url)
-        eq_(QueryDict(prev.query).dict(), {'limit': '2', 'offset': '4'})
+        eq_(QueryDict(prev.query), QueryDict('limit=2&offset=4'))
 
         eq_(serialized['next'], None)
 
@@ -92,13 +92,13 @@ class TestMetaSerializer(TestCase):
 
         prev = urlparse(serialized['previous'])
         eq_(prev.path, '')
-        eq_(QueryDict(prev.query).dict(), {'limit': '2', 'offset': '0'})
+        eq_(QueryDict(prev.query), QueryDict('limit=2&offset=0'))
 
         next = urlparse(serialized['next'])
         eq_(next.path, '')
-        eq_(QueryDict(next.query).dict(), {'limit': '2', 'offset': '4'})
+        eq_(QueryDict(next.query), QueryDict('limit=2&offset=4'))
 
-    def test_wit_request_path_override_existing_params(self):
+    def test_with_request_path_override_existing_params(self):
         self.url = '/api/whatever/?limit=0&offset=xxx&extra&superfluous=yes'
         self.request = RequestFactory().get(self.url)
 
@@ -112,10 +112,10 @@ class TestMetaSerializer(TestCase):
 
         prev = urlparse(serialized['previous'])
         eq_(prev.path, '/api/whatever/')
-        eq_(QueryDict(prev.query).dict(), {'limit': '2', 'offset': '0',
-                                           'extra': '', 'superfluous': 'yes'})
+        eq_(QueryDict(prev.query),
+            QueryDict('limit=2&offset=0&extra=&superfluous=yes'))
 
         next = urlparse(serialized['next'])
         eq_(next.path, '/api/whatever/')
-        eq_(QueryDict(next.query).dict(), {'limit': '2', 'offset': '4',
-                                           'extra': '', 'superfluous': 'yes'})
+        eq_(QueryDict(next.query),
+            QueryDict('limit=2&offset=4&extra=&superfluous=yes'))


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=945709

This prevents us from returning pagination URLs like /api/v1/lol/?offset=0&offset=25 ; which work, but are ugly & scary
