### PR TITLE
optimize content ratings in app resource (bug 948192)

### DIFF
--- a/docs/api/topics/apps.rst
+++ b/docs/api/topics/apps.rst
@@ -58,17 +58,28 @@ App
             ],
             "content_ratings": {
                 "ratings": {
-                    "en": {"body": "ESRB", "body_label": "esrb", "rating": "Teen", "rating_label": "13", "description": "Not recommended..."},
-                    "generic": {"body": "Generic", "body_label": "generic", "rating": "For ages 13+", "rating_label": "13", "description": "Not recommended..."}
+                    "esrb": {"body": "ESRB", "body_label": "esrb", "rating": "Teen", "rating_label": "13", "description": "Not recommended for users younger than 13."},
+                    "classind": {"body": "CLASSIND", "body_label": "classind", "rating": "For ages 14+", "rating_label": "14", "description": "Not recommended for users younger than 14."},
+                    "pegi": {"body": "PEGI", "body_label": "pegi", "rating": "For ages 12+", "rating_label": "12", "description": "Not recommended for users younger than 12."},
+                    "usk": {"body": "USK", "body_label": "usk", "rating": "For ages 16+", "rating_label": "16", "description": "Not recommended for users younger than 16."},
+                    "generic": {"body": "Generic", "body_label": "generic", "rating": "For ages 13+", "rating_label": "13", "description": "Not recommended for users younger than 13."}
                 },
-                "descriptors": [
+                "descriptors": {
                     "esrb": [{"label": "esrb-scary", "name": "Scary Themes"}],
                     "generic": [{"label": "generic-scary", "name": "Fear"}]
-                ],
+                },
                 "interactive_elements": [
                     {"label": "users-interact", "name": "Users Interact"},
                     {"label": "shares-location", "name": "Shares Location"},
                 ]
+                "regions": {
+                    "us": "esrb",
+                    "mx": "esrb",
+                    "br": "classind",
+                    "es": "pegi",
+                    "it": "pegi",
+                    "de": "usk"
+                }
             },
             "created": "2013-09-17T13:19:16",
             "current_version": "1.1",
@@ -169,11 +180,10 @@ App
     :type categories: array
     :param content_ratings: International Age Rating Coalition (IARC) content
         ratings data. It has three parts, ``ratings``, ``descriptors``, and
-        ``interactive_elements``
+        ``interactive_elements``. If a region is detected, only a subset
+        of data will be returned.
     :type content_ratings: object
-    :param content_ratings.ratings: Content ratings associated with the app by
-        region. Apps that do not fall into all of the specific regions uses the
-        rating keyed under "generic".
+    :param content_ratings.ratings: Content ratings associated with the app.
     :type content_ratings.ratings: object
     :param content_ratings.descriptors: IARC content descriptors, flags about
         the app that might affect its suitability for younger-aged users.
@@ -181,7 +191,12 @@ App
     :param content_ratings.interactive_elements: IARC interactive elements,
         aspects about the app relating to whether the app shares info or
         interacts with external elements.
-    :type content_ratings: array
+    :type content_ratings.interactive_elements: array
+    :param content_ratings.regions: The mapping of region slugs to their
+        respective and assigned IARC ratings bodies. Regions that do not fall
+        under any of the listed regions uses the "generic" content rating in
+        content_ratings.ratings.
+    :type content_ratings.interactive_elements: array
     :param created: The date the app was added to the Marketplace, in ISO 8601
         format.
     :type created: string

--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -353,14 +353,21 @@ def RATINGS_BY_NAME():
     return ratings_choices
 
 
+def slugify_iarc_name(obj):
+    """
+    Converts ratings body's or rating's iarc_name to a slug-like label
+    (e.g. "USK" to "usk").
+    """
+    return obj.iarc_name.lower().replace(' ', '-')
+
+
 def dehydrate_rating(rating):
     """
     Returns a rating with translated fields attached and with fields that are
     easily created dynamically.
     """
     if rating.label is None:
-        rating.label = (str(rating.age) or
-                        rating.iarc_name.lower().replace(' ', '-'))
+        rating.label = str(rating.age) or slugify_iarc_name(rating)
     if rating.name is None:
         if rating.age == 0:
             rating.name = unicode(NAME_GENERAL)
@@ -380,7 +387,7 @@ def dehydrate_rating(rating):
 def dehydrate_ratings_body(body):
     """Returns a rating body with translated fields attached."""
     if body.label is None:
-        body.label = body.iarc_name.lower().replace(' ', '-')
+        body.label = slugify_iarc_name(body)
 
     body.name = unicode(body.name)
     body.description = unicode(body.description)

--- a/mkt/constants/regions.py
+++ b/mkt/constants/regions.py
@@ -4,6 +4,7 @@ import sys
 from tower import ugettext_lazy as _lazy
 
 from mkt.constants import ratingsbodies
+from mkt.constants.ratingsbodies import slugify_iarc_name
 
 
 class REGION(object):
@@ -289,3 +290,29 @@ def ALL_REGIONS_WITHOUT_CONTENT_RATINGS():
     Regions without ratings bodies and fallback to the GENERIC rating body.
     """
     return set(ALL_REGIONS) - set(ALL_REGIONS_WITH_CONTENT_RATINGS())
+
+
+def REGION_TO_RATINGS_BODY():
+    """
+    Return a map of region slugs to ratings body labels for use in
+    serializers and to send to Fireplace.
+
+    e.g. {'us': 'esrb', 'mx': 'esrb', 'es': 'pegi', 'br': 'classind'}.
+    """
+    import waffle
+
+    # Create the mapping.
+    region_to_bodies = {}
+    for region in ALL_REGIONS_WITH_CONTENT_RATINGS():
+        ratings_body_label = GENERIC_RATING_REGION_SLUG
+        if region.ratingsbody:
+            ratings_body_label = slugify_iarc_name(region.ratingsbody)
+        region_to_bodies[region.slug] = ratings_body_label
+
+    # Resolve edge cases related to switches.
+    if not waffle.switch_is_active('iarc'):
+        region_to_bodies.update({
+            'de': GENERIC_RATING_REGION_SLUG
+        })
+
+    return region_to_bodies

--- a/mkt/constants/tests/test_regions.py
+++ b/mkt/constants/tests/test_regions.py
@@ -1,0 +1,22 @@
+from nose.tools import eq_
+
+import amo.tests
+
+import mkt.constants.regions as regions
+
+
+class TestRegionContentRatings(amo.tests.TestCase):
+
+    def test_region_to_ratings_body(self):
+        region_to_body = regions.REGION_TO_RATINGS_BODY()
+        eq_(len(region_to_body), 2)
+        eq_(region_to_body['br'], 'classind')
+        eq_(region_to_body['de'], 'generic')
+
+    def test_region_to_ratings_body_switch(self):
+        self.create_switch('iarc')
+        region_to_body = regions.REGION_TO_RATINGS_BODY()
+        eq_(region_to_body['br'], 'classind')
+        eq_(region_to_body['es'], 'pegi')
+        eq_(region_to_body['de'], 'usk')
+        eq_(region_to_body['us'], 'esrb')


### PR DESCRIPTION
Rather than having in the app resource:

```
'ratings': {
    'us': <ESRB_RATING>,
    've': <ESRB_RATING>,
    'mx': <ESRB_RATING>,
    'sp': <PEGI_RATING>,
    'it': <PEGI_RATING>
}
```

Remove redundancy and refactor to:

```
'content_ratings': {
    'regions': {
        'us': 'esrb',
        've': 'esrb',
        'mx': 'esrb',
        'sp': 'pegi',
        'it': 'pegi',
        ...  
    },
    'ratings': {
        'esrb': <ESRB_RATING>,
        'pegi': <PEGI_RATING>,
        'generic': <GENERIC_RATING> 
    }
}
```

Greatly reducing the size of the app resource to Fireplace.

Fireplace/Flue being updated.
