### PR TITLE
attempting to fix Http404 has_header calls (bug 951355)

### DIFF
--- a/apps/files/decorators.py
+++ b/apps/files/decorators.py
@@ -23,7 +23,7 @@ def allowed(request, file):
         try:
             addon = file.version.addon
         except ObjectDoesNotExist:
-            return http.Http404()
+            raise http.Http404
 
         if addon.view_source and addon.status in amo.REVIEWED_STATUSES:
             allowed = True

--- a/apps/files/tests/test_decorators.py
+++ b/apps/files/tests/test_decorators.py
@@ -1,0 +1,32 @@
+from django import http
+from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
+
+from mock import Mock, patch
+
+import amo.tests
+from access import acl
+from files.decorators import allowed
+
+
+class AllowedTest(amo.tests.TestCase):
+
+    def setUp(self):
+        self.request = Mock()
+        self.file = Mock()
+
+    @patch.object(acl, 'check_reviewer', lambda x: True)
+    def test_reviewer_allowed(self):
+        self.assertTrue(allowed(self.request, self.file))
+
+    @patch.object(acl, 'check_reviewer', lambda x: False)
+    def test_reviewer_unallowed(self):
+        self.assertRaises(PermissionDenied, allowed, self.request, self.file)
+
+    @patch.object(acl, 'check_reviewer', lambda x: False)
+    def test_addon_not_found(self):
+        class MockVersion():
+            @property
+            def addon(self):
+                raise ObjectDoesNotExist
+        self.file.version = MockVersion()
+        self.assertRaises(http.Http404, allowed, self.request, self.file)

--- a/apps/files/tests/test_views.py
+++ b/apps/files/tests/test_views.py
@@ -263,6 +263,10 @@ class FilesBase:
         res = self.client.post(self.file_url(), {'left': ids[0]})
         self.assert3xx(res, reverse('files.list', args=ids))
 
+    def test_browse_404(self):
+        res = self.client.get('/files/browse/file/dont/exist.png', follow=True)
+        eq_(res.status_code, 404)
+
     def test_invalid_redirect(self):
         res = self.client.post(self.file_url(), {})
         self.assert3xx(res, self.file_url())

--- a/apps/files/views.py
+++ b/apps/files/views.py
@@ -190,6 +190,6 @@ def serve(request, viewer, key):
     if not obj:
         log.error(u'Couldn\'t find %s in %s (%d entries) for file %s' %
                   (key, files.keys()[:10], len(files.keys()), viewer.file.id))
-        raise http.Http404()
+        raise http.Http404
     return HttpResponseSendFile(request, obj['full'],
                                 content_type=obj['mimetype'])

--- a/apps/zadmin/tests/test_views.py
+++ b/apps/zadmin/tests/test_views.py
@@ -1397,6 +1397,11 @@ class TestLookup(amo.tests.TestCase):
             assert email in emails, (
                 'Expected username "%s" not found' % email)
 
+    def test_lookup_wrong_model(self):
+        self.url = reverse('zadmin.search', args=['doesnt', 'exist'])
+        res = self.client.get(urlparams(self.url, q=''))
+        eq_(res.status_code, 404)
+
     def test_lookup_empty(self):
         users = UserProfile.objects.values('id', 'email')
         self.check_results('', [dict(

--- a/apps/zadmin/views.py
+++ b/apps/zadmin/views.py
@@ -715,7 +715,7 @@ def general_search(request, app_id, model_id):
 
     model = app_cache.get_model(app_id, model_id)
     if not model:
-        return http.Http404()
+        raise http.Http404
 
     limit = 10
     obj = admin.site._registry[model]


### PR DESCRIPTION
As mentioned in [bug 951355](https://bugzilla.mozilla.org/show_bug.cgi?id=951355) Sentry reports lots of errors about Http404 having no `has_header`.
This could also fix https://bugzilla.mozilla.org/show_bug.cgi?id=873550.
