### PR TITLE
Remove click-through EULA on install buttons (bug 743829)

### DIFF
--- a/apps/addons/templates/addons/button.html
+++ b/apps/addons/templates/addons/button.html
@@ -63,7 +63,7 @@
           {{ link.text }}
           {% if link.os %}
             <span class="os" data-os="{{ link.os.name }}">
-              {% if not (b.show_eula or b.show_contrib) %}
+              {% if not b.show_contrib %}
                 {# L10n: {0} is a platform name like Windows or Mac OS X. #}
                 {{ _('for {0}')|f(link.os.name) }}
               {% endif %}
@@ -82,6 +82,12 @@
   {% if addon.privacy_policy %}
     <a class="privacy-policy" href="{{ url('addons.privacy', addon.slug) }}">
       <strong>{{ _('View privacy policy') }}</strong>
+    </a>
+  {% endif %}
+  {% if addon.eula %}
+    <a class="eula" href="{{ url('addons.eula', addon.slug) }}">
+      {# L10n: EULA stands for End-User License Agreement. #}
+      <strong>{{ _('View EULA') }}</strong>
     </a>
   {% endif %}
 

--- a/apps/addons/templates/addons/eula.html
+++ b/apps/addons/templates/addons/eula.html
@@ -29,7 +29,7 @@
     <div class="policy-statement">{{ addon.eula|nl2br }}</div>
     <div class="policy-install">
       {{ install_button(addon, version=version, show_contrib=False,
-                        show_eula=False, show_warning=False, impala=True) }}
+                        show_warning=False, impala=True) }}
     </div>
     <p class="policy-back">
       <a href="{{ detail_url }}">{{ _('Back to {0}…')|f(addon.name) }}</a>

--- a/apps/addons/templates/addons/impala/button.html
+++ b/apps/addons/templates/addons/impala/button.html
@@ -45,6 +45,11 @@
       {{ _('Privacy Policy') }}
     </a>
   {% endif %}
+  {% if addon.eula %}
+    <a class="eula badge" href="{{ url('addons.eula', addon.slug) }}">
+      {{ _('EULA') }}
+    </a>
+  {% endif %}
 
   {% if addon.is_unreviewed() %}
     <p class="warning">

--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -323,6 +323,15 @@
       </div>
     </div>
   {% endif %}
+  {% if addon.eula %}
+    <div class="modal" id="eula">
+      <a href="#" class="close">{{ _('close') }}</a>
+      <h2>{{ _('End-User License Agreement') }}</h2>
+      <div class="prose">
+        {{ addon.eula|nl2br }}
+      </div>
+    </div>
+  {% endif %}
   {% if review_form and request.user.is_authenticated() %}
       {{ impala_review_add_box(addon=addon) }}
   {% endif %}

--- a/apps/addons/templates/addons/includes/install_button.html
+++ b/apps/addons/templates/addons/includes/install_button.html
@@ -5,9 +5,6 @@
   {% if b.show_warning and not addon.is_webapp() %}
     href="{{ b.addon.get_url_path() }}"
     data-realurl="{{ link.url }}"
-  {% elif b.show_eula and not addon.is_webapp() and request.MOBILE %}
-    href="{{ link.url|absolutify }}"
-    data-realurl="{{ b.xpiurl }}"
   {% else %}
     href="{{ link.url }}"
   {% endif %}>
@@ -27,7 +24,7 @@
       {{ link.text }}
       {% if link.os %}
         <span class="os" data-os="{{ link.os.name }}">
-          {% if not (b.show_eula or b.show_contrib) %}
+          {% if not b.show_contrib %}
             {# L10n: {0} is a platform name like Windows or Mac OS X. #}
             {{ _('for {0}')|f(link.os.name) }}
           {% endif %}

--- a/apps/addons/templates/addons/mobile/button.html
+++ b/apps/addons/templates/addons/mobile/button.html
@@ -28,5 +28,11 @@
       {{ _('View privacy policy') }}
     </a>
   {% endif %}
+  {% if addon.eula %}
+    <a class="eula" href="{{ url('addons.eula', addon.slug) }}">
+      {# L10n: EULA stands for End-User License Agreement. #}
+      {{ _('View EULA') }}
+    </a>
+  {% endif %}
 </div> {# install #}
 

--- a/apps/discovery/templates/discovery/addons/detail.html
+++ b/apps/discovery/templates/discovery/addons/detail.html
@@ -15,15 +15,8 @@
 
 <ul id="install">
   <li class="install-action">
-    {% if addon.has_eula %}
-      <a href="{{ services_url('discovery.addons.eula', addon.slug, src=src) }}"
-         class="button eula go">
-         {# L10n: please keep &nbsp; in the string so the &rarr; does not wrap #}
-         {{ _('Continue to Download&nbsp;&rarr;')|safe }}</a>
-    {% else %}
-      {{ install_button(addon, show_contrib=False, show_warning=True,
-                        detailed=True) }}
-    {% endif %}
+    {{ install_button(addon, show_contrib=False, show_warning=True,
+                      detailed=False) }}
   </li>
   <li><a href="{{ url('addons.detail', addon.slug, src='discovery-learnmore') }}"
          id="learn-more" class="button">{{ _('Learn More') }}</a></li>
@@ -35,6 +28,10 @@
   {% if addon.privacy_policy %}
     <li class="privacy"><a href="{{ url('addons.privacy', addon.slug, src='discovery-learnmore') }}">
       {{ _('View Privacy Policy') }}</a></li>
+  {% endif %}
+  {% if addon.eula %}
+    <li class="eula"><a href="{{ url('addons.eula', addon.slug, src='discovery-learnmore') }}">
+      {{ _('View EULA') }}</a></li>
   {% endif %}
 </ul>
 

--- a/apps/discovery/templates/discovery/addons/eula.html
+++ b/apps/discovery/templates/discovery/addons/eula.html
@@ -21,7 +21,7 @@
 <ul id="install" class="install-action">
   <li>
     {{ install_button(addon, version=version, show_contrib=False,
-                      show_eula=False, show_warning=False) }}
+                      show_warning=False) }}
   </li>
   <li><a href="{{ services_url('discovery.addons.detail', addon.slug, src=src) }}" class="button">
     {{ _('Cancel Installation') }}</a></li>

--- a/apps/discovery/tests/test_views.py
+++ b/apps/discovery/tests/test_views.py
@@ -412,9 +412,10 @@ class TestDetails(amo.tests.TestCase):
 
     def test_install_button_eula(self):
         doc = pq(self.client.get(self.detail_url).content)
-        assert doc('#install .eula').text().startswith('Continue to Download')
+        eq_(doc('#install .install-button').text(), 'Download Now')
+        eq_(doc('#install .eula').text(), 'View EULA')
         doc = pq(self.client.get(self.eula_url).content)
-        eq_(doc('#install .install-button').text(), 'Accept and Download')
+        eq_(doc('#install .install-button').text(), 'Download Now')
 
     def test_install_button_no_eula(self):
         self.addon.update(eula=None)
@@ -488,7 +489,7 @@ class TestDownloadSources(amo.tests.TestCase):
         url = reverse('discovery.addons.detail', args=['a3615'])
         r = self.client.get(url)
         doc = pq(r.content)
-        assert doc('#install a.go').attr('href').endswith(
+        assert doc('#install a.download').attr('href').endswith(
             '?src=discovery-details')
         assert doc('#install li:eq(1)').find('a').attr('href').endswith(
             '?src=discovery-learnmore')
@@ -500,7 +501,7 @@ class TestDownloadSources(amo.tests.TestCase):
                '?src=discovery-featured')
         r = self.client.get(url)
         doc = pq(r.content)
-        assert doc('#install a.go').attr('href').endswith(
+        assert doc('#install a.download').attr('href').endswith(
             '?src=discovery-featured')
 
     def test_eula(self):

--- a/media/css/impala/addon_details.less
+++ b/media/css/impala/addon_details.less
@@ -21,7 +21,7 @@
     }
     .badge {
         font-size: 14px;
-        margin: 0 1em;
+        margin-left: 1em;
     }
     .install-shell {
         font-family: @sans-stack;

--- a/media/css/zamboni/mobile.css
+++ b/media/css/zamboni/mobile.css
@@ -969,7 +969,8 @@ button:active,
 #content .badges .warning span {
     cursor: pointer;
 }
-.install .privacy-policy {
+.install .privacy-policy,
+.install .eula {
     display: block;
     margin-top: 12px;
     -moz-border-radius: 4px;

--- a/templates/qunit/qunit.html
+++ b/templates/qunit/qunit.html
@@ -297,7 +297,6 @@
 
             b={'show_warning': True,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -322,7 +321,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': True,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -347,7 +345,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -372,7 +369,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': True,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -397,7 +393,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -422,7 +417,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -447,7 +441,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -474,7 +467,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -499,7 +491,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': True,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -524,7 +515,6 @@
 
             b={'show_warning': False,
                 'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-                'show_eula': False,
                 'show_contrib': False,
                 'xpiurl': 'http://xpiurl.com',
                 'button_class': ['download', 'prominent']},
@@ -549,7 +539,6 @@
 
             b={'show_warning': True,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -574,7 +563,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': True,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -599,7 +587,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': False,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},
@@ -624,7 +611,6 @@
 
             b={'show_warning': False,
                'addon': {'get_url_path': Mock(return_value='http://testurl.com')},
-               'show_eula': False,
                'show_contrib': True,
                'xpiurl': 'http://xpiurl.com',
                'button_class': ['download', 'prominent']},


### PR DESCRIPTION
What has been tested by hand:
- addons detail page (desktop and mobile)
- addons discovery detail page
- search results

I've successfully ran both the modified test files, but couldn't have all the qunit test run: they stop all of a sudden after the 8th and there's two CSP report logs in the console, no more details, please let me know if there's anything I can do about it.

There's one place where click-through EULAs are still present: in the add-ons pane on Firefox (when clicking on an INSTALL button in the search results). No clue if it's possible to modify this without touching Firefox's own code.

Here's what Unfocused told me on irc about that:

```
22:49 < Unfocused> magopian: you want to get rid of the EULA popup that the addons manager shows? file a bug
22:50 < Unfocused> the addons manager goes have a separate popup for that, but if there's a click-through EULA in the discovery pane then that comes from AMO
22:53 < Unfocused> er, and when you file a bug, needinfo both Mossop and I... things like EULAs are always trickier when its in-product UI :\
```

So before (or after?) merging, we should/could create a bug for this, thoughts?

Here's a screenshot of the EULA link added:

![eula_link](https://f.cloud.github.com/assets/167767/1885444/950e98a6-79cd-11e3-807e-c7ccb8228512.png)
