### PR TITLE
fix iarc form company parameter to point at developer (bug 956850)

### DIFF
--- a/lib/iarc/tests/test_utils_.py
+++ b/lib/iarc/tests/test_utils_.py
@@ -9,7 +9,7 @@ from nose.tools import eq_
 import amo.tests
 
 from lib.iarc.client import get_iarc_client
-from lib.iarc.utils import get_iarc_app_title, IARC_XML_Parser, render_xml
+from lib.iarc.utils import IARC_XML_Parser, render_xml
 
 from mkt.constants import ratingsbodies
 
@@ -27,7 +27,6 @@ class TestRenderAppInfo(amo.tests.TestCase):
         assert '<FIELD NAME="password" VALUE="s3kr3t"' in xml
         assert '<FIELD NAME="submission_id" VALUE="100"' in xml
         assert '<FIELD NAME="security_code" VALUE="AB12CD3"' in xml
-        assert '<FIELD NAME="company" VALUE="Mozilla"' in xml
         assert '<FIELD NAME="platform" VALUE="Firefox"' in xml
         # If these aren't specified in the context they aren't included.
         assert not '<FIELD NAME="title"' in xml
@@ -39,7 +38,6 @@ class TestRenderSetStorefrontData(amo.tests.TestCase):
         self.template = 'set_storefront_data.xml'
 
     @override_settings(IARC_PASSWORD='s3kr3t',
-                       IARC_COMPANY='Mozilla',
                        IARC_PLATFORM='Firefox')
     def test_render(self):
         xml = render_xml(self.template, {
@@ -48,12 +46,13 @@ class TestRenderSetStorefrontData(amo.tests.TestCase):
             'rating_system': 'PEGI',
             'release_date': datetime.date(2013, 11, 1),
             'title': 'Twitter',
+            'company': 'Test User',
             'rating': '16+',
             'descriptors': u'N\xc3\xa3o h\xc3\xa1 inadequa\xc3\xa7\xc3\xb5es',
             'interactive_elements': 'users interact'})
         assert xml.startswith('<?xml version="1.0" encoding="utf-8"?>')
         assert '<FIELD NAME="password" VALUE="s3kr3t"' in xml
-        assert '<FIELD NAME="storefront_company" VALUE="Mozilla"' in xml
+        assert '<FIELD NAME="storefront_company" VALUE="Test User"' in xml
         assert '<FIELD NAME="platform" VALUE="Firefox"' in xml
         assert '<FIELD NAME="submission_id" VALUE="100"' in xml
         assert '<FIELD NAME="security_code" VALUE="AB12CD3"' in xml
@@ -70,10 +69,6 @@ class TestRenderSetStorefrontData(amo.tests.TestCase):
         # The client base64 encodes these. Mimic what the client does here to
         # ensure no unicode problems.
         base64.b64encode(xml.encode('utf-8'))
-
-    def test_get_iarc_app_title(self):
-        app = amo.tests.app_factory(name='fu', app_slug='bah')
-        eq_(get_iarc_app_title(app), 'fu (bah)')
 
 
 class TestRenderRatingChanges(amo.tests.TestCase):

--- a/lib/iarc/utils.py
+++ b/lib/iarc/utils.py
@@ -28,7 +28,6 @@ def render_xml(template, context):
     """
     # All XML passed requires a password. Let's add it to the context.
     context['password'] = settings.IARC_PASSWORD
-    context['company'] = settings.IARC_COMPANY
     context['platform'] = settings.IARC_PLATFORM
 
     template = env.get_template(template)
@@ -36,16 +35,13 @@ def render_xml(template, context):
 
 
 def get_iarc_app_title(app):
-    """
-    Unique identifier for app to hand to IARC (e.g. 'Test App (test-app)').
-    """
+    """Delocalized app name."""
     from mkt.webapps.models import Webapp
 
     with amo.utils.no_translation(app.default_locale):
         delocalized_app = Webapp.objects.get(pk=app.pk)
 
-    return u'{0} ({1})'.format(unicode(delocalized_app.name),
-                               app.app_slug)
+    return unicode(delocalized_app.name)
 
 
 class IARC_Parser(object):

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1603,7 +1603,6 @@ AES_KEYS = {
 }
 
 # IARC content ratings.
-IARC_COMPANY = 'Mozilla'
 IARC_ENV = 'test'
 IARC_MOCK = False
 IARC_PASSWORD = ''

--- a/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
+++ b/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
@@ -52,8 +52,16 @@
           {% endtrans %}
         </p>
         <form id="iarc" method="post" action="{{ settings.IARC_SUBMISSION_ENDPOINT }}" target="IARCForm">
-          <input type="hidden" name="email" value="{{ request.amo_user.email }}">
-          <input type="hidden" name="company" value="{{ settings.IARC_COMPANY }}">
+          {% set company_email = request.amo_user.email %}
+          {% set company_name = request.amo_user.display_name %}
+          {# Try to be consistent when passing email/company to IARC form by defaulting to first app author. #}
+          {% set authors = addon.authors.all() %}
+          {% if authors.exists() %}
+            {% set company_email = authors[0].email %}
+            {% set company_name = authors[0].display_name %}
+          {% endif %}
+          <input type="hidden" name="email" value="{{ company_email }}">
+          <input type="hidden" name="company" value="{{ company_name }}">
           <input type="hidden" name="appname" value="{{ app_name }}">
           <input type="hidden" name="platform" value="{{ settings.IARC_PLATFORM }}">
           <input type="hidden" name="storefront" value="{{ settings.IARC_STOREFRONT_ID }}">

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -1147,9 +1147,13 @@ class TestContentRatings(amo.tests.TestCase):
         self.req.session = mock.MagicMock()
 
     @override_settings(IARC_SUBMISSION_ENDPOINT='https://yo.lo',
-                       IARC_STOREFRONT_ID=1, IARC_COMPANY='Mozilla',
-                       IARC_PLATFORM='Firefox', IARC_PASSWORD='s3kr3t')
+                       IARC_STOREFRONT_ID=1, IARC_PLATFORM='Firefox',
+                       IARC_PASSWORD='s3kr3t')
     def test_edit(self):
+        author = self.app.authors.all()[0]
+        # Update to get rid of weird unicode display_name.
+        author.update(display_name='luthor', email='lex@lexcorp.com')
+
         r = content_ratings_edit(self.req, app_slug=self.app.app_slug)
         doc = pq(r.content)
 
@@ -1160,8 +1164,8 @@ class TestContentRatings(amo.tests.TestCase):
         # Check the hidden form values.
         values = dict(form.form_values())
         eq_(values['storefront'], '1')
-        eq_(values['company'], 'Mozilla')
-        eq_(values['email'], self.req.amo_user.email)
+        eq_(values['company'], author.display_name)
+        eq_(values['email'], author.email)
         eq_(values['appname'], get_iarc_app_title(self.app))
         eq_(values['platform'], 'Firefox')
         eq_(values['token'], self.app.iarc_token())

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1212,6 +1212,7 @@ class Webapp(Addon):
             # App wasn't rated by IARC, return.
             return
 
+        authors = self.authors.all()
         xmls = []
         for cr in self.content_ratings.all():
             xmls.append(render_xml('set_storefront_data.xml', {
@@ -1220,6 +1221,7 @@ class Webapp(Addon):
                 'rating_system': cr.get_body().iarc_name,
                 'release_date': datetime.date.today() if not disable else '',
                 'title': get_iarc_app_title(self),
+                'company': authors[0].display_name if authors.exists() else '',
                 'rating': cr.get_rating().iarc_name,
                 'descriptors': self.rating_descriptors.iarc_deserialize(
                     body=cr.get_body()),

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -629,7 +629,7 @@ class TestWebapp(amo.tests.TestCase):
         eq_(data['submission_id'], 1234)
         eq_(data['security_code'], 'sektor')
         eq_(data['rating'], 'Adults Only')
-        eq_(data['title'], 'LOL (ha)')
+        eq_(data['title'], 'LOL')
         eq_(data['rating_system'], 'ESRB')
         eq_(data['descriptors'], 'Blood')
         self.assertSetEqual(data['interactive_elements'].split(', '),
@@ -640,7 +640,7 @@ class TestWebapp(amo.tests.TestCase):
         eq_(data['submission_id'], 1234)
         eq_(data['security_code'], 'sektor')
         eq_(data['rating'], '3+')
-        eq_(data['title'], 'LOL (ha)')
+        eq_(data['title'], 'LOL')
         eq_(data['rating_system'], 'PEGI')
         eq_(data['descriptors'], 'Fear')
 

--- a/sites/dev/settings_mkt.py
+++ b/sites/dev/settings_mkt.py
@@ -208,7 +208,6 @@ POSTFIX_DOMAIN = 'marketplace-dev.allizom.org'
 MONOLITH_INDEX = 'mktdev-time_*'
 
 # IARC content ratings.
-IARC_COMPANY = 'Mozilla'
 IARC_ENV = 'prod'
 IARC_MOCK = False
 IARC_PASSWORD = private_mkt.IARC_PASSWORD

--- a/sites/stage/settings_mkt.py
+++ b/sites/stage/settings_mkt.py
@@ -185,7 +185,6 @@ BANGO_BASE_PORTAL_URL = 'https://mozilla.bango.com/login/al.aspx?'
 MONOLITH_INDEX = 'mktstage-time_*'
 
 # IARC content ratings.
-IARC_COMPANY = 'Mozilla'
 IARC_ENV = 'prod'
 IARC_MOCK = False
 IARC_PASSWORD = private_mkt.IARC_PASSWORD


### PR DESCRIPTION
IARC_COMPANY was a constant being set to 'Mozilla'.

Based on the technical requirements, it should be set to the developer's "company name", which I decided to be `display_name`.
