### PR TITLE
update app status in content ratings pingback api (bug 945265)

### DIFF
--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -1118,6 +1118,10 @@ class IARCGetAppInfoForm(happyforms.Form):
             app.set_descriptors(row.get('descriptors', []))
             app.set_interactives(row.get('interactives', []))
 
+            # Update status if incomplete status.
+            if app.is_incomplete() and app.is_fully_complete()[0]:
+                app.update(status=amo.STATUS_PENDING)
+
         else:
             msg = _('Content rating record not found.')
             self._errors['submission_id'] = self.error_class([msg])


### PR DESCRIPTION
After couple hours looking and with little way to test locally, just gave up with the `post_save` working and am just manually updating the status in the API.

**Debugging Notes**
- ContentRating has a post_save to update the app status.
- set_content_ratings calls ContentRating.safer_get_or_create, which calls the post_save.
- calling set_content_ratings in the shell updates the app's status, for a submitted app that hasn't yet gotten content rating.
- tests on the pingback API correctly update the status
- the actual pingback API sets the content ratings, but fails to update the status
