### PR TITLE
Refactors CanBeHeroAuthorization to rely on request.DATA to parse request body, rather than assuming JSON (bug 951353)

### DIFF
--- a/mkt/collections/authorization.py
+++ b/mkt/collections/authorization.py
@@ -1,5 +1,3 @@
-import json
-
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 
@@ -85,9 +83,7 @@ class CanBeHeroAuthorization(BasePermission):
         if request.method == 'POST' and 'can_be_hero' in request.POST:
             return True
         elif request.method in ('PATCH', 'POST', 'PUT'):
-            request_json = json.loads(request.body) if request.body else {}
-            return (isinstance(request_json, dict) and 'can_be_hero' in
-                request_json.keys())
+            return 'can_be_hero' in request.DATA.keys()
         return False
 
     def has_object_permission(self, request, view, obj):

--- a/mkt/collections/tests/test_authorization.py
+++ b/mkt/collections/tests/test_authorization.py
@@ -1,10 +1,12 @@
 import json
+from urllib import urlencode
 
 from django.contrib.auth.models import User
 
 from nose.tools import ok_
 from rest_framework.generics import GenericAPIView
 from rest_framework.request import Request
+from rest_framework.settings import api_settings
 
 from access.middleware import ACLMiddleware
 from amo.tests import TestCase
@@ -146,15 +148,17 @@ class TestCanBeHeroAuthorization(CollectionTestMixin, TestCase):
         return self.auth.has_object_permission(request, self.view,
                                                self.collection)
 
-    def request(self, verb, qs=None, **data):
+    def request(self, verb, qs=None, content_type='application/json',
+                encoder=json.dumps, **data):
         if not qs:
             qs = ''
         request = getattr(RequestFactory(), verb.lower())
-        request = request('/?' + qs, content_type='application/json',
-                          data=json.dumps(data) if data else '')
+        request = request('/?' + qs, content_type=content_type,
+                          data=encoder(data) if data else '')
         request.user = self.user
         ACLMiddleware().process_request(request)
-        return Request(request)
+        return Request(request, parsers=[parser_cls() for parser_cls in
+                                         api_settings.DEFAULT_PARSER_CLASSES])
 
     def test_unenforced(self):
         """
@@ -183,6 +187,18 @@ class TestCanBeHeroAuthorization(CollectionTestMixin, TestCase):
         self.give_permission()
         for verb in self.enforced_verbs:
             request = self.request(verb, can_be_hero=True)
+            ok_(self.auth.hero_field_modified(request), verb)
+
+    def test_change_permission_urlencode(self):
+        """
+        Should pass if the user is attempting to modify the can_be_hero field
+        and has the permission.
+        """
+        self.give_permission()
+        for verb in self.enforced_verbs:
+            request = self.request(verb, encoder=urlencode,
+                content_type='application/x-www-form-urlencoded',
+                can_be_hero=True)
             ok_(self.auth.hero_field_modified(request), verb)
 
     def test_no_change_no_permission(self):


### PR DESCRIPTION
r? @cvan @diox
