### PR TITLE
show error msg if content rating info invalid (bug 948524)

### DIFF
--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -1133,7 +1133,7 @@ class PreloadTestPlanForm(happyforms.Form):
 
 class IARCGetAppInfoForm(happyforms.Form):
     submission_id = forms.CharField()
-    security_code = forms.CharField()
+    security_code = forms.CharField(max_length=10)
 
     def clean_submission_id(self):
         submission_id = (
@@ -1163,6 +1163,14 @@ class IARCGetAppInfoForm(happyforms.Form):
 
         if data.get('rows'):
             row = data['rows'][0]
+
+            if 'submission_id' not in row:
+                # [{'ActionStatus': 'No records found. Please try another
+                #                   'criteria.', 'rowId: 1}].
+                msg = _('Invalid submission ID or security code.')
+                self._errors['submission_id'] = self.error_class([msg])
+                raise forms.ValidationError(msg)
+
             # We found a rating, so store the id and code for future use.
             app.set_iarc_info(iarc_id, iarc_code)
             app.set_content_ratings(row.get('ratings', {}))
@@ -1170,7 +1178,7 @@ class IARCGetAppInfoForm(happyforms.Form):
             app.set_interactives(row.get('interactives', []))
 
         else:
-            msg = _('Content rating record not found.')
+            msg = _('Invalid submission ID or security code.')
             self._errors['submission_id'] = self.error_class([msg])
             raise forms.ValidationError(msg)
 

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -830,8 +830,9 @@ class TestIARCGetAppInfoForm(amo.tests.WebappTestCase):
 
     @mock.patch('lib.iarc.utils.IARC_XML_Parser.parse_string')
     def test_rating_not_found(self, _mock):
-        _mock.return_value = {
-            'ActionStatus': 'No records found. Please try another criteria.'}
+        _mock.return_value = {'rows': [
+            {'ActionStatus': 'No records found. Please try another criteria.'}
+        ]}
         form = forms.IARCGetAppInfoForm({'submission_id': 1,
                                          'security_code': 'a'})
         assert form.is_valid(), form.errors


### PR DESCRIPTION
The response puts the "No records found." inside the "rows" key. The code thought if there was a "rows" key, there were ratings.

![screen shot 2013-12-13 at 1 22 36 pm](https://f.cloud.github.com/assets/674727/1746354/ac3930c2-643d-11e3-9bbe-181cd0553f4c.png)

Also set a max_length on the security_code.
