### PR TITLE
Fix FeaturedSearchView to use ES for collections (bug 950655)

### DIFF
--- a/mkt/search/api.py
+++ b/mkt/search/api.py
@@ -120,6 +120,9 @@ class SearchView(CORSMixin, MarketplaceView, GenericAPIView):
         return _filter_search(request, qs, data, region=region,
                               profile=profile)
 
+
+class FeaturedSearchView(SearchView):
+
     def collections(self, request, collection_type=None, limit=1):
         filters = request.GET.dict()
         filters.setdefault('region', self.get_region(request).slug)
@@ -129,12 +132,8 @@ class SearchView(CORSMixin, MarketplaceView, GenericAPIView):
             qs = Collection.public.all()
         qs = CollectionFilterSetWithFallback(filters, queryset=qs).qs
         serializer = CollectionSerializer(qs[:limit], many=True,
-                                          context={'request': request,
-                                                   'view': self})
+            context={'request': request, 'view': self, 'use-es-for-apps': True})
         return serializer.data, getattr(qs, 'filter_fallback', None)
-
-
-class FeaturedSearchView(SearchView):
 
     def get(self, request, *args, **kwargs):
         serializer = self.search(request)

--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -785,8 +785,7 @@ class TestFeaturedCollections(BaseFeaturedTests):
         header = 'API-Fallback-%s' % self.prop_name
         ok_(not header in res)
 
-    @patch('mkt.collections.serializers.CollectionMembershipField.'
-           'field_to_native')
+    @patch('mkt.collections.serializers.CollectionMembershipField.to_native_es')
     def test_limit(self, mock_field_to_native):
         """
         Add a second collection, then ensure than the old one is not present
@@ -797,11 +796,13 @@ class TestFeaturedCollections(BaseFeaturedTests):
         self.col = Collection.objects.create(
             name='Me', description='Hello', collection_type=self.col_type,
             category=self.cat, is_public=True, region=mkt.regions.US.id)
-        self.col.add_app(self.app)
-        # Call standard test method.
-        self.test_added_to_results()
-        # Make sure we don't try to serialize data from collections we are
-        # not returning.
+
+        # Call standard test method that adds the app and refreshes ES.
+        self.test_apps_included()
+
+        # We are only dealing with one collection with only one app inside,
+        # our mock of the method that serializes app data from ES should only
+        # have been called once.
         eq_(mock_field_to_native.call_count, 1)
 
     @patch('mkt.search.api.SearchView.get_region')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=950655

FeaturedSearchView was no longer using ES for collections since the switch to DRF. Fixed the tests to detect this better by mocking something specific to the ES path.
