### PR TITLE
remove and drop legacyaddonlog

### DIFF
--- a/apps/amo/tasks.py
+++ b/apps/amo/tasks.py
@@ -13,9 +13,8 @@ from abuse.models import AbuseReport
 from addons.models import Addon
 from amo.decorators import set_task_user
 from amo.utils import get_email_backend
-from applications.models import Application, AppVersion
 from bandwagon.models import Collection
-from devhub.models import ActivityLog, AppLog, LegacyAddonLog
+from devhub.models import ActivityLog, AppLog
 from editors.models import EscalationQueue, EventLog
 from market.models import Refund
 from reviews.models import Review
@@ -48,6 +47,7 @@ def send_email(recipient, subject, message, from_email=None,
             raise
         else:
             return False
+
 
 @task
 def flush_front_end_cache_urls(urls, **kw):
@@ -118,15 +118,6 @@ def delete_incomplete_addons(items, **kw):
             addon.delete('Deleted for incompleteness')
         except Exception as e:
             log.error("Couldn't delete add-on %s: %s" % (addon.id, e))
-
-
-@task
-def migrate_admin_logs(items, **kw):
-    print 'Processing: %d..%d' % (items[0], items[-1])
-    for item in LegacyAddonLog.objects.filter(pk__in=items):
-        kw = dict(user=item.user, created=item.created)
-        amo.log(amo.LOG.ADD_APPVERSION, (Application, item.object1_id),
-                (AppVersion, item.object2_id), **kw)
 
 
 @task

--- a/apps/devhub/models.py
+++ b/apps/devhub/models.py
@@ -479,25 +479,6 @@ class ActivityLogAttachment(amo.models.ModelBase):
         return imghdr.what(self.full_path()) is not None
 
 
-# TODO(davedash): Remove after we finish the import.
-class LegacyAddonLog(models.Model):
-    TYPES = [(value, key) for key, value in amo.LOG.items()]
-
-    addon = models.ForeignKey('addons.Addon', null=True, blank=True)
-    user = models.ForeignKey('users.UserProfile', null=True)
-    type = models.SmallIntegerField(choices=TYPES)
-    object1_id = models.IntegerField(null=True, blank=True)
-    object2_id = models.IntegerField(null=True, blank=True)
-    name1 = models.CharField(max_length=255, default='', blank=True)
-    name2 = models.CharField(max_length=255, default='', blank=True)
-    notes = models.TextField(blank=True)
-    created = models.DateTimeField(auto_now_add=True)
-
-    class Meta:
-        db_table = 'addonlogs'
-        ordering = ('id',)
-
-
 class SubmitStep(models.Model):
     addon = models.ForeignKey(Addon)
     step = models.IntegerField()

--- a/migrations/732-rm-legacyaddonlog.sql
+++ b/migrations/732-rm-legacyaddonlog.sql
@@ -1,0 +1,1 @@
+DROP TABLE addonlogs;


### PR DESCRIPTION
LegacyAddonLog has 200k+ rows on prod, and isn't being used anymore (last `created` was March 2012).

This is not an attempt to steal @mstriemer migration number.
