### PR TITLE
send iarc unique identifier for app title (bug 950216)

### DIFF
--- a/lib/iarc/tests/test_utils_.py
+++ b/lib/iarc/tests/test_utils_.py
@@ -9,7 +9,7 @@ from nose.tools import eq_
 import amo.tests
 
 from lib.iarc.client import get_iarc_client
-from lib.iarc.utils import IARC_XML_Parser, render_xml
+from lib.iarc.utils import get_iarc_app_title, IARC_XML_Parser, render_xml
 
 from mkt.constants import ratingsbodies
 
@@ -70,6 +70,10 @@ class TestRenderSetStorefrontData(amo.tests.TestCase):
         # The client base64 encodes these. Mimic what the client does here to
         # ensure no unicode problems.
         base64.b64encode(xml.encode('utf-8'))
+
+    def test_get_iarc_app_title(self):
+        app = amo.tests.app_factory(name='fu', app_slug='bah')
+        eq_(get_iarc_app_title(app), 'fu (bah)')
 
 
 class TestRenderRatingChanges(amo.tests.TestCase):

--- a/lib/iarc/utils.py
+++ b/lib/iarc/utils.py
@@ -8,7 +8,9 @@ from rest_framework.compat import etree, six
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import JSONParser, XMLParser
 
+import amo.utils
 from amo.helpers import strip_controls
+
 from mkt.constants import ratingsbodies
 
 
@@ -31,6 +33,19 @@ def render_xml(template, context):
 
     template = env.get_template(template)
     return template.render(**context)
+
+
+def get_iarc_app_title(app):
+    """
+    Unique identifier for app to hand to IARC (e.g. 'Test App (test-app)').
+    """
+    from mkt.webapps.models import Webapp
+
+    with amo.utils.no_translation(app.default_locale):
+        delocalized_app = Webapp.objects.get(pk=app.pk)
+
+    return u'{0} ({1})'.format(unicode(delocalized_app.name),
+                               app.app_slug)
 
 
 class IARC_Parser(object):

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -35,6 +35,8 @@ from translations.models import Translation
 from users.models import UserProfile
 from versions.models import Version
 
+from lib.iarc.utils import get_iarc_app_title
+
 import mkt
 from mkt.constants import MAX_PACKAGED_APP_SIZE
 from mkt.developers import tasks
@@ -1160,7 +1162,7 @@ class TestContentRatings(amo.tests.TestCase):
         eq_(values['storefront'], '1')
         eq_(values['company'], 'Mozilla')
         eq_(values['email'], self.req.amo_user.email)
-        eq_(values['appname'], self.app.name)
+        eq_(values['appname'], get_iarc_app_title(self.app))
         eq_(values['platform'], 'Firefox')
         eq_(values['token'], self.app.iarc_token())
         eq_(values['pingbackurl'],
@@ -1175,14 +1177,16 @@ class TestContentRatings(amo.tests.TestCase):
 
         r = content_ratings_edit(self.req, app_slug=self.app.app_slug)
         doc = pq(r.content.decode('utf-8'))
-        eq_(dict(doc('#ratings-edit form')[0].form_values())['appname'],
-            u'Español')
+        eq_(u'Español' in
+            dict(doc('#ratings-edit form')[0].form_values())['appname'],
+            True)
 
         self.app.update(default_locale='en-US')
         r = content_ratings_edit(self.req, app_slug=self.app.app_slug)
         doc = pq(r.content.decode('utf-8'))
-        eq_(dict(doc('#ratings-edit form')[0].form_values())['appname'],
-            u'English')
+        eq_(u'English' in
+            dict(doc('#ratings-edit form')[0].form_values())['appname'],
+            True)
 
     def test_summary(self):
         rbs = mkt.ratingsbodies

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -42,6 +42,8 @@ from users.models import UserProfile
 from users.views import _login
 from versions.models import Version
 
+from lib.iarc.utils import get_iarc_app_title
+
 from mkt.api.models import Access, generate
 from mkt.comm.utils import create_comm_note
 from mkt.constants import comm
@@ -359,9 +361,6 @@ def content_ratings_edit(request, addon_id, addon):
         except django_forms.ValidationError:
             pass  # Fall through to show the form error.
 
-    with amo.utils.no_translation(addon.default_locale):
-        addon_delocalized = Addon.objects.get(pk=addon.pk)
-
     # Save some information for _ratings_success_msg.
     if not 'ratings_edit' in request.session:
         request.session['ratings_edit'] = {}
@@ -374,7 +373,7 @@ def content_ratings_edit(request, addon_id, addon):
     return jingo.render(
         request, 'developers/apps/ratings/ratings_edit.html', {
             'addon': addon,
-            'app_name': addon_delocalized.name,
+            'app_name': get_iarc_app_title(addon),
             'form': form,
             'now': datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         })

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -7,7 +7,6 @@ import shutil
 import unittest
 import uuid
 import zipfile
-from collections import defaultdict
 from datetime import datetime, timedelta
 
 from django.conf import settings
@@ -610,7 +609,7 @@ class TestWebapp(amo.tests.TestCase):
     def test_set_iarc_storefront_data(self, render_mock, storefront_mock):
         # Set up ratings/descriptors/interactives.
         self.create_switch('iarc')
-        app = app_factory(name='LOL')
+        app = app_factory(name='LOL', app_slug='ha')
         app.set_iarc_info(submission_id='1234', security_code='sektor')
         app.set_descriptors(['has_esrb_blood', 'has_pegi_scary'])
         app.set_interactives(['has_users_interact', 'has_shares_info'])
@@ -632,7 +631,7 @@ class TestWebapp(amo.tests.TestCase):
         eq_(data['submission_id'], 1234)
         eq_(data['security_code'], 'sektor')
         eq_(data['rating'], 'Adults Only')
-        eq_(data['title'], 'LOL')
+        eq_(data['title'], 'LOL (ha)')
         eq_(data['rating_system'], 'ESRB')
         eq_(data['descriptors'], 'Blood')
         self.assertSetEqual(data['interactive_elements'].split(', '),
@@ -643,7 +642,7 @@ class TestWebapp(amo.tests.TestCase):
         eq_(data['submission_id'], 1234)
         eq_(data['security_code'], 'sektor')
         eq_(data['rating'], '3+')
-        eq_(data['title'], 'LOL')
+        eq_(data['title'], 'LOL (ha)')
         eq_(data['rating_system'], 'PEGI')
         eq_(data['descriptors'], 'Fear')
 
@@ -816,6 +815,7 @@ class TestWebapp(amo.tests.TestCase):
 
         pay_step.return_value = True
         assert not app.next_step()
+
 
 class DeletedAppTests(amo.tests.ESTestCase):
 


### PR DESCRIPTION
**Problem**
- Sending IARC the app's title for the `title` parameter in `set_storefront_data` and IARC form.

**Solution**
- Create a Webapp helper function to create a unique title by tacking on the app slug.
