### PR TITLE
Prevent DeprecationWarnings from being raised while running API tests.

### DIFF
--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -7,6 +7,8 @@ import tempfile
 from django.core.urlresolvers import reverse
 from mock import patch
 from nose.tools import eq_
+from rest_framework.request import Request
+from test_utils import RequestFactory
 
 import amo
 from access.models import Group, GroupUser
@@ -1006,10 +1008,14 @@ class TestPriceCurrency(RestOAuth):
 class TestLargeTextField(TestCase):
     fixtures = fixture('webapp_337141')
 
+    def setUp(self):
+        self.request = Request(RequestFactory().get('/'))
+
     def test_receive(self):
         data = 'privacy policy text'
         into = {}
         field = LargeTextField(view_name='app-privacy-policy-detail')
+        field.context = {'request': self.request}
         field.field_from_native({'field_name': data}, None, 'field_name', into)
         eq_(into['field_name'], data)
 
@@ -1017,6 +1023,6 @@ class TestLargeTextField(TestCase):
         app = Webapp.objects.get(pk=337141)
         app.privacy_policy = 'privacy policy text'
         field = LargeTextField(view_name='app-privacy-policy-detail')
-        field.context = {'request': None}
+        field.context = {'request': self.request}
         url = field.field_to_native(app, None)
         self.assertApiUrlEqual(url, '/apps/app/337141/privacy/')

--- a/mkt/comm/api.py
+++ b/mkt/comm/api.py
@@ -93,7 +93,7 @@ class ThreadSerializer(ModelSerializer):
         NoteSerializer.get_request = self.get_request
         notes = (obj.notes.with_perms(self.get_request().amo_user, obj)
                           .order_by('-created')[:5])
-        return NoteSerializer(notes).data
+        return NoteSerializer(notes, many=True).data
 
     def get_notes_count(self, obj):
         return obj.notes.count()

--- a/mkt/developers/tests/test_api_payments.py
+++ b/mkt/developers/tests/test_api_payments.py
@@ -7,7 +7,7 @@ from django import forms
 from curling.lib import HttpClientError, HttpServerError
 from mock import Mock, patch
 from nose.tools import eq_, ok_
-
+from rest_framework.request import Request
 from test_utils import RequestFactory
 
 import amo
@@ -238,7 +238,9 @@ class TestSerializer(AccountCase):
     def test_serialize(self):
         # Just a smoke test that we can serialize this correctly.
         self.create()
-        res = AddonPaymentAccountSerializer(self.payment).data
+        request = Request(RequestFactory().get('/'))
+        res = AddonPaymentAccountSerializer(self.payment,
+                                            context={'request': request}).data
         eq_(res['url'], self.app_payment_detail)
 
     def test_free(self):

--- a/mkt/search/api.py
+++ b/mkt/search/api.py
@@ -128,7 +128,7 @@ class SearchView(CORSMixin, MarketplaceView, GenericAPIView):
         else:
             qs = Collection.public.all()
         qs = CollectionFilterSetWithFallback(filters, queryset=qs).qs
-        serializer = CollectionSerializer(qs[:limit],
+        serializer = CollectionSerializer(qs[:limit], many=True,
                                           context={'request': request,
                                                    'view': self})
         return serializer.data, getattr(qs, 'filter_fallback', None)


### PR DESCRIPTION
- Explicitly pass `many=True` when instantiating a serializer with an iterable
- Add `request` to the context of subclasses of hyperlinked fields when directly testing the fields' classes.
- Instantiate serializers containing hyperlinked fields with contexts containing `request` when directly testing the serializers' classes.

One `DeprecationWarning` is still raised, but I'm not touching that with a 10-foot pole:

```
apps/addons/models.py:360: DeprecationWarning: object.__new__() takes no parameters
  return super(Addon, cls).__new__(cls, *args, **kw)
```

Patches for that are welcome :wink:

r?
