### PR TITLE
comm api create thread (bug 946459)

### DIFF
--- a/apps/comm/models.py
+++ b/apps/comm/models.py
@@ -73,7 +73,7 @@ def user_has_perm_thread(thread, profile):
     Developers of the add-on used in the thread, users in the CC list,
     and users who post to the thread are allowed to access the object.
 
-    Moreover, other object permissions are also checked agaisnt the ACLs
+    Moreover, other object permissions are also checked against the ACLs
     of the user.
     """
     user_post = CommunicationNote.objects.filter(

--- a/docs/api/topics/apps.rst
+++ b/docs/api/topics/apps.rst
@@ -344,6 +344,7 @@ App
 
    See :ref:`Creating an app <app-put-label>`
 
+.. _versions-label:
 
 Versions
 ========

--- a/docs/api/topics/comm.rst
+++ b/docs/api/topics/comm.rst
@@ -35,6 +35,27 @@ Thread
 
 .. _thread-response-label:
 
+.. http:post:: /api/v1/comm/thread/
+
+    .. note:: Requires authentication.
+
+    Create a thread from a new note for a version of an app.
+
+    **Request**
+
+    :param app: id or slug of the app to filter the threads by.
+    :type app: int|string
+    :param version: version number for the thread's :ref:`version <versions-label>` (e.g. 1.2).
+    :type version: string
+    :param note_type: a :ref:`note type label <note-type-label>`.
+    :type note_type: int
+    :param body: contents of the note.
+    :type body: string
+
+    **Response**
+
+    A :ref:`note <note-response-label>` object.
+
 .. http:get:: /api/v1/comm/thread/(int:id)/
 
     .. note:: Does not require authentication if the thread is public.
@@ -195,13 +216,11 @@ Note
 
     **Response**
 
-    A thread object, see below for example.
+    A note object, see below for example.
 
     :status 200: successfully completed.
     :status 403: not allowed to access this object.
     :status 404: not found.
-
-    Example:
 
     .. code-block:: json
 
@@ -270,11 +289,12 @@ Note
 
 .. http:post:: /api/v1/comm/thread/(int:thread_id)/note/
 
+
     .. note:: Requires authentication.
 
     **Request**
 
-    :param author: the id of the addon.
+    :param author: the id of the author.
     :type author: int
     :param thread: the id of the thread to post to.
     :type thread: int

--- a/mkt/comm/forms.py
+++ b/mkt/comm/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 
 import happyforms
-from tower import ugettext_lazy as _lazy
+from tower import ugettext as _, ugettext_lazy as _lazy
 
 from mkt.api.forms import SluggableModelChoiceField
 from mkt.constants import comm
@@ -18,3 +18,24 @@ class CreateCommNoteForm(happyforms.Form):
     note_type = forms.TypedChoiceField(
         coerce=int, choices=[(x, x) for x in comm.NOTE_TYPES],
         error_messages={'invalid_choice': _lazy(u'Invalid note type.')})
+
+
+class CreateCommThreadForm(happyforms.Form):
+    app = SluggableModelChoiceField(queryset=Webapp.objects.all(),
+                                    sluggable_to_field_name='app_slug')
+    version = forms.CharField()
+    note_type = forms.TypedChoiceField(
+        empty_value=comm.NO_ACTION,
+        choices=[(note, note) for note in comm.NOTE_TYPES], coerce=int,
+        error_messages={'invalid_choice': _lazy('Invalid note type.')})
+    body = forms.CharField(
+        error_messages={'required': _lazy('Note body is empty.')})
+
+    def clean_version(self):
+        version_num = self.cleaned_data['version']
+        versions = self.cleaned_data['app'].versions.filter(
+            version=version_num).order_by('-created')
+        if versions.exists():
+            return versions[0]
+        raise forms.ValidationError(
+            _('Version %s does not exist' % version_num))

--- a/mkt/comm/tests/test_api.py
+++ b/mkt/comm/tests/test_api.py
@@ -234,13 +234,6 @@ class TestThreadList(RestOAuth, CommTestMixin):
         eq_(res.json['objects'][0]['addon_meta']['app_slug'],
             self.addon.app_slug)
 
-    def test_creation(self):
-        version = self.addon.current_version
-        res = self.client.post(self.list_url, data=json.dumps(
-            {'addon': self.addon.id, 'version': version.id}))
-
-        eq_(res.status_code, 201)
-
     def test_app_threads(self):
         version1 = version_factory(addon=self.addon, version='7.12')
         thread1 = CommunicationThread.objects.create(
@@ -256,6 +249,20 @@ class TestThreadList(RestOAuth, CommTestMixin):
         eq_(res.json['app_threads'],
             [{"id": thread2.id, "version__version": version2.version},
              {"id": thread1.id, "version__version": version1.version}])
+
+    def test_create(self):
+        self.create_switch('comm-dashboard')
+        version_factory(addon=self.addon, version='1.1')
+        data = {
+            'app': self.addon.app_slug,
+            'version': '1.1',
+            'note_type': '0',
+            'body': 'flylikebee'
+        }
+        self.addon.addonuser_set.create(user=self.user.get_profile())
+        res = self.client.post(self.list_url, data=json.dumps(data))
+        eq_(res.status_code, 200)
+        assert self.addon.threads.count()
 
 
 class TestNote(RestOAuth, CommTestMixin):

--- a/mkt/comm/tests/test_forms.py
+++ b/mkt/comm/tests/test_forms.py
@@ -1,0 +1,34 @@
+from nose.tools import eq_
+
+import amo.tests
+
+from mkt.comm.forms import CreateCommThreadForm
+from mkt.constants import comm
+
+
+class TestCreateCommThreadForm(amo.tests.TestCase):
+
+   def setUp(self):
+       self.app = amo.tests.app_factory()
+
+   def _data(self, **kwargs):
+       data = {
+           'app': self.app.app_slug,
+           'version': self.app.current_version.version,
+           'note_type': comm.NO_ACTION,
+           'body': 'note body'
+       }
+       data.update(**kwargs)
+       return data
+
+   def test_basic(self):
+       data = self._data()
+       form = CreateCommThreadForm(data)
+       assert form.is_valid()
+       eq_(form.cleaned_data['app'], self.app)
+       eq_(form.cleaned_data['version'], self.app.current_version)
+
+   def test_version_does_not_exist(self):
+       data = self._data(version='1234.9')
+       form = CreateCommThreadForm(data)
+       assert not form.is_valid()

--- a/mkt/comm/tests/test_utils_.py
+++ b/mkt/comm/tests/test_utils_.py
@@ -76,6 +76,7 @@ class TestCreateCommNote(TestCase):
         self.create_switch('comm-dashboard')
         self.contact = user_factory(username='contact')
         self.user = user_factory()
+        self.grant_permission(self.user, '*:*')
         self.app = app_factory(mozilla_contact=self.contact.email)
 
     def test_create_thread(self):

--- a/mkt/comm/urls.py
+++ b/mkt/comm/urls.py
@@ -10,8 +10,8 @@ api_thread.register(r'thread', ThreadViewSet, base_name='comm-thread')
 api_thread.register(r'thread/(?P<thread_id>\d+)/note', NoteViewSet,
                     base_name='comm-note')
 api_thread.register(
-	r'thread/(?P<thread_id>\d+)/note/(?P<note_id>\d+)/replies', ReplyViewSet,
-	base_name='comm-note-replies')
+    r'thread/(?P<thread_id>\d+)/note/(?P<note_id>\d+)/replies', ReplyViewSet,
+    base_name='comm-note-replies')
 
 api_patterns = patterns('',
     url(r'^comm/', include(api_thread.urls)),


### PR DESCRIPTION
- override CreateModelMixin.create to use `create_comm_note` to create threads.

Blocker for https://github.com/mozilla/commbadge/pull/38
