### PR TITLE
restored the global_series urlpatterns for json files (bug 951451)

### DIFF
--- a/apps/stats/urls.py
+++ b/apps/stats/urls.py
@@ -36,6 +36,8 @@ urls = []
 for key in keys:
     urls.append(url('^%s/$' % key, views.site_stats_report,
                 name='stats.%s' % key, kwargs={'report': key}))
+    urls.append(url(global_series[key], views.site_series,
+                    kwargs={'field': key}))
 
 urlpatterns += patterns('', *urls)
 


### PR DESCRIPTION
Restored some URL excessive deletion from [commit #fd81633d](https://github.com/mozilla/zamboni/commit/fd81633d).
See bug [#951451](https://bugzilla.mozilla.org/show_bug.cgi?id=951451)
