### PR TITLE
show esrb for non-brazil s. american countries, minor ratings page fixes (bug 931948)

### DIFF
--- a/media/css/devreg/content_ratings.styl
+++ b/media/css/devreg/content_ratings.styl
@@ -183,18 +183,31 @@ $box-red = #ff2600;
     }
 }
 
-.interactive-elements .icon {
-    height: 60px;
-    width: 60px;
+.interactive-elements {
+    .names {
+        margin-bottom: 5px;
 
-    &.shares-info {
-        background-image: url('../../img/icons/ratings/interactives/ESRB_shares-info_small.png');
+        span:not(:last-child):after {
+            content: '\00B7';  // &middot;
+            display: inline-block;
+            left: 1px;
+            margin: 0 1px;
+            position: relative;
+        }
     }
-    &.shares-location {
-        background-image: url('../../img/icons/ratings/interactives/ESRB_shares-location_small.png');
-    }
-    &.users-interact {
-        background-image: url('../../img/icons/ratings/interactives/ESRB_users-interact_small.png');
+    .icon {
+        height: 60px;
+        width: 60px;
+
+        &.shares-info {
+            background-image: url('../../img/icons/ratings/interactives/ESRB_shares-info_small.png');
+        }
+        &.shares-location {
+            background-image: url('../../img/icons/ratings/interactives/ESRB_shares-location_small.png');
+        }
+        &.users-interact {
+            background-image: url('../../img/icons/ratings/interactives/ESRB_users-interact_small.png');
+        }
     }
 }
 

--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -251,7 +251,8 @@ class ESRB(RATING_BODY):
     ratings = (ESRB_E, ESRB_10, ESRB_T, ESRB_M, ESRB_A)
 
     name = 'ESRB'
-    description = _lazy(u'N. America')  # L10n: `N.` stands for North.
+    # L10n: North and South American, but not Brazil.
+    description = _lazy(u'All Americas except Brazil')
     full_name = _lazy(u'Entertainment Software Rating Board')
     url = 'http://esrb.org'
 

--- a/mkt/constants/regions.py
+++ b/mkt/constants/regions.py
@@ -102,6 +102,7 @@ class CO(REGION):
     default_currency = 'COP'
     default_language = 'es'
     mcc = 732
+    ratingsbody = ratingsbodies.ESRB
 
 
 class VE(REGION):
@@ -111,6 +112,7 @@ class VE(REGION):
     default_currency = 'USD'
     default_language = 'es'
     mcc = 734
+    ratingsbody = ratingsbodies.ESRB
 
 
 class PL(REGION):
@@ -189,6 +191,7 @@ class PE(REGION):
     default_currency = 'PEN'
     default_language = 'es'
     mcc = 716
+    ratingsbody = ratingsbodies.ESRB
 
 
 class UY(REGION):
@@ -198,6 +201,7 @@ class UY(REGION):
     default_currency = 'UYU'
     default_language = 'es'
     mcc = 748
+    ratingsbody = ratingsbodies.ESRB
 
 
 class AR(REGION):
@@ -207,6 +211,7 @@ class AR(REGION):
     default_currency = 'ARS'
     default_language = 'es'
     mcc = 722
+    ratingsbody = ratingsbodies.ESRB
 
 
 class CN(REGION):
@@ -268,6 +273,7 @@ REGION_IDS = sorted(REGIONS_CHOICES_ID_DICT.keys())[1:]
 
 GENERIC_RATING_REGION_SLUG = 'generic'
 
+
 def ALL_REGIONS_WITH_CONTENT_RATINGS():
     """Regions that have ratings bodies."""
     import waffle
@@ -278,7 +284,8 @@ def ALL_REGIONS_WITH_CONTENT_RATINGS():
     # Only require content ratings in Brazil/Germany without IARC switch.
     return [BR, DE]
 
-def ALL_REGIONS_WO_CONTENT_RATINGS():
+
+def ALL_REGIONS_WITHOUT_CONTENT_RATINGS():
     """
     Regions without ratings bodies and fallback to the GENERIC rating body.
     """

--- a/mkt/developers/templates/developers/apps/ratings/ratings_summary.html
+++ b/mkt/developers/templates/developers/apps/ratings/ratings_summary.html
@@ -36,7 +36,7 @@
               <td class="content-rating">{{ iarc_rating_icon(cr) }}</td>
               <td class="content-descriptors">
                 {% for descriptor in addon.get_descriptors(body=ratings_body.label) %}
-                  {% if ratings_body.label == 'pegi' %}
+                  {% if ratings_body.label == 'pegi' and descriptor.label != 'pegi-no-descs' %}
                     <img class="icon {{ descriptor.label }}" title="{{ descriptor.name }}">
                   {% else %}
                     <p>{{ descriptor.name }}</p>
@@ -52,7 +52,13 @@
 
       <h3>{{ _('Interactive Elements') }}</h3>
       <div class="interactive-elements c">
-        {% for interactive in addon.get_interactives() %}
+        {% set interactives = addon.get_interactives() %}
+        <div class="names">
+          {% for interactive in interactives %}
+            <span>{{ interactive.name }}</span>
+          {% endfor %}
+        </div>
+        {% for interactive in interactives %}
           <img class="icon {{ interactive.label }}" title="{{ interactive.name }}">
         {% endfor %}
       </div>

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1785,7 +1785,7 @@ class ContentRating(amo.models.ModelBase):
         generic_regions = []
         if (waffle.switch_is_active('iarc') and
             self.get_body() == mkt.ratingsbodies.GENERIC):
-            generic_regions = mkt.regions.ALL_REGIONS_WO_CONTENT_RATINGS()
+            generic_regions = mkt.regions.ALL_REGIONS_WITHOUT_CONTENT_RATINGS()
 
         return [x for x in mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS()
                 if self.get_body() == x.ratingsbody] + list(generic_regions)

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -183,7 +183,8 @@ def dehydrate_content_rating(rating, region=None):
     {body.id, rating.id} to translated {rating labels, names, descriptions}.
     """
     if (not waffle.switch_is_active('iarc') and
-        region not in ['br', 'de']):
+        region not in [_region.slug for _region in
+                       mkt.regions.ALL_REGIONS_WITH_CONTENT_RATINGS()]):
         # Ratings only enabled for Brazil and Germany before IARC work.
         # When removing this waffle switch, remove the whole `if`
         # clause.


### PR DESCRIPTION
ESRB changed their requirement to be relevant not just in USA/Canada, but S. American countries that aren't called Brazil. Include Columbia, Peru, Venezuela, Uruguay, etc in the ESRB pool.

Minor ratings pages fixes include:
- show "No Descriptors" for PEGI (instead of a black box) since there's no icon for that yet.
- show text for interactive elements rather than just context-less icons

![screen shot 2013-12-04 at 3 51 47 pm](https://f.cloud.github.com/assets/674727/1678754/13a57b0e-5d3f-11e3-8444-07975ef14637.png)
