### PR TITLE
fix devhub ratings success msg for public apps (bug 950948)

### DIFF
--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1237,6 +1237,11 @@ class Webapp(Addon):
         for xml in xmls:
             get_iarc_client('services').Set_Storefront_Data(XMLString=xml)
 
+    def last_rated_time(self):
+        """Most recent content rating modified time or None if not rated."""
+        if self.is_rated():
+            return self.content_ratings.order_by('-modified')[0].modified
+
 
 class Trending(amo.models.ModelBase):
     addon = models.ForeignKey(Addon, related_name='trending')


### PR DESCRIPTION
Rewrite the logic for showing the success message for content ratings. 

```
Ratings can be created via IARC pinging our API.
Thus we can't display a success message via the standard POST/req/res.
To workaround, we stored app's rating's `modified` from edit page.
When hitting back to the ratings summary page, calc what msg to show.
```

There are two messages to show:
- message A (app completion): "Congrats, your app is complete and is now being reviewed."
- message B (content ratings saved): "Content ratings successfully saved."

Here are the cases on which messages to show:
1. if app's status upgrades to PENDING when going from edit -> summary page, show message A.
2. else if content ratings were updated when going from edit -> summary page, show message B.
