### PR TITLE
fix deleted apps in lookup tool (bug 944010)

### DIFF
--- a/apps/addons/buttons.py
+++ b/apps/addons/buttons.py
@@ -197,7 +197,7 @@ class InstallButton(object):
             self.addon.status == file.status == amo.STATUS_PUBLIC):
             url = file.latest_xpi_url()
         else:
-            url = file.get_url_path(self.src, self.addon)
+            url = file.get_url_path(self.src)
 
         if platform == amo.PLATFORM_ALL.id:
             text, os = _('Download Now'), None

--- a/apps/api/templates/api/includes/addon.xml
+++ b/apps/api/templates/api/includes/addon.xml
@@ -91,7 +91,7 @@
   {%- for file in version.all_files -%}
   <install hash="{{ file.hash }}"
     os="{{ amo.PLATFORMS[file.platform_id].api_name }}"
-    size="{{ file.size }}">{{ file.get_url_path('api', addon) }}</install>
+    size="{{ file.size }}">{{ file.get_url_path('api') }}</install>
   {% endfor -%}
   {%- endif -%}
   {%- if new_api %}
@@ -100,7 +100,7 @@
     <install hash="{{ file.hash }}" os="{{ file.platform.name }}"
              size="{{ file.size }}"
              status="{{ amo.STATUS_CHOICES[amo.STATUS_BETA] }}">
-      {{ file.get_url_path('api', addon) }}
+      {{ file.get_url_path('api') }}
     </install>
     {% endfor -%}
     {%- endif -%}

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -135,11 +135,8 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
 
         return posixpath.join(*map(smart_str, [host, addon.id, self.filename]))
 
-    def get_url_path(self, src, addon=None):
+    def get_url_path(self, src):
         from amo.helpers import urlparams, absolutify
-        # In most cases we have an addon in the calling context.
-        if not addon:
-            addon = self.version.addon
         url = os.path.join(reverse('downloads.file', args=[self.id]),
                            self.filename)
         # Firefox's Add-on Manager needs absolute urls.

--- a/mkt/lookup/tests/test_views.py
+++ b/mkt/lookup/tests/test_views.py
@@ -18,6 +18,7 @@ from nose.tools import eq_, ok_
 from slumber import exceptions
 
 import amo
+import amo.tests
 from abuse.models import AbuseReport
 from addons.cron import reindex_addons
 from addons.models import Addon, AddonUser
@@ -727,6 +728,13 @@ class TestAppSummary(AppSummaryTest):
         self._setUp()
 
     def test_app_deleted(self):
+        self.app.delete()
+        self.summary()
+
+    def test_packaged_app_deleted(self):
+        self.app.update(is_packaged=True)
+        ver = amo.tests.version_factory(addon=self.app)
+        amo.tests.file_factory(version=ver)
         self.app.delete()
         self.summary()
 


### PR DESCRIPTION
`File.models.get_url_path` had some old code that was trying to grab the addon for no reason.
