### PR TITLE
only load paypal objects when needed (bug 755563)

### DIFF
--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -2,7 +2,9 @@
 {% set is_author = request.check_ownership(addon, require_owner=False) %}
 
 {% block title %}{{ page_title(addon.name) }}{% endblock %}
-{% block js %}{% include("amo/recaptcha_js.html") %}{% endblock %}
+{% block js %}{% include("amo/recaptcha_js.html") %}
+    <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
+{% endblock %}
 {% block bodyclass %}gutter addon-details {{ super() }}{% endblock %}
 
 {% block extrahead %}

--- a/apps/addons/templates/addons/impala/developers.html
+++ b/apps/addons/templates/addons/impala/developers.html
@@ -1,5 +1,9 @@
 {% extends "impala/base_shared.html" %}
 
+{% block js %}
+    <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
+{% endblock %}
+
 {% if page == 'installed' %}
   {# L10n: {0} is an add-on name. #}
   {% set title = _('Thank you for installing {0}')|f(addon.name) %}

--- a/apps/editors/templates/editors/review.html
+++ b/apps/editors/templates/editors/review.html
@@ -1,5 +1,9 @@
 {% extends "editors/base.html" %}
 
+{% block js %}
+    <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
+{% endblock %}
+
 {% block title %}
   {{ editor_page_title(title=addon.name) }}
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -148,7 +148,6 @@
         <script src="{{ static(url('jsi18n')) }}"></script>
         {{ js('common') }}
         <script async defer src="{{ static(url('addons.buttons.js')) }}"></script>
-        <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
       {% endblock %}
       {% block tabzilla_js %}
         <script src="//mozorg.cdn.mozilla.net/{{ LANG }}/tabzilla/tabzilla.js"></script>

--- a/templates/impala/base.html
+++ b/templates/impala/base.html
@@ -230,7 +230,6 @@
       {% endif %}
       {{ js('impala') }}
       <script async defer src="{{ static(url('addons.buttons.js')) }}"></script>
-      <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
     {% endblock %}
     {% block tabzilla_js %}
       <script src="//mozorg.cdn.mozilla.net/{{ LANG }}/tabzilla/tabzilla.js"></script>


### PR DESCRIPTION
Is it possible to make paypal payments anywhere else than on the addon detail page?
Are the PayPal objects needed anywhere else?

This is a very naive fix, please let me know if I'm missing anything.
