### PR TITLE
Fix missing 'user' object in installed apps API (bug 944419)

### DIFF
--- a/mkt/account/tests/test_api.py
+++ b/mkt/account/tests/test_api.py
@@ -206,6 +206,8 @@ class TestInstalled(RestOAuth):
         data = json.loads(res.content)
         eq_(data['meta']['total_count'], 1)
         eq_(data['objects'][0]['id'], ins.addon.pk)
+        eq_(data['objects'][0]['user'],
+            {'developed': False, 'purchased': False, 'installed': True})
 
     def test_installed_pagination(self):
         ins1 = Installed.objects.create(user=self.user, addon=app_factory())


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=944419

For `InstalledView`, We were re-using `AppSerializer` (yay) but without passing the necessary info (doh) because it was inside a method in `AppViewSet`. I removed the method and moved stuff to the serializer to make it easier to re-use.
