### PR TITLE
Link to MDN submission process page from app submission page (bug 957393)

### DIFF
--- a/mkt/developers/templates/developers/validate_addon.html
+++ b/mkt/developers/templates/developers/validate_addon.html
@@ -1,7 +1,7 @@
 {% extends "developers/base_impala.html" %}
 
 {% set title = _('Test App Validation') %}
-{% set doc_url = 'https://developer.mozilla.org/docs/Apps/Manifest' %}
+{% set doc_url = 'https://developer.mozilla.org/Marketplace/Submission/Pre-submission_checklist' %}
 
 {% block title %}{{ hub_page_title(title) }}{% endblock %}
 
@@ -58,7 +58,7 @@
   </section>
 
   <p class="learn-mdn"><a href="{{ doc_url }}" target="_blank">
-    {% trans %}Learn more about <b>app manifests</b> on MDN.{% endtrans %}
+    {% trans %}Learn more about submitting an app.{% endtrans %}
     </a>
   </p>
 

--- a/mkt/submit/templates/submit/manifest.html
+++ b/mkt/submit/templates/submit/manifest.html
@@ -1,7 +1,7 @@
 {% extends 'developers/base_impala.html' %}
 {% from 'developers/includes/macros.html' import upload_webapp_features with context %}
 
-{% set manifest_doc_url = 'https://developer.mozilla.org/en-US/docs/Apps/Manifest' %}
+{% set app_submission_doc_url = 'https://developer.mozilla.org/Marketplace/Submission/Pre-submission_checklist' %}
 {% set packaged_doc_url = 'https://developer.mozilla.org/en-US/docs/Apps/Packaged_apps' %}
 
 {% set title = _('Submit an App') %}
@@ -120,8 +120,8 @@
     </form>
   </section>
 
-  <p class="hosted learn-mdn active"><a href="{{ manifest_doc_url }}" target="_blank">
-    {% trans %}Learn more about <b>app manifests</b> on MDN.{% endtrans -%}
+  <p class="hosted learn-mdn active"><a href="{{ app_submission_doc_url }}" target="_blank">
+    {% trans %}Learn more about submitting an app.{% endtrans -%}
   </a></p>
   <p class="packaged learn-mdn"><a href="{{ packaged_doc_url }}" target="_blank">
     {% trans %}Learn more about <b>packaged apps</b> on MDN.{% endtrans -%}


### PR DESCRIPTION
This modifies the links in the app submission and validation pages to go to the app submission MDN page as suggested in the ticket: https://bugzilla.mozilla.org/show_bug.cgi?id=957393.

I am just getting started with the project but hope to be able to start contributing frequently!
