### PR TITLE
add tests for communication dashboard emails

### DIFF
--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -128,8 +128,14 @@ class CommunicationThread(CommunicationPermissionModel):
     class Meta:
         db_table = 'comm_threads'
 
+    def join_thread(self, user):
+        return self.thread_cc.get_or_create(user=user)
+
 
 class CommunicationThreadCC(amo.models.ModelBase):
+    """
+    Determines recipients of emails. Akin being joined on a thread.
+    """
     thread = models.ForeignKey(CommunicationThread,
                                related_name='thread_cc')
     user = models.ForeignKey('users.UserProfile',

--- a/mkt/comm/tests/test_utils_.py
+++ b/mkt/comm/tests/test_utils_.py
@@ -2,6 +2,7 @@ import os.path
 
 from django.conf import settings
 
+import mock
 from nose.tools import eq_
 
 import amo
@@ -133,6 +134,7 @@ class TestCreateCommNote(TestCase):
         eq_(reply.read_by_users.count(), 2)
         eq_(last_word.read_by_users.count(), 1)
 
+    @mock.patch('mkt.comm.utils.post_create_comm_note', new=mock.Mock)
     def test_custom_perms(self):
         thread, note = create_comm_note(
             self.app, self.app.current_version, self.user, 'escalatedquickly',


### PR DESCRIPTION
- change the way email recipients are chosen, rather than emailing to anyone who has permission, email only to   relevant people (e.g. developer, reviewers who have posted to the thread)
- in reviewer/utils.py, use communication dashboard email utility to send emails if comm-dashboard switch is on
- tests to comm emails + comments to reviewer utils
