### PR TITLE
 enhance strings in generated list pages avoiding composite strings (bug 925288)

### DIFF
--- a/apps/amo/helpers.py
+++ b/apps/amo/helpers.py
@@ -267,7 +267,7 @@ def login_link(context):
 
 @register.function
 @jinja2.contextfunction
-def page_title(context, title, force_webapps=False):
+def page_title(context, title, section=None, force_webapps=False):
     title = smart_unicode(title)
     if settings.APP_PREVIEW:
         base_title = _('Firefox Marketplace')
@@ -275,6 +275,8 @@ def page_title(context, title, force_webapps=False):
         base_title = _('Firefox Marketplace')
     else:
         base_title = page_name(context['request'].APP)
+    if section:
+        return u'%s :: %s :: %s' % (section, title, base_title)
     return u'%s :: %s' % (title, base_title)
 
 

--- a/apps/bandwagon/templates/bandwagon/impala/collection_listing.html
+++ b/apps/bandwagon/templates/bandwagon/impala/collection_listing.html
@@ -2,17 +2,23 @@
 
 {% set url_base = url('collections.list') %}
 {% if sort %}
-  {% set title = {'featured': _('Featured Collections'),
-                  'followers': _('Most-Followed Collections'),
-                  'created': _('Newest Collections'),
-                  'name': _('Collections by Name'),
-                  'updated': _('Recently Updated Collections'),
-                  'popular': _('Recently Popular Collections')}.get(sorting) %}
+  {% set title = {'featured': _('Featured'),
+                  'followers': _('Most-Followed'),
+                  'created': _('Newest'),
+                  'name': _('By Name'),
+                  'updated': _('Recently Updated'),
+                  'popular': _('Recently Popular')}.get(sorting) %}
 {% else %}
   {% set title = _('Collections') %}
 {% endif %}
 
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}
+  {% if sort %}
+    {{ page_title(title, _('Collection')) }}
+  {% else %}
+    {{ page_title(title) }}
+  {% endif %}
+{% endblock %}
 
 {% block primary %}
 <section class="primary">

--- a/apps/browse/templates/browse/impala/base_listing.html
+++ b/apps/browse/templates/browse/impala/base_listing.html
@@ -7,40 +7,37 @@
 {% if category %}
   {% set title = category.name %}
 {% else %}
-  {% if section == 'extensions' %}
-    {% set title = {'featured': _('Featured Extensions'),
-                    'users': _('Most Popular Extensions'),
-                    'rating': _('Top-Rated Extensions'),
-                    'created': _('Newest Extensions'),
-                    'name': _('Extensions by Name'),
-                    'popular': _('Extensions by Weekly Downloads'),
-                    'updated': _('Recently Updated Extensions'),
-                    'hotness': _('Up & Coming Extensions')}.get(sorting) %}
-  {% elif section == 'themes' %}
-    {# L10n: "Complete" is used as an adjective. "Complete Theme" means a full-featured theme. #}
-    {% set title = {'featured': _('Featured Complete Themes'),
-                    'users': _('Most Popular Complete Themes'),
-                    'rating': _('Top-Rated Complete Themes'),
-                    'created': _('Newest Complete Themes'),
-                    'name': _('Complete Themes by Name'),
-                    'popular': _('Complete Themes by Weekly Downloads'),
-                    'updated': _('Recently Updated Complete Themes'),
-                    'hotness': _('Up & Coming Complete Themes')}.get(sorting) %}
-  {% elif section == 'apps' %}
-    {% set title = {'featured': _('Featured Apps'),
-                    'downloads': _('Apps by Weekly Downloads'),
-                    'free': loc('Top Free Apps'),
-                    'paid': loc('Top Paid Apps'),
-                    'rating': _('Top-Rated Apps'),
-                    'created': _('Newest Apps'),
-                    'name': _('Apps by Name'),
-                    'updated': _('Recently Updated Apps'),
-                    'hotness': _('Up & Coming Apps')}.get(sorting) %}
+  {% if section == 'apps' %}
+    {% set title = {'featured': _('Featured'),
+                    'downloads': _('By Weekly Downloads'),
+                    'free': loc('Top Free'),
+                    'paid': loc('Top Paid'),
+                    'rating': _('Top-Rated'),
+                    'created': _('Newest'),
+                    'name': _('By Name'),
+                    'updated': _('Recently Updated'),
+                    'hotness': _('Up & Coming')}.get(sorting) %}
+    {% set section_name = _('Apps') %}
+  {% else  %}
+    {% set title = {'featured': _('Featured'),
+                  'users': _('Most Popular'),
+                  'rating': _('Top-Rated'),
+                  'created': _('Newest'),
+                  'name': _('By Name'),
+                  'popular': _( 'By Weekly Downloads'),
+                  'updated': _('Recently Updated'),
+                  'hotness': _('Up & Coming')}.get(sorting) %}
+    {% if section == 'extensions' %}
+      {% set section_name = _('Extensions') %}
+    {% elif section == 'theme'%}
+      {# L10n: "Complete" is used as an adjective. "Complete Theme" means a full-featured theme. #}
+      {% set section_name = _('Complete Theme') %}
+    {% endif %}
   {% endif %}
 {% endif %}
 
 {% block title %}
-  {{ page_title(title) }}
+  {{ page_title(title, section_name) }}
 {% endblock %}
 
 {% set base_crumb = {

--- a/apps/browse/templates/browse/personas/base.html
+++ b/apps/browse/templates/browse/personas/base.html
@@ -3,7 +3,7 @@
 
 {% set name = category.name if category else filter.title %}
 {# L10n: {0} is a category name. Ex: "Sports" #}
-{% set title = _('Themes') if is_homepage else _('{0} Themes')|f(name) %}
+{% set title = _('Themes') if is_homepage else _('{0}')|f (name) %}
 {% set url_base = request.path %}
 {% if category %}
   {% set url_base = profile.get_user_url('themes', args=[category.slug]) if profile else url('browse.personas', category.slug) %}
@@ -15,7 +15,7 @@
     {% set pagetitle = _("{0}'s Themes")|f(profile.name) %}
     {{ page_title('%s :: %s' % (name ~ '', pagetitle)) }}
   {% else %}
-    {{ page_title(title) }}
+    {{ page_title(title, _('Themes'))}}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=925288

Changed the Title format for such pages to Extensions :: Most Rated :: Addons
Also, changed the the format of H1 to Extensions::Most Rated
