### PR TITLE
API performance tweaks regarding apps (bug 956987)

### DIFF
--- a/mkt/abuse/api.py
+++ b/mkt/abuse/api.py
@@ -10,7 +10,7 @@ from mkt.api.authentication import (RestOAuthAuthentication,
                                     RestSharedSecretAuthentication)
 from mkt.api.base import check_potatocaptcha, CORSMixin
 from mkt.api.fields import SlugOrPrimaryKeyRelatedField, SplitField
-from mkt.webapps.api import AppSerializer
+from mkt.webapps.api import SimpleAppSerializer
 from mkt.webapps.models import Webapp
 
 
@@ -44,7 +44,7 @@ class AppAbuseSerializer(BaseAbuseSerializer):
     app = SplitField(
         SlugOrPrimaryKeyRelatedField(source='addon', slug_field='app_slug',
                                      queryset=Webapp.objects.all()),
-        AppSerializer(source='addon'))
+        SimpleAppSerializer(source='addon'))
 
     class Meta:
         model = AbuseReport

--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -29,7 +29,7 @@ from mkt.api.authentication import (RestAnonymousAuthentication,
 from mkt.api.authorization import AllowSelf, AllowOwner
 from mkt.api.base import CORSMixin, MarketplaceView
 from mkt.constants.apps import INSTALL_TYPE_USER
-from mkt.webapps.api import AppSerializer
+from mkt.webapps.api import SimpleAppSerializer
 from mkt.webapps.models import Webapp
 
 
@@ -45,7 +45,7 @@ class MineMixin(object):
 
 
 class InstalledView(MarketplaceView, ListAPIView):
-    serializer_class = AppSerializer
+    serializer_class = SimpleAppSerializer
     permission_classes = [AllowSelf]
     authentication_classes = [RestOAuthAuthentication,
                               RestSharedSecretAuthentication]

--- a/mkt/fireplace/api.py
+++ b/mkt/fireplace/api.py
@@ -1,15 +1,9 @@
-from mkt.webapps.api import AppSerializer, AppViewSet as BaseAppViewset
+from mkt.webapps.api import SimpleAppSerializer, AppViewSet as BaseAppViewset
 
 
-class FireplaceAppSerializer(AppSerializer):
-    upsold = None
-    tags = None
-    class Meta(AppSerializer.Meta):
-        exclude = [
-            'absolute_url', 'app_type', 'categories', 'created',
-            'default_locale', 'payment_account', 'regions',
-            'supported_locales', 'weekly_downloads', 'upsold', 'tags',]
+class FireplaceAppSerializer(SimpleAppSerializer):
+    pass
+
 
 class AppViewSet(BaseAppViewset):
-
     serializer_class = FireplaceAppSerializer


### PR DESCRIPTION
- Re-use categories instead of using a new queryset
- Re-use all_previews cached list
- Don't load translations when loading versions
- Use a simplified serializer everywhere
- Check premium status before returning prices

(Split from #1593, that's just the API part)
