### PR TITLE
don't show required step on top of detail submit step, show msg if app is public wo/ ratings (bug 949728)

### DIFF
--- a/mkt/developers/templates/developers/base_impala.html
+++ b/mkt/developers/templates/developers/base_impala.html
@@ -19,16 +19,33 @@
 {% block title %}{{ hub_page_title() }}{% endblock %}
 
 {% block outer_content %}
-  {% if addon and next_step %}
-    <div class="notification-box">
-      <p>
-        {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
-        {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
-          You must set up <a href="{{ next_url }}">{{ next_step_name }}</a> before your app can be reviewed or published.
-        {% endtrans %}
-      </p>
-    </div>
-  {% endif %}
+  {% block submit_next_step %}
+    {% if addon and next_step %}
+      <div class="notification-box">
+        <p>
+          {% if addon.is_incomplete() %}
+            {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
+            {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
+              You must set up <a href="{{ next_url }}">{{ next_step_name }}</a> before your app can be reviewed or published.
+            {% endtrans %}
+          {% elif next_step['url'] == addon.get_dev_url('ratings') %}
+            {# Pre-IARC apps. #}
+            {% if passed_iarc_app_disable_date() %}
+              {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
+              {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
+                You must set up <a href="{{ next_url }}">{{ next_step_name }}</a>.
+              {% endtrans %}
+            {% else %}
+              {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
+              {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
+                You must set up <a href="{{ next_url }}">{{ next_step_name }}</a> or else your app will be disabled on April 15th.
+              {% endtrans %}
+            {% endif %}
+          {% endif %}
+        </p>
+      </div>
+    {% endif %}
+  {% endblock %}
 
   {{ super() }}
 {% endblock %}

--- a/mkt/submit/templates/submit/details.html
+++ b/mkt/submit/templates/submit/details.html
@@ -6,6 +6,8 @@
 
 {% block title %}{{ hub_page_title(title) }}{% endblock %}
 
+{% block submit_next_step %}{% endblock %}
+
 {% set icon_status_url = addon.get_dev_url('ajax.image.status') %}
 {% set icon_upload_url = addon.get_dev_url('upload_icon') %}
 {% set screenshot_upload_url = addon.get_dev_url('upload_preview') %}


### PR DESCRIPTION
- Don't show "You need to get XXX" on top of the "Details" submission step since they're not there yet.
- If an app is public, but doesn't have ratings, display a fixed message onto of the devhub app page saying "You need to get ratings else your app might get disabled" 

![screen shot 2013-12-13 at 4 17 34 pm](https://f.cloud.github.com/assets/674727/1747262/26f673ee-6455-11e3-9fc9-f97f050d30b1.png)
