### PR TITLE
fix devhub user msg logic for public apps (bug 951038)

### DIFF
--- a/mkt/developers/templates/developers/base_impala.html
+++ b/mkt/developers/templates/developers/base_impala.html
@@ -30,17 +30,17 @@
             {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
               You must set up <a href="{{ next_url }}">{{ next_step_name }}</a> before your app can be reviewed or published.
             {% endtrans %}
-          {% elif next_step['url'] == addon.get_dev_url('ratings') %}
-            {# Pre-IARC apps. #}
-            {% if passed_iarc_app_disable_date() %}
-              {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
-              {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
-                You must set up <a href="{{ next_url }}">{{ next_step_name }}</a>.
-              {% endtrans %}
-            {% else %}
+          {% else %}
+            {# Pre-IARC public/pending apps. #}
+            {% if next_step['url'] == addon.get_dev_url('ratings') and not passed_iarc_app_disable_date() %}
               {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
               {% trans next_url=next_step['url'], next_step_name=next_step['name'], pretty_date=settings.IARC_APP_DISABLE_DATE|datetime %}
                 You must set up <a href="{{ next_url }}">{{ next_step_name }}</a> or else your app will be disabled on {{ pretty_date }}.
+              {% endtrans %}
+            {% else %}
+              {# L10n: `next_step_name` is a plural noun, the title of the page of the next step of the submission process (e.g. 'Payments' or 'Content Ratings'). #}
+              {% trans next_url=next_step['url'], next_step_name=next_step['name'] %}
+                You must set up <a href="{{ next_url }}">{{ next_step_name }}</a>.
               {% endtrans %}
             {% endif %}
           {% endif %}

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -492,7 +492,8 @@ class Webapp(Addon):
         """
         Gets the next step to fully complete app submission.
         """
-        if not self.details_complete():
+        if self.has_incomplete_status() and not self.details_complete():
+            # Some old public apps may have some missing detail fields.
             return {
                 'name': _('Details'),
                 'description': _('This app\'s submission process has not been '

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -782,7 +782,7 @@ class TestWebapp(amo.tests.TestCase):
         self.create_switch('iarc')
         for step in (detail_step, rating_step, pay_step):
             step.return_value = False
-        app = app_factory()
+        app = app_factory(status=amo.STATUS_NULL)
         self.make_premium(app)
         eq_(app.next_step()['url'], app.get_dev_url())
 


### PR DESCRIPTION
- some public apps were missing some `Details` fields such as `support_email`, which causes `details_complete` to throw `False`, thus showing a bad "You need to set up Details" msg for public apps.
- allow showing of non-content-rating user messages for public apps
