### PR TITLE
improved the addon_view decorator addon.id replacement (bug 948357)

### DIFF
--- a/apps/addons/decorators.py
+++ b/apps/addons/decorators.py
@@ -21,9 +21,9 @@ def addon_view(f, qs=Addon.objects.all):
         if addon_id and addon_id.isdigit():
             addon = get(id=addon_id)
             # Don't get in an infinite loop if addon.slug.isdigit().
-            # Magically replace addon.id by its slug directly in the url.
             if addon.slug != addon_id:
-                url = request.path.replace(addon_id, addon.slug)
+                url = request.path.replace(addon_id, addon.slug, 1)
+
                 if request.GET:
                     url += '?' + request.GET.urlencode()
                 return http.HttpResponsePermanentRedirect(url)

--- a/apps/addons/tests/test_decorators.py
+++ b/apps/addons/tests/test_decorators.py
@@ -27,6 +27,13 @@ class TestAddonView(amo.tests.TestCase):
         res = self.view(self.request, str(self.addon.id))
         self.assert3xx(res, self.slug_path, 301)
 
+    def test_slug_replace_no_conflict(self):
+        self.request.path = '/addon/{id}/reviews/{id}345/path'.format(
+            id=self.addon.id)
+        res = self.view(self.request, str(self.addon.id))
+        self.assert3xx(res, '/addon/{slug}/reviews/{id}345/path'.format(
+            id=self.addon.id, slug=self.addon.slug), 301)
+
     def test_301_with_querystring(self):
         self.request.GET = mock.Mock()
         self.request.GET.urlencode.return_value = 'q=1'


### PR DESCRIPTION
See [bug 948357](https://bugzilla.mozilla.org/show_bug.cgi?id=948357)
This was originally met and fixed in [bug 944107](https://github.com/mozilla/zamboni/pull/1472) and got splitted here.
