### PR TITLE
Fix upsell in AppSerializer and es_app_to_dict (bug 956820)

### DIFF
--- a/mkt/webapps/api.py
+++ b/mkt/webapps/api.py
@@ -213,9 +213,13 @@ class AppSerializer(serializers.ModelSerializer):
         return [t.tag_text for t in app.tags.all()]
 
     def get_upsell(self, app):
-        if (app.upsell and self._get_region_id() in
-                app.upsell.premium.get_price_region_ids()):
+        upsell = False
+        if app.upsell:
             upsell = app.upsell.premium
+        # Only return the upsell app if it's public and we are not in an
+        # excluded region.
+        if (upsell and upsell.is_public() and self._get_region_id()
+                not in upsell.get_excluded_region_ids()):
             return {
                 'id': upsell.id,
                 'app_slug': upsell.app_slug,

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -709,12 +709,10 @@ class Webapp(Addon):
 
         if self.is_premium():
             all_regions = set(mkt.regions.ALL_REGION_IDS)
-            tier = self.get_tier()
-            if tier:
-                # Find every region that does not have payments supported
-                # and add that into the exclusions.
-                return excluded.union(
-                    all_regions.difference(self.get_price_region_ids()))
+            # Find every region that does not have payments supported
+            # and add that into the exclusions.
+            return excluded.union(
+                all_regions.difference(self.get_price_region_ids()))
 
         return sorted(list(excluded))
 
@@ -1659,7 +1657,7 @@ class WebappIndexer(MappingType, Indexable):
             d['supported_locales'] = []
 
         d['tags'] = getattr(obj, 'tag_list', [])
-        if obj.upsell:
+        if obj.upsell and obj.upsell.premium.is_public():
             upsell_obj = obj.upsell.premium
             d['upsell'] = {
                 'id': upsell_obj.id,

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -201,7 +201,7 @@ def es_app_to_dict(obj, profile=None, request=None):
     data['upsell'] = False
     if hasattr(obj, 'upsell'):
         exclusions = obj.upsell.get('region_exclusions')
-        if exclusions is not None and region_slug not in exclusions:
+        if exclusions is not None and region_id not in exclusions:
             data['upsell'] = obj.upsell
             data['upsell']['resource_uri'] = reverse(
                 'app-detail',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=956820
- Don't return upsell if in an excluded region
- Don't return upsell if it's not a public app
- Add tests

cc @andym for the `get_excluded_region_ids()` change. Questions I asked on IRC:
- ~~In https://github.com/mozilla/zamboni/commit/df6eddf9#diff-692d706d337b4dc29d4f2b4202e1766bR594 where `get_excluded_region_ids()` was added, a check was added making sure there is a tier before excluding regions ; Was there a reason ? Wouldn't we want to consider all regions are excluded if there is no tier for this app ?~~ @andym said that _if its premium and there is no tier, it should be excluded from all regions_. This is what I implemented here.
- ~~How does payments disabling in a region works ? In particular, does this affect the result of `get_excluded_region_ids()` ? If it does, doesn’t that mean that an app indexed while payments are disabled in a region will exclude it from that region till the next time it's re-indexed, even if payments are re-enabled in that region in the meantime ?~~ confirmed as not a problem by @andymckay and @muffinresearch on IRC: we just re-index all premium apps in that case.
