### PR TITLE
Stop storing URLs of icons/previews in ES, generate them at runtime (bug 952153)

### DIFF
--- a/mkt/search/api.py
+++ b/mkt/search/api.py
@@ -192,6 +192,9 @@ class SuggestionsView(SearchView):
         icons = []
 
         for obj in qs:
+            # FIXME: this does a lot of stuff we don't need. When es_app_to_dict
+            # is replaced by a Serializer, then we should replace this with a
+            # custom, lean serializer.
             base_data = self.serialize(request, obj)
             names.append(base_data['name'])
             descriptions.append(truncate(base_data['description']))

--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -888,6 +888,7 @@ class TestSuggestionsApi(ESTestCase):
         self.app1.save()
         self.app2 = app_factory(name=u'Second âpp',
                                 description=u'Second dèsc' * 25,
+                                icon_type='image/png',
                                 created=self.days_ago(3))
         self.refresh('webapp')
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=952153

Should be backwards-compatible with existing data in ES and allow us to change the CDN url at runtime.
