### PR TITLE
Add back update_developer_name command temporarily

### DIFF
--- a/apps/addons/management/commands/process_addons.py
+++ b/apps/addons/management/commands/process_addons.py
@@ -13,8 +13,8 @@ from market.tasks import check_paypal, check_paypal_multiple
 
 from mkt.webapps.tasks import (add_uuids, clean_apps, dump_apps,
                                fix_missing_icons, import_manifests,
-                               update_manifests, update_supported_locales,
-                               zip_apps)
+                               update_developer_name, update_manifests,
+                               update_supported_locales, zip_apps)
 
 
 tasks = {
@@ -54,6 +54,12 @@ tasks = {
                            disabled_by_user=False)],
                   'pre': clean_apps,
                   'post': zip_apps},
+    'update_developer_name': {'method': update_developer_name,
+                         'qs': [Q(type=amo.ADDON_WEBAPP,
+                                  status__in=[amo.STATUS_PENDING,
+                                              amo.STATUS_PUBLIC,
+                                              amo.STATUS_PUBLIC_WAITING],
+                                  disabled_by_user=False)]},
     'fix_missing_icons': {'method': fix_missing_icons,
                           'qs': [Q(type=amo.ADDON_WEBAPP,
                                   status__in=[amo.STATUS_PENDING,

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -10,6 +10,7 @@ import time
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.files.storage import default_storage as storage
+from django.forms import ValidationError
 from django.template import Context, loader
 
 import pytz
@@ -479,6 +480,42 @@ def zip_users(*args, **kw):
     task_log.info(u'Creating user dump {0}'.format(target_file))
     subprocess.call(cmd)
     return target_file
+
+
+def _update_developer_name(id):
+    try:
+        webapp = Webapp.objects.get(pk=id)
+    except Webapp.DoesNotExist:
+        _log(id, u'Webapp does not exist')
+        return
+
+    version = webapp.current_version
+
+    # If the app doesn't have a current_version, don't bother.
+    if not version:
+        _log(id, u'Webapp does not have a current_version')
+        return
+
+    # If the current_version already has a non-empty developer_name set, don't
+    # touch it and bail.
+    if version._developer_name:
+        _log(id, u'Webapp already has a non-empty developer_name')
+        return
+
+    try:
+        data = WebAppParser().parse(webapp.get_latest_file().file_path)
+    except ValidationError:
+        _log(id, u'Webapp manifest can not be parsed')
+        return
+
+    max_len = version._meta.get_field_by_name('_developer_name')[0].max_length
+    version.update(_developer_name=data['developer_name'][:max_len])
+
+
+@task
+def update_developer_name(ids, **kw):
+    for id in ids:
+        _update_developer_name(id)
 
 
 def _fix_missing_icons(id):


### PR DESCRIPTION
(30 or so public apps have no developer_name set, they must have been had some issues when the command was ran, add it back so that we can fix them)

I've re-opened https://bugzilla.mozilla.org/show_bug.cgi?id=911998 to go with this commit.
