### PR TITLE
Accept an optional format in rocketfuel image URLs (bug 944109)

### DIFF
--- a/mkt/api/v1/urls.py
+++ b/mkt/api/v1/urls.py
@@ -5,7 +5,7 @@ from rest_framework.routers import SimpleRouter
 
 from mkt.abuse.urls import api_patterns as abuse_api_patterns
 from mkt.account.urls import api_patterns as account_api_patterns
-from mkt.api.base import AppRouter
+from mkt.api.base import SubRouter, SubRouterWithFormat
 from mkt.api.resources import (CarrierViewSet, CategoryViewSet,
                                error_reporter, ErrorViewSet, PriceTierViewSet,
                                PriceCurrencyViewSet, RefreshManifestViewSet,
@@ -25,8 +25,8 @@ rocketfuel = SimpleRouter()
 rocketfuel.register(r'collections', CollectionViewSet,
                     base_name='collections')
 
-subcollections = AppRouter(trailing_slash=False)
-subcollections.register('image.png', CollectionImageViewSet,
+subcollections = SubRouterWithFormat()
+subcollections.register('image', CollectionImageViewSet,
                         base_name='collection-image')
 
 apps = SimpleRouter()
@@ -36,7 +36,7 @@ apps.register(r'category', CategoryViewSet, base_name='app-category')
 apps.register(r'status', StatusViewSet, base_name='app-status')
 apps.register(r'app', AppViewSet, base_name='app')
 
-subapps = AppRouter()
+subapps = SubRouter()
 subapps.register('refresh-manifest', RefreshManifestViewSet,
                  base_name='app-refresh-manifest')
 subapps.register('privacy', PrivacyPolicyViewSet,

--- a/mkt/collections/serializers.py
+++ b/mkt/collections/serializers.py
@@ -117,6 +117,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     image = HyperlinkedRelatedOrNullField(
         source='*',
         view_name='collection-image-detail',
+        format='png',
         predicate=lambda o: o.has_image)
     carrier = SlugChoiceField(required=False, empty=None,
         choices_dict=mkt.carriers.CARRIER_MAP)

--- a/mkt/collections/tests/test_serializers.py
+++ b/mkt/collections/tests/test_serializers.py
@@ -206,8 +206,8 @@ class TestCollectionSerializer(CollectionDataMixin, amo.tests.TestCase):
         eq_(data['image'], None)
         self.collection.update(has_image=True)
         data = self.serializer.to_native(self.collection)
-        ok_(data['image'].startswith(reverse(
-            'collection-image-detail', kwargs={'pk': self.collection.id})))
+        self.assertApiUrlEqual(data['image'],
+            '/rocketfuel/collections/%s/image.png' % self.collection.pk)
 
     def test_wrong_default_language_serialization(self):
         # The following is wrong because we only accept the 'en-us' form.

--- a/mkt/collections/views.py
+++ b/mkt/collections/views.py
@@ -248,15 +248,23 @@ class CollectionViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
         return self.serialized_curators(no_cache=True)
 
 
-class CollectionImageViewSet(CORSMixin, MarketplaceView, 
-                             generics.RetrieveUpdateAPIView,
-                             generics.DestroyAPIView, viewsets.ViewSet):
+class CollectionImageViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
+                             generics.GenericAPIView, viewsets.ViewSet):
     queryset = Collection.objects.all()
     permission_classes = [CuratorAuthorization]
     authentication_classes = [RestOAuthAuthentication,
                               RestSharedSecretAuthentication,
                               RestAnonymousAuthentication]
     cors_allowed_methods = ('get', 'put', 'delete')
+
+    def perform_content_negotiation(self, request, force=False):
+        """
+        Force DRF's content negociation to not raise an error - It wants to use
+        the format passed to the URL, but we don't care since we only deal with
+        "raw" content: we don't even use the renderers.
+        """
+        return super(CollectionImageViewSet, self).perform_content_negotiation(
+            request, force=True)
 
     def retrieve(self, request, *args, **kwargs):
         obj = self.get_object()

--- a/mkt/developers/urls.py
+++ b/mkt/developers/urls.py
@@ -7,7 +7,7 @@ from lib.misc.urlconf_decorator import decorate
 
 import amo
 from amo.decorators import write
-from mkt.api.base import AppRouter
+from mkt.api.base import SubRouter
 from mkt.developers.api import ContentRatingList, ContentRatingsPingback
 from mkt.developers.api_payments import (
     AddonPaymentAccountViewSet, PaymentAccountViewSet, PaymentCheckViewSet,
@@ -179,7 +179,7 @@ api_payments.register(r'upsell', UpsellViewSet, base_name='app-upsell')
 api_payments.register(r'app', AddonPaymentAccountViewSet,
                       base_name='app-payment-account')
 
-app_payments = AppRouter()
+app_payments = SubRouter()
 app_payments.register(r'payments', PaymentViewSet, base_name='app-payments')
 app_payments.register(r'payments/status', PaymentCheckViewSet,
                       base_name='app-payments-status')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=944109

This should fix the collection image URLs be totally backwards-compatible with what we had before (rocketfuel was PUTing to `/api/v1/rocketfuel/collections/xxx/image/`) and at the same time give us nice URLs with a `.png` suffix to make the CDN happy.
