### PR TITLE
Improve mkt.search.tests:TestApi.test_sort (bug 913019)

### DIFF
--- a/docs/api/topics/search.rst
+++ b/docs/api/topics/search.rst
@@ -60,7 +60,7 @@ Search
         curator-level access to a collection are required to do so.
     :type region: string
     :param optional sort: The fields to sort by. One or more of 'created',
-        'downloads', 'name', 'price', 'rating', or 'reviewed'. Sorts by
+        'downloads', 'name', 'rating', or 'reviewed'. Sorts by
         relevance by default.
     :type sort: string
 

--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -152,14 +152,21 @@ class TestApi(RestOAuth, ESTestCase):
         eq_(res.status_code, 400)
 
     def test_sort(self):
+        # Mocked version, to make sure we are calling ES with the parameters
+        # we want.
         with patch('mkt.webapps.models.Webapp.from_search') as mocked_search:
             mocked_qs = MagicMock()
             mocked_search.return_value = mocked_qs
-
             for api_sort, es_sort in DEFAULT_SORTING.items():
                 res = self.client.get(self.url, [('sort', api_sort)])
                 eq_(res.status_code, 200, res.content)
                 mocked_qs.order_by.assert_called_with(es_sort)
+
+        # Unmocked version, to make sure elasticsearch is actually accepting
+        # the params.
+        for api_sort, es_sort in DEFAULT_SORTING.items():
+            res = self.client.get(self.url, [('sort', api_sort)])
+            eq_(res.status_code, 200)
 
     def test_right_category(self):
         res = self.client.get(self.url, data={'cat': self.category.pk})

--- a/mkt/search/views.py
+++ b/mkt/search/views.py
@@ -13,7 +13,6 @@ DEFAULT_SORTING = {
     'created': '-created',
     'reviewed': '-reviewed',
     'name': 'name_sort',
-    'price': 'price'
 }
 
 


### PR DESCRIPTION
This test has been slow for ages, and now it's unusable on my machine, and results in "MySQL server has gone away" in jenkins.

~~From my testing, those mocks actually slow us down more than just calling ES, somehow it ends up eating a lot of memory too. Also, this hides problems with DEFAULT_SORTING, since the real calls are never made, we don't know if ES accepts those sorts params.~~

~~@robhudson what do you think? Not 100% happy with it because we don't know for sure that the sort parameter gets passed down to ES but I couldn't pinpoint the exact source of the issues with the mocks :/~~

Somehow the conversion from tastypie to DRF of the search API seems to have fixed the slowness. I changed my code to do both mocked and unmocked queries, both are useful IMHO.
