### PR TITLE
Display devices for packages apps conditionally based on waffles (bug 945733)

### DIFF
--- a/mkt/constants/platforms.py
+++ b/mkt/constants/platforms.py
@@ -26,25 +26,49 @@ APP_PLATFORMS = [
 ]
 
 
-def FREE_PLATFORMS():
-    return (
+def FREE_PLATFORMS(request=None, is_packaged=False):
+    import waffle
+    platforms = (
         ('free-firefoxos', _('Firefox OS')),
-        ('free-desktop', _('Firefox')),
-        ('free-android-mobile', _('Firefox Mobile')),
-        ('free-android-tablet', _('Firefox Tablet')),
     )
 
+    android_packaged_enabled = (request and
+        waffle.flag_is_active(request, 'android-packaged'))
+    desktop_packaged_enabled = (request and
+        waffle.flag_is_active(request, 'desktop-packaged'))
 
-def PAID_PLATFORMS(request=None):
+    if not is_packaged or (is_packaged and desktop_packaged_enabled):
+        platforms += (
+            ('free-desktop', _('Firefox')),
+        )
+
+    if not is_packaged or (is_packaged and android_packaged_enabled):
+        platforms += (
+            ('free-android-mobile', _('Firefox Mobile')),
+            ('free-android-tablet', _('Firefox Tablet')),
+        )
+
+    return platforms
+
+
+def PAID_PLATFORMS(request=None, is_packaged=False):
     import waffle
     platforms = (
         ('paid-firefoxos', _('Firefox OS')),
     )
-    if request and waffle.flag_is_active(request, 'android-payments'):
-        platforms += (
-            ('paid-android-mobile', _('Firefox Mobile')),
-            ('paid-android-tablet', _('Firefox Tablet')),
-        )
+
+    android_payments_enabled = (request and
+        waffle.flag_is_active(request, 'android-payments'))
+    android_packaged_enabled = (request and
+        waffle.flag_is_active(request, 'android-packaged'))
+
+    if android_payments_enabled :
+        if not is_packaged or (is_packaged and android_packaged_enabled):
+            platforms += (
+                ('paid-android-mobile', _('Firefox Mobile')),
+                ('paid-android-tablet', _('Firefox Tablet')),
+            )
+
     return platforms
 
 

--- a/mkt/constants/tests/test_platforms.py
+++ b/mkt/constants/tests/test_platforms.py
@@ -1,0 +1,99 @@
+from django.test.client import RequestFactory
+from nose.tools import eq_
+from tower import ugettext_lazy as _
+
+import amo.tests
+from mkt.constants.platforms import FREE_PLATFORMS, PAID_PLATFORMS
+
+
+class TestPlatforms(amo.tests.TestCase):
+
+    def test_free_platforms_default(self):
+        platforms = FREE_PLATFORMS()
+        expected = (
+            ('free-firefoxos', _('Firefox OS')),
+            ('free-desktop', _('Firefox')),
+            ('free-android-mobile', _('Firefox Mobile')),
+            ('free-android-tablet', _('Firefox Tablet')),
+        )
+        eq_(platforms, expected)
+
+    def test_free_platforms_pkg_waffle_off(self):
+        platforms = FREE_PLATFORMS(request=RequestFactory(),
+                                   is_packaged=True)
+        expected = (
+            ('free-firefoxos', _('Firefox OS')),
+        )
+        eq_(platforms, expected)
+
+    def test_free_platforms_pkg_desktop_waffle_on(self):
+        self.create_flag('desktop-packaged')
+        platforms = FREE_PLATFORMS(request=RequestFactory(),
+                                   is_packaged=True)
+        expected = (
+            ('free-firefoxos', _('Firefox OS')),
+            ('free-desktop', _('Firefox')),
+        )
+        eq_(platforms, expected)
+
+    def test_free_platforms_pkg_android_waffle_on(self):
+        self.create_flag('android-packaged')
+        platforms = FREE_PLATFORMS(request=RequestFactory(),
+                                   is_packaged=True)
+        expected = (
+            ('free-firefoxos', _('Firefox OS')),
+            ('free-android-mobile', _('Firefox Mobile')),
+            ('free-android-tablet', _('Firefox Tablet')),
+        )
+        eq_(platforms, expected)
+
+    def test_free_platforms_pkg_android_and_desktop_waffle_on(self):
+        self.create_flag('android-packaged')
+        self.create_flag('desktop-packaged')
+        platforms = FREE_PLATFORMS(request=RequestFactory(),
+                                   is_packaged=True)
+        expected = (
+            ('free-firefoxos', _('Firefox OS')),
+            ('free-desktop', _('Firefox')),
+            ('free-android-mobile', _('Firefox Mobile')),
+            ('free-android-tablet', _('Firefox Tablet')),
+        )
+        eq_(platforms, expected)
+
+    def test_paid_platforms_default(self):
+        platforms = PAID_PLATFORMS()
+        expected = (
+            ('paid-firefoxos', _('Firefox OS')),
+        )
+        eq_(platforms, expected)
+
+    def test_paid_platforms_android_payments_waffle_on(self):
+        self.create_flag('android-payments')
+        platforms = PAID_PLATFORMS(request=RequestFactory())
+        expected = (
+            ('paid-firefoxos', _('Firefox OS')),
+            ('paid-android-mobile', _('Firefox Mobile')),
+            ('paid-android-tablet', _('Firefox Tablet')),
+        )
+        eq_(platforms, expected)
+
+    def test_paid_platforms_pkg_with_android_payments_waffle_on(self):
+        self.create_flag('android-payments')
+        platforms = PAID_PLATFORMS(request=RequestFactory(),
+                                   is_packaged=True)
+        expected = (
+            ('paid-firefoxos', _('Firefox OS')),
+        )
+        eq_(platforms, expected)
+
+    def test_paid_platforms_pkg_with_android_payment_pkg_waffle_on(self):
+        self.create_flag('android-payments')
+        self.create_flag('android-packaged')
+        platforms = PAID_PLATFORMS(request=RequestFactory(),
+                                   is_packaged=True)
+        expected = (
+            ('paid-firefoxos', _('Firefox OS')),
+            ('paid-android-mobile', _('Firefox Mobile')),
+            ('paid-android-tablet', _('Firefox Tablet')),
+        )
+        eq_(platforms, expected)

--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -55,8 +55,10 @@
           <div class="free tab {{ 'active' if not is_paid }}">
             <h2 id="free-tab-header"><a href="#">{{ _('Free') }}</a></h2>
             <div class="error">{{ form.errors.free_platforms }}</div>
-            {%- for item in form.fields['free_platforms'].choices -%}
-              {{ button(form, item, can_change=not is_paid) }}
+            {% set free_platforms = form.fields['free_platforms'].choices %}
+            {% set has_multiple_free_platforms = free_platforms|length > 1 %}
+            {%- for item in free_platforms -%}
+              {{ button(form, item, can_change=has_multiple_free_platforms and not is_paid) }}
             {%- endfor %}
             {% if is_paid %}
               <div id="free-tab-save" class="update-payment-type">

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -101,16 +101,32 @@ def payments(request, addon_id, addon, webapp=False):
             return redirect(addon.get_dev_url('payments'))
 
     # TODO: refactor this (bug 945267)
+    is_packaged = addon.is_packaged
     android_payments_enabled = waffle.flag_is_active(request,
                                                      'android-payments')
+    android_packaged_enabled = waffle.flag_is_active(request,
+                                                     'android-packaged')
+    desktop_packaged_enabled = waffle.flag_is_active(request,
+                                                     'desktop-packaged')
 
     # If android payments is not allowed then firefox os must
     # be 'checked' and android-mobile and android-tablet should not be.
-    invalid_paid_platform_state = [('desktop', True)]
+    invalid_paid_platform_state = []
+
+    # If isn't packaged or it is packaged and the android-packaged flag is on
+    # then we should check that desktop isn't set to True.
+    if not is_packaged or (is_packaged and desktop_packaged_enabled):
+        invalid_paid_platform_state.append(('desktop', True))
+
     if not android_payments_enabled:
-        invalid_paid_platform_state += [('android-mobile', True),
-                                        ('android-tablet', True),
-                                        ('firefoxos', False)]
+        # When android-payments is off...
+        # If isn't packaged or it is packaged and the android-packaged flag is on
+        # then we should check for the state of android-mobile and android-tablet.
+        if not is_packaged or (is_packaged and android_packaged_enabled):
+            invalid_paid_platform_state += [('android-mobile', True),
+                                            ('android-tablet', True)]
+        invalid_paid_platform_state.append(('firefoxos', False))
+
     cannot_be_paid = (
         addon.premium_type == amo.ADDON_FREE and
         any(premium_form.device_data['free-%s' % x] == y
@@ -131,7 +147,7 @@ def payments(request, addon_id, addon, webapp=False):
 
     provider = get_provider()
     paid_platform_names = [unicode(platform[1])
-                           for platform in PAID_PLATFORMS(request)]
+                           for platform in PAID_PLATFORMS(request, is_packaged)]
 
     return jingo.render(
         request, 'developers/payments/premium.html',


### PR DESCRIPTION
This shows only relevant devices for free and paid based on the packaged flags.

@cvan r?
