### PR TITLE
remove action visibility checkboxes from reviewer tools (bug 931237)

### DIFF
--- a/mkt/reviewers/forms.py
+++ b/mkt/reviewers/forms.py
@@ -55,17 +55,6 @@ class ReviewAppAttachmentForm(happyforms.Form):
 AttachmentFormSet = forms.formsets.formset_factory(ReviewAppAttachmentForm,
                                                    extra=1)
 
-# This contains default values for action visibility.
-# `disabled` will be disabled (not allowed to check).
-DEFAULT_ACTION_VISIBILITY = {
-    'escalate': {
-        'disabled': ['developer']
-    },
-    'comment': {
-        'disabled': ['developer']
-    },
-}
-
 
 class ReviewAppForm(happyforms.Form):
 
@@ -81,17 +70,6 @@ class ReviewAppForm(happyforms.Form):
         choices=[(k, v.name) for k, v in amo.DEVICE_TYPES.items()],
         coerce=int, label=_lazy(u'Device Type Override:'),
         widget=forms.CheckboxSelectMultiple, required=False)
-
-    thread_perms = [('developer', _lazy('Developers')),
-                    ('reviewer', _lazy('Reviewers')),
-                    ('senior_reviewer', _lazy('Senior Reviewers')),
-                    ('staff', _lazy('Staff')),
-                    ('mozilla_contact', _lazy('Mozilla Contact'))]
-    action_visibility = forms.TypedMultipleChoiceField(
-        choices=thread_perms,
-        coerce=unicode, label=_lazy('Action Visibility to Users:'),
-        widget=forms.CheckboxSelectMultiple, required=False)
-
     notify = forms.BooleanField(
         required=False, label=_lazy(u'Notify me the next time the manifest is '
                                     u'updated. (Subsequent updates will not '

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -285,13 +285,6 @@
         </ul>
       </div>
       {% endif %}
-      {% if waffle.switch('comm-dashboard') %}
-      <div data-default-visibility="{{ default_visibility|json }}" class="review-actions-section review-actions-options review-actions-visibility">
-        <strong>{{ _('Make this action visible to') }}</strong>
-        {{ form.action_visibility }}
-        {{ form.action_visibility.errors }}
-      </div>
-      {% endif %}
       <div class="review-actions-section">
         {{ form.notify }}
         <label for="id_notify">

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -1283,8 +1283,7 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         eq_(scores[0].note_key, reviewed_type)
 
     def test_comm_emails(self):
-        data = {'action': 'reject', 'comments': 'suxor',
-                'action_visibility': ('developer', 'reviewer', 'staff')}
+        data = {'action': 'reject', 'comments': 'suxor'}
         data.update(self._attachment_management_form(num=0))
         self.create_switch(name='comm-dashboard')
         self.post(data)

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -219,10 +219,17 @@ class ReviewApp(ReviewBase):
         self.files = self.version.files.all()
 
     def _create_comm_note(self, note_type):
+        # Permissions default to developers + reviewers + Mozilla contacts.
+        # For escalation/comment, exclude the developer from the conversation.
+        perm_overrides = {
+            comm.ESCALATION: {'developer': False},
+            comm.COMMENT: {'developer': False},
+        }
+
         self.comm_thread, self.comm_note = create_comm_note(
             self.addon, self.version, self.request.amo_user,
             self.data['comments'], note_type=note_type,
-            perms=self.data['action_visibility'])
+            perms=perm_overrides.get(note_type))
 
     def process_public(self):
         if self.addon.is_incomplete():

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -45,8 +45,7 @@ from zadmin.models import set_config, unmemoized_get_config
 
 import mkt
 from mkt.regions.utils import parse_region
-from mkt.reviewers.forms import (ApiReviewersSearchForm,
-                                 DEFAULT_ACTION_VISIBILITY)
+from mkt.reviewers.forms import ApiReviewersSearchForm
 from mkt.reviewers.utils import (AppsReviewing, clean_sort_param,
                                  device_queue_search)
 from mkt.site import messages
@@ -399,8 +398,7 @@ def _review(request, addon, version):
                   actions=actions, actions_minimal=actions_minimal,
                   tab=queue_type, product_attrs=product_attrs,
                   attachment_formset=attachment_formset,
-                  appfeatures_form=appfeatures_form,
-                  default_visibility=DEFAULT_ACTION_VISIBILITY)
+                  appfeatures_form=appfeatures_form)
 
     if features_list is not None:
         ctx['feature_list'] = features_list


### PR DESCRIPTION
**Remove action visibility checkboxes from reviewer tools**
- previously reviewers could exclude senior reviewer from conversations
- simplifies the UX by having fixed permissions for different types of reviewer actions (developers can't see escalations/reviewer comments)
