### PR TITLE
Bump statsd and django-statsd (bug 944245)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -37,7 +37,7 @@ django-ratelimit==0.1
 django-recaptcha-mozilla==0.0.1
 djangorestframework==2.3.9
 #django-session-csrf==0.6
-django-statsd-mozilla==0.3.8.6
+django-statsd-mozilla==0.3.10
 django-storages==1.1.8
 django-waffle==0.9.1
 easy-thumbnails==1.3
@@ -92,7 +92,7 @@ schematic==0.2
 six==1.3.0
 slumber==0.5.3
 SQLAlchemy==0.7.5
-statsd==1.0.0
+statsd==2.0.3
 suds==0.3.9
 
 ## Not on pypi.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=944245

Bumping django-statsd gives us https://github.com/andymckay/django-statsd/pull/43. The newer django-statsd wants statds 2.0.0, so bump that too.

r? @andymckay
