### PR TITLE
Go through db pinning after successful shared secret auth (bug 951946)

### DIFF
--- a/mkt/api/authentication.py
+++ b/mkt/api/authentication.py
@@ -170,6 +170,8 @@ class RestSharedSecretAuthentication(BaseAuthentication):
                     request.amo_user.save()
 
                 ACLMiddleware().process_request(request)
+                request.API = True  # We can be pretty sure we are in the API.
+                APIPinningMiddleware().process_request(request)
             else:
                 log.info('Shared-secret auth token does not match')
                 return False

--- a/mkt/api/middleware.py
+++ b/mkt/api/middleware.py
@@ -50,6 +50,10 @@ class APIPinningMiddleware(PinningRouterMiddleware):
     recently.
 
     If not in the API, will fall back to the cookie pinning middleware.
+
+    Note: because the authentication process happens late when we are in the
+    API, process_request() will be manually called from authentication classes
+    when a user is successfully authenticated by one of those classes.
     """
 
     def cache_key(self, request):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=951946

We weren't pinning properly everytime when using shared secret (when you first go through the db pinning middleware, it's too early, you aren't authenticated yet, so we don't pin you) - oauth was correctly doing this already.

I've done dozens of tests locally, including creating a fake, faulty master/slave configuration and this is the only explanation for bug 951946 that I can find so far, but it's a convincing one. Let's try that on -dev and see what happens.
