### PR TITLE
fix done/not done logic on submit next steps page (bug 948098), create fixed message on devhub indicating next steps (bug 948656)

### DIFF
--- a/mkt/developers/templates/developers/apps/status.html
+++ b/mkt/developers/templates/developers/apps/status.html
@@ -25,23 +25,17 @@
         <div class="status-info">
           {% if addon.disabled_by_user and addon.status != amo.STATUS_DISABLED %}
             {{ status(_('You have <b>delisted</b> this app.')|safe) }}
+
           {% elif addon.status == amo.STATUS_NULL %}
-            {% if addon.is_premium() and addon.is_complete()[0] %}
-              {{ status(_('This app is <b>incomplete</b> because it is missing payment information.')) }}
-              <a href="{{ addon.get_dev_url('payments') }}">
-                {{- _('Set Up Payments') -}}
-              </a>
-            {% elif waffle.switch('iarc') and not addon.is_rated() and addon.is_complete()[0] %}
-              {{ status(_('This app is <b>incomplete</b> because it is missing content ratings.')) }}
-              <a href="{{ addon.get_dev_url('ratings') }}">
-                {{- _('Set Up Content Ratings') -}}
-              </a>
-            {% else %}
+            {# Links to complete app submission. #}
+            {% if next_step %}
               {{ status(_('This app is <b>incomplete</b>.')|safe) }}
-              <a href="{{ url('submit.app.resume', addon.app_slug) }}">
-                {{- _('Please complete your app.') -}}
-              </a>
+              {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
+              {%- trans next_url=next_step['url'], next_step_name=next_step['name'] %}
+                You must set up <a href="{{ next_url }}">{{ next_step_name }}</a> before your app can be reviewed or published.
+              {% endtrans %}
             {% endif %}
+
           {% elif addon.status == amo.STATUS_PENDING %}
             <p>{{ status(_('This app is <b>pending review</b> by a Firefox Marketplace reviewer.')|safe) }}</p>
             {{ queue_position(addon, 'p') }}

--- a/mkt/developers/templates/developers/base_impala.html
+++ b/mkt/developers/templates/developers/base_impala.html
@@ -8,6 +8,7 @@
   {% set editable = "no-edit"
      if not check_addon_ownership(request, addon, dev=True) and
         not action_allowed('Apps', 'Configure') %}
+  {% set next_step = addon.next_step() %}
 {% endif %}
 {% block bodyclass %}developer-hub{{ ' apps' if webapp }} gutter {{ editable }}{% endblock %}
 
@@ -16,6 +17,21 @@
 {% endblock %}
 
 {% block title %}{{ hub_page_title() }}{% endblock %}
+
+{% block outer_content %}
+  {% if addon and next_step %}
+    <div class="notification-box">
+      <p>
+        {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
+        {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
+          You must set up <a href="{{ next_url }}">{{ next_step_name }}</a> before your app can be reviewed or published.
+        {% endtrans %}
+      </p>
+    </div>
+  {% endif %}
+
+  {{ super() }}
+{% endblock %}
 
 {% block extrahead %}
   <noscript>

--- a/mkt/submit/templates/submit/next_steps.html
+++ b/mkt/submit/templates/submit/next_steps.html
@@ -6,12 +6,7 @@
 
 {% set payments = waffle.flag('allow-b2g-paid-submission') and addon.is_premium() %}
 {% set public = addon.is_public() %}
-
-{% set fully_complete = addon.is_fully_complete() %}
-{% set is_complete = fully_complete[0] %}
-
-{# Dict of booleans indicating why app may not be complete. #}
-{% set completeness = fully_complete[1] %}
+{% set done = addon.is_fully_complete()[1] %}
 
 {% block content %}
   {{ hub_breadcrumbs(items=[(None, _('Submit App'))]) }}
@@ -33,34 +28,21 @@
         </h2>
         <li class="done"><span>{{ _('Submit App Manifest') }}</span></li>
         <li class="done"><span>{{ _('Enter App Details') }}</span></li>
-        <li{% if completeness['content_ratings'] %} class="done"{% endif %}>
-          {%- trans url=addon.get_dev_url('ratings') %}
-            <span>Set up <a href="{{ url }}">Content Ratings</a></span>
+        <li{% if done['content_ratings'] %} class="done"{% endif %}>
+          {%- trans rating_url=addon.get_dev_url('ratings') %}
+            <span>Set up <a href="{{ rating_url }}">Content Ratings</a></span>
           {% endtrans -%}
         </li>
         {% if addon.is_premium() %}
-          <li{% if completeness['payments'] %} class="done"{% endif %}>
-            {%- trans url=addon.get_dev_url('payments') %}
-              <span>Set up <a href="{{ url }}">Payments & Countries</a></span>
+          <li{% if done['payments'] %} class="done"{% endif %}>
+            {%- trans pay_url=addon.get_dev_url('payments') %}
+              <span>Set up <a href="{{ pay_url }}">Payments</a></span>
             {% endtrans %}
           </li>
         {% endif %}
         <li{% if public or addon.is_public_waiting() %} class="done"{% endif %}><span>{{ _('Wait for Review') }}</span></li>
         <li{% if public %} class="done"{% endif %}><span>{{ _('Publish') }}</span></li>
       </ol>
-
-     {# Tell the developer what's next to do (in same order as checklist). #}
-      <p>
-        {% if not completeness['content_ratings'] %}
-          {% trans url=addon.get_dev_url('ratings') %}
-            You must set up <a href="{{ url }}">Content Ratings</a> before we can review your app.
-          {% endtrans %}
-        {% elif not completeness['payments'] %}
-          {% trans payment_url=addon.get_dev_url('payments') %}
-            You must set up <a href="{{ payment_url }}">Payments & Countries</a> before we can review your app.
-          {% endtrans %}
-        {% endif %}
-      </p>
 
       <h2>{{ _('At any point, you can') }}</h2>
       <ul class="other-options">
@@ -100,18 +82,12 @@
 
       <footer class="listing-footer">
         {% set continue_url = addon.get_dev_url('versions') %}
-        {% if not completeness['content_ratings'] %}
-          {% set continue_url = addon.get_dev_url('ratings') %}
+        {% if next_step %}
+          {% set continue_url = next_step['url'] %}
           <span>
-            {% trans %}
-              <strong>What's next:</strong> Set up Content Ratings
-            {% endtrans %}
-          </span>
-        {% elif not completeness['payments'] %}
-          {% set continue_url = addon.get_dev_url('payments') %}
-          <span>
-            {% trans %}
-              <strong>What's next:</strong> Set up Payments & Countries
+            {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
+            {%- trans next_step_name=next_step['name'] %}
+              <strong>What's next:</strong> Set up {{ next_step_name }}
             {% endtrans %}
           </span>
         {% elif addon.is_public_waiting() %}
@@ -123,6 +99,7 @@
         {% endif %}
         <a href="{{ continue_url }}" class="button prominent">{{- _('Continue') }}</a>
       </footer>
+
     </div>
   </section>
 {% endblock %}

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -440,7 +440,7 @@ class Webapp(Addon):
         """
         is_complete = True
         reasons = {
-            'details': True,
+            'details': True,  # True == complete.
             'content_ratings': True,
             'payments': True
         }
@@ -455,6 +455,28 @@ class Webapp(Addon):
             reasons['payments'] = False
 
         return is_complete, reasons
+
+    def next_step(self):
+        """
+        Gets the next step to fully complete app submission.
+        Similar to AppSubmissionChecklist, but don't need to keep state.
+        """
+        is_complete, reasons = self.is_fully_complete()
+        next_step = {}
+
+        if not reasons['details']:
+            next_step['name'] = _('Details')
+            next_step['url'] = self.get_dev_url()
+
+        elif not reasons['content_ratings']:
+            next_step['name'] = _('Content Ratings')
+            next_step['url'] = self.get_dev_url('ratings')
+
+        elif not reasons['payments']:
+            next_step['name'] = _('Payments')
+            next_step['url'] = self.get_dev_url('payments')
+
+        return next_step
 
     def is_rated(self):
         return self.content_ratings.exists()


### PR DESCRIPTION
**Notes:**
- cross out "Set Up Payments" on the checklist when it is actually done.
- when lacking Content Ratings or Payments, there will be a fixed message on top of the app's devhub page.
- `mkt.webapps.models.Webapp.is_fully_complete()` is tested which drives everything here

![screen shot 2013-12-10 at 5 43 30 pm](https://f.cloud.github.com/assets/674727/1720550/a9172794-6205-11e3-8bc2-ee3e0fd0be72.png)

![screen shot 2013-12-10 at 5 14 02 pm](https://f.cloud.github.com/assets/674727/1720562/146f512e-6206-11e3-891a-94ecb4e715fd.png)
