### PR TITLE
paginate 'my reviews' in user profile (bug 731682)

### DIFF
--- a/apps/users/templates/users/profile.html
+++ b/apps/users/templates/users/profile.html
@@ -110,6 +110,7 @@
       <p class="no-reviews no-results">{{ _('No add-on reviews yet.') }}</p>
     {% endif %}
   </div>
+  {{ reviews|impala_paginator }}
 </div>
 
 {% endblock %}

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -600,6 +600,7 @@ def profile(request, user):
 
     # Don't show marketplace reviews for AMO (since that would break).
     reviews = list(user.reviews.exclude(addon__type=amo.ADDON_WEBAPP))
+    reviews = amo.utils.paginate(request, reviews)
 
     data = {'profile': user, 'own_coll': own_coll, 'reviews': reviews,
             'fav_coll': fav_coll, 'edit_any_user': edit_any_user,


### PR DESCRIPTION
Paginate "my reviews" to display at most 20 reviews at a time in a user's profile.
