### PR TITLE
create attachments api (bug 958382)

### DIFF
--- a/docs/api/topics/comm.rst
+++ b/docs/api/topics/comm.rst
@@ -4,7 +4,9 @@
 Communication
 =============
 
-API for communication between reviewers and developers.
+API for communication between reviewers and developers
+
+.. note:: Under development.
 
 Thread
 ======
@@ -59,6 +61,8 @@ Thread
 .. http:get:: /api/v1/comm/thread/(int:id)/
 
     .. note:: Does not require authentication if the thread is public.
+
+    View a thread object.
 
     **Response**
 
@@ -138,7 +142,7 @@ Thread
 
     .. note:: Requires authentication.
 
-    This endpoint can be used to mark all notes in a thread as read.
+    Mark all notes in a thread as read.
 
     **Request**
 
@@ -148,36 +152,9 @@ Thread
     **Response**
 
     :status code: 204 Thread is marked as read.
-    :status code: 403 There is an attempt to modify other fields or not allowed to access the object.
     :status code: 400 Thread object not found.
+    :status code: 403 There is an attempt to modify other fields or not allowed to access the object.
 
-.. _thread-post-label:
-
-.. http:post:: /api/v1/comm/thread/
-
-    .. note:: Requires authentication.
-
-    **Request**
-
-    :param addon: the id of the addon.
-    :type addon: int
-    :param version: the id of the version of the addon.
-    :type version: int
-
-    **Response**
-
-    :param: A :ref:`thread <thread-response-label>`.
-    :status code: 201 successfully created.
-
-.. _thread-delete-label:
-
-.. http:delete:: /api/v1/comm/thread/(int:id)/
-
-    .. note:: Requires authentication.
-
-    **Response**
-
-    :status code: 204 successfully deleted.
 
 Note
 ====
@@ -186,7 +163,7 @@ Note
 
     .. note:: Does not require authentication if the thread is public.
 
-    Returns the list of notes that the thread contains.
+    Returns the list of notes that a thread contains.
 
     **Request**
 
@@ -210,6 +187,8 @@ Note
 
     .. note:: Does not require authentication if the note is in a public thread.
 
+    View a note.
+
     **Request**
 
     The standard :ref:`list-query-params-label`.
@@ -220,11 +199,17 @@ Note
 
     :status 200: successfully completed.
     :status 403: not allowed to access this object.
-    :status 404: not found.
+    :status 404: thread or note not found.
 
     .. code-block:: json
 
         {
+            "attachments": [{
+                "id": 1,
+                "created": "2013-06-14T11:54:48",
+                "display_name": "Screenshot of my app.",
+                "url": "http://marketplace.cdn.mozilla.net/someImage.jpg",
+            }],
             "author": 1,
             "author_meta": {
                 "name": "Landfill Admin"
@@ -239,6 +224,8 @@ Note
 
     Notes on the response.
 
+    :param attachments: files attached to the note (often images).
+    :type attachments: array
     :param note_type: type of action taken with the note.
     :type note_type: int
     :param is_read: Whether the note is read or unread.
@@ -272,7 +259,7 @@ Note
 
     .. note:: Requires authentication.
 
-    This endpoint can be used to mark an unread note as read.
+    Mark an unread note as read.
 
     **Request**
 
@@ -282,15 +269,16 @@ Note
     **Response**
 
     :status code: 204 Note marked as read.
-    :status code: 403 There is an attempt to modify other fields or not allowed to access the object.
     :status code: 400 Note object not found.
+    :status code: 403 There is an attempt to modify other fields or not allowed to access the object.
 
 .. _note-post-label:
 
 .. http:post:: /api/v1/comm/thread/(int:thread_id)/note/
 
-
     .. note:: Requires authentication.
+
+    Create a note on a thread.
 
     **Request**
 
@@ -307,16 +295,8 @@ Note
 
     :param: A :ref:`note <note-response-label>`.
     :status code: 201 successfully created.
-
-.. _note-delete-label:
-
-.. http:delete:: /api/v1/comm/thread/(int:thread_id)/note/(int:id)/
-
-    .. note:: Requires authentication.
-
-    **Response**
-
-    :status code: 204 successfully deleted.
+    :status code: 400 bad request.
+    :status code: 404 thread not found.
 
 
 .. _list-ordering-params-label:
@@ -333,3 +313,35 @@ Order results by created or modified times, by using `ordering` param.
 * *modified* - Earliest modified notes first.
 
 * *-modified* - Latest modified notes first.
+
+
+Attachment
+==========
+
+.. _attachment-post-label:
+
+.. http:post:: /api/v1/comm/thread/(int:thread_id)/note/(int:note_id)/attachment
+
+    .. note:: Requires authentication and the user to be the author of the note.
+
+    Create attachment(s) on a note.
+
+    **Request**
+
+    The request must be sent and encoded with the multipart/form-data Content-Type.
+
+    :param form-0-attachment: the first attachment file encoded with multipart/form-data.
+    :type form-0-attachment: multipart/form-data encoded file stream
+    :param form-0-description: description of the first attachment.
+    :type form-0-description: string
+    :param form-N-attachment: If sending multiple attachments, replace N with the number of the n-th attachment.
+    :type form-N-attachment: multipart/form-data encoded file stream
+    :param form-N-description: description of the n-th attachment.
+    :type form-N-description: string
+
+    **Response**
+
+    :param: The :ref:`note <note-response-label>` the attachment was attached to.
+    :status code: 201 successfully created.
+    :status code: 400 bad request (e.g. no attachments, more than 10 attachments).
+    :status code: 403 permission denied if user isn't the author of the note.

--- a/mkt/comm/forms.py
+++ b/mkt/comm/forms.py
@@ -1,6 +1,9 @@
 from django import forms
+from django.conf import settings
+from django.forms import ValidationError
 
 import happyforms
+from jinja2.filters import do_filesizeformat
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 from mkt.api.forms import SluggableModelChoiceField
@@ -14,22 +17,18 @@ class AppSlugForm(happyforms.Form):
 
 
 class CreateCommNoteForm(happyforms.Form):
-    body = forms.CharField()
+    body = forms.CharField(
+        error_messages={'required': _lazy('Note body is empty.')})
     note_type = forms.TypedChoiceField(
+        empty_value=comm.NO_ACTION,
         coerce=int, choices=[(x, x) for x in comm.NOTE_TYPES],
         error_messages={'invalid_choice': _lazy(u'Invalid note type.')})
 
 
-class CreateCommThreadForm(happyforms.Form):
+class CreateCommThreadForm(CreateCommNoteForm):
     app = SluggableModelChoiceField(queryset=Webapp.objects.all(),
                                     sluggable_to_field_name='app_slug')
     version = forms.CharField()
-    note_type = forms.TypedChoiceField(
-        empty_value=comm.NO_ACTION,
-        choices=[(note, note) for note in comm.NOTE_TYPES], coerce=int,
-        error_messages={'invalid_choice': _lazy('Invalid note type.')})
-    body = forms.CharField(
-        error_messages={'required': _lazy('Note body is empty.')})
 
     def clean_version(self):
         version_num = self.cleaned_data['version']
@@ -39,3 +38,24 @@ class CreateCommThreadForm(happyforms.Form):
             return versions[0]
         raise forms.ValidationError(
             _('Version %s does not exist' % version_num))
+
+
+class CommAttachmentForm(happyforms.Form):
+    attachment = forms.FileField(label=_lazy(u'Attachment:'))
+    description = forms.CharField(required=False, label=_lazy(u'Description:'))
+
+    max_upload_size = settings.MAX_REVIEW_ATTACHMENT_UPLOAD_SIZE
+
+    def clean(self, *args, **kwargs):
+        data = super(CommAttachmentForm, self).clean(*args, **kwargs)
+        attachment = data.get('attachment')
+        max_size = self.max_upload_size
+        if attachment and attachment.size > max_size:
+            # L10n: error raised when review attachment is too large.
+            exc = _('Attachment exceeds maximum size of %s.' %
+                    do_filesizeformat(self.max_upload_size))
+            raise ValidationError(exc)
+        return data
+
+
+CommAttachmentFormSet = forms.formsets.formset_factory(CommAttachmentForm)

--- a/mkt/comm/urls.py
+++ b/mkt/comm/urls.py
@@ -2,7 +2,8 @@ from django.conf.urls import include, patterns, url
 
 from rest_framework.routers import DefaultRouter
 
-from mkt.comm.api import NoteViewSet, post_email, ReplyViewSet, ThreadViewSet
+from mkt.comm.api import (AttachmentViewSet, NoteViewSet, post_email,
+                          ReplyViewSet, ThreadViewSet)
 
 
 api_thread = DefaultRouter()
@@ -12,6 +13,9 @@ api_thread.register(r'thread/(?P<thread_id>\d+)/note', NoteViewSet,
 api_thread.register(
     r'thread/(?P<thread_id>\d+)/note/(?P<note_id>\d+)/replies', ReplyViewSet,
     base_name='comm-note-replies')
+api_thread.register(
+    r'thread/(?P<thread_id>\d+)/note/(?P<note_id>\d+)/attachment',
+    AttachmentViewSet, base_name='comm-attachment')
 
 api_patterns = patterns('',
     url(r'^comm/', include(api_thread.urls)),

--- a/mkt/comm/utils.py
+++ b/mkt/comm/utils.py
@@ -2,6 +2,7 @@ from email import message_from_string
 from email.utils import parseaddr
 
 from django.conf import settings
+from django.core.files.storage import get_storage_class
 
 import commonware.log
 import waffle
@@ -194,9 +195,12 @@ def create_comm_note(app, version, author, body, note_type=comm.NO_ACTION,
         return None, None
 
     # Dict of {'read_permission_GROUP_TYPE': boolean}.
-    # Perm for dev, reviewer, senior_reviewer, moz_contact, staff all True by
-    # default.
+    # Perm for reviewer, senior_reviewer, moz_contact, staff True by default.
+    # Perm for developer False if is escalation or reviewer comment by default.
     perms = perms or {}
+    if 'developer' not in perms and note_type in (comm.ESCALATION,
+                                                  comm.REVIEWER_COMMENT):
+        perms['developer'] = False
     create_perms = dict(('read_permission_%s' % key, has_perm)
                         for key, has_perm in perms.iteritems())
 
@@ -237,3 +241,33 @@ def post_create_comm_note(note):
 
     # Send out emails.
     send_mail_comm(note)
+
+
+def create_attachments(note, formset):
+    """Create attachments from CommAttachmentFormSet onto note."""
+    errors = []
+    storage = get_storage_class()()
+
+    for form in formset:
+        if not form.is_valid():
+            errors.append(form.errors)
+            continue
+
+        data = form.cleaned_data
+        attachment = data['attachment']
+        attachment_name = _save_attachment(
+            storage, attachment,
+            '%s/%s' % (settings.REVIEWER_ATTACHMENTS_PATH, attachment.name))
+
+        note.attachments.create(
+            description=data.get('description'), filepath=attachment_name,
+            mimetype=attachment.content_type)
+
+    return errors
+
+
+def _save_attachment(storage, attachment, filepath):
+    """Saves an attachment and returns the filename."""
+    filepath = storage.save(filepath, attachment)
+    # In case of duplicate filename, storage suffixes filename.
+    return filepath.split('/')[-1]

--- a/mkt/constants/comm.py
+++ b/mkt/constants/comm.py
@@ -4,6 +4,8 @@ THREAD_TOKEN_EXPIRY = 30
 # Number of times a token can be used.
 MAX_TOKEN_USE_COUNT = 5
 
+MAX_ATTACH = 10
+
 NO_ACTION = 0
 APPROVAL = 1
 REJECTION = 2

--- a/mkt/reviewers/forms.py
+++ b/mkt/reviewers/forms.py
@@ -2,11 +2,8 @@ import datetime
 import logging
 
 from django import forms
-from django.conf import settings
-from django.forms import ValidationError
 
 import happyforms
-from jinja2.filters import do_filesizeformat
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 import amo
@@ -26,34 +23,13 @@ from .tasks import approve_rereview, reject_rereview, send_mail
 
 log = logging.getLogger('z.reviewers.forms')
 
+
 # We set 'any' here since we need to default this field
 # to PUBLIC if not specified for consumer pages.
 STATUS_CHOICES = [('any', _lazy(u'Any Status'))]
 for status in amo.WEBAPPS_UNLISTED_STATUSES + (amo.STATUS_PUBLIC,):
     STATUS_CHOICES.append((amo.STATUS_CHOICES_API[status],
                            amo.MKT_STATUS_CHOICES[status]))
-
-
-class ReviewAppAttachmentForm(happyforms.Form):
-    attachment = forms.FileField(label=_lazy(u'Attachment:'))
-    description = forms.CharField(required=False, label=_lazy(u'Description:'))
-
-    max_upload_size = settings.MAX_REVIEW_ATTACHMENT_UPLOAD_SIZE
-
-    def clean(self, *args, **kwargs):
-        data = super(ReviewAppAttachmentForm, self).clean(*args, **kwargs)
-        attachment = data.get('attachment')
-        max_size = self.max_upload_size
-        if attachment and attachment.size > max_size:
-            # Translators: Error raised when review attachment is too large.
-            exc = _('Attachment exceeds maximum size of %s.' %
-                    do_filesizeformat(self.max_upload_size))
-            raise ValidationError(exc)
-        return data
-
-
-AttachmentFormSet = forms.formsets.formset_factory(ReviewAppAttachmentForm,
-                                                   extra=1)
 
 
 class ReviewAppForm(happyforms.Form):

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -25,7 +25,7 @@ import amo.tests
 import reviews
 from abuse.models import AbuseReport
 from access.models import Group, GroupUser
-from addons.models import Addon, AddonDeviceType
+from addons.models import AddonDeviceType
 from amo.helpers import absolutify
 from amo.tests import (app_factory, check_links, days_ago, formset, initial,
                        req_factory_factory, user_factory, version_factory)
@@ -56,6 +56,7 @@ from mkt.webapps.tests.test_models import PackagedFilesMixin
 
 
 class AttachmentManagementMixin(object):
+
     def _attachment_management_form(self, num=1):
         """
         Generate and return data for a management form for `num` attachments
@@ -63,6 +64,22 @@ class AttachmentManagementMixin(object):
         return {'attachment-TOTAL_FORMS': max(1, num),
                 'attachment-INITIAL_FORMS': 0,
                 'attachment-MAX_NUM_FORMS': 1000}
+
+    def _attachments(self, num):
+        """Generate and return data for `num` attachments """
+        data = {}
+        files = ['bacon.jpg', 'bacon.txt']
+        descriptions = ['mmm, bacon', '']
+        if num > 0:
+            for n in xrange(num):
+                i = 0 if n % 2 else 1
+                path = os.path.join(ATTACHMENTS_DIR, files[i])
+                attachment = open(path, 'r+')
+                data.update({
+                    'attachment-%d-attachment' % n: attachment,
+                    'attachment-%d-description' % n: descriptions[i]
+                })
+        return data
 
 
 class AppReviewerTest(amo.tests.TestCase):
@@ -2016,23 +2033,6 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         eq_(dd.text(), u'1')
         eq_(dd.find('a').attr('href'), reverse('reviewers.apps.review.abuse',
                                                args=[self.app.app_slug]))
-
-    def _attachments(self, num):
-        """ Generate and return data for `num` attachments """
-        data = {}
-        files = ['bacon.jpg', 'bacon.txt']
-        descriptions = ['mmm, bacon', '']
-        if num > 0:
-            for n in xrange(num):
-                i = 0 if n % 2 else 1
-                path = os.path.join(settings.REVIEWER_ATTACHMENTS_PATH,
-                                    files[i])
-                attachment = open(path)
-                data.update({
-                    'attachment-%d-attachment' % n: attachment,
-                    'attachment-%d-description' % n: descriptions[i]
-                })
-        return data
 
     def _attachment_form_data(self, num=1, action='comment'):
         data = {'action': action,

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -47,6 +47,7 @@ from users.models import UserProfile
 from zadmin.models import set_config, unmemoized_get_config
 
 import mkt
+from mkt.comm.forms import CommAttachmentFormSet
 from mkt.regions.utils import parse_region
 from mkt.reviewers.forms import ApiReviewersSearchForm
 from mkt.reviewers.utils import (AppsReviewing, clean_sort_param,
@@ -252,9 +253,9 @@ def _review(request, addon, version):
             request, _('Only senior reviewers can review blocklisted apps.'))
         return redirect(reverse('reviewers.home'))
 
-    attachment_formset = forms.AttachmentFormSet(data=request.POST or None,
-                                                 files=request.FILES or None,
-                                                 prefix='attachment')
+    attachment_formset = CommAttachmentFormSet(data=request.POST or None,
+                                               files=request.FILES or None,
+                                               prefix='attachment')
     form = forms.get_review_form(data=request.POST or None,
                                  files=request.FILES or None, request=request,
                                  addon=addon, version=version,


### PR DESCRIPTION
An API for attaching files to a CommunicationNote.
- Requests are in the form of an attachment formset, encoded with `multipart/form-data`.
- Attachment API separate from CommunicationNote API (therefore are created after notes).
- Decided to make the APIs separate (not create note+attachments in one request) to keep it refactored. 
- Clean up the CommunicationNote API a bit, removing unused methods.

**Notes:**
- This will be used in Commbadge (commonplace project) to allow developers to attach a file to a note.
- a utility within this patch will be used in the Reviewer Tools to create attachments

r? @chuckharmston (the true chuck) since some code based off of your attachments code.
