### PR TITLE
refactor the way comm notes/threads are created

### DIFF
--- a/apps/comm/models.py
+++ b/apps/comm/models.py
@@ -14,11 +14,11 @@ from mkt.constants import comm as const
 class CommunicationPermissionModel(amo.models.ModelBase):
     # Read permissions imply write permissions as well.
     read_permission_public = models.BooleanField()
-    read_permission_developer = models.BooleanField()
-    read_permission_reviewer = models.BooleanField()
-    read_permission_senior_reviewer = models.BooleanField()
-    read_permission_mozilla_contact = models.BooleanField()
-    read_permission_staff = models.BooleanField()
+    read_permission_developer = models.BooleanField(default=True)
+    read_permission_reviewer = models.BooleanField(default=True)
+    read_permission_senior_reviewer = models.BooleanField(default=True)
+    read_permission_mozilla_contact = models.BooleanField(default=True)
+    read_permission_staff = models.BooleanField(default=True)
 
     class Meta:
         abstract = True

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -151,6 +151,7 @@ class TestWebapp(amo.tests.TestCase):
         eq_(url, '/app/woo/statistics/installs-day-20120101-20120201.json')
 
     def test_get_comm_thread_url(self):
+        self.create_switch('comm-dashboard')
         app = app_factory(app_slug='putain')
         eq_(app.get_comm_thread_url(), '/comm/app/putain')
 


### PR DESCRIPTION
Split off from https://github.com/mozilla/zamboni/pull/1497

**Refactor comm utils:**
- in `create_comm_note` have actual args instead of `**kwargs`, document args
- have default permissions (notes default visible to devs, reviewers, and mozilla contacts)
