### PR TITLE
unrot command to exclude unrated games

### DIFF
--- a/mkt/developers/tests/test_commands.py
+++ b/mkt/developers/tests/test_commands.py
@@ -6,10 +6,8 @@ import amo.tests
 from addons.models import AddonPremium
 
 import mkt
-from mkt.developers.management.commands import (
-    cleanup_addon_premium,
-    migrate_geodata
-)
+from mkt.developers.management.commands import (cleanup_addon_premium,
+                                                exclude_games, migrate_geodata)
 from mkt.site.fixtures import fixture
 from mkt.webapps.models import Webapp
 
@@ -101,3 +99,55 @@ class TestMigrateGeodata(amo.tests.TestCase):
         self.assertSetEqual(self.webapp.reload().addonexcludedregion
                                 .values_list('region', flat=True),
                             regions)
+
+
+class TestExcludeUnratedGames(amo.tests.TestCase):
+    fixtures = fixture('webapp_337141')
+
+    def setUp(self):
+        self.webapp = Webapp.objects.get(pk=337141)
+        self.br = mkt.regions.BR.id
+        self.de = mkt.regions.DE.id
+
+    def _assert_listed(self, region):
+        assert not self.webapp.addonexcludedregion.filter(
+            region=region).exists()
+
+    def _assert_excluded(self, region):
+        assert self.webapp.addonexcludedregion.filter(region=region).exists()
+
+    def test_exclude_unrated(self):
+        amo.tests.make_game(self.webapp, rated=False)
+
+        exclude_games.Command().handle('br')
+        self._assert_excluded(self.br)
+        self._assert_listed(self.de)
+
+    def test_dont_exclude_non_game(self):
+        exclude_games.Command().handle('br')
+        self._assert_listed(self.br)
+        self._assert_listed(self.de)
+
+    def test_dont_exclude_rated(self):
+        amo.tests.make_game(self.webapp, rated=True)
+
+        exclude_games.Command().handle('br')
+        self._assert_listed(self.br)
+
+    def test_germany_case_generic(self):
+        amo.tests.make_game(self.webapp, rated=False)
+        self.webapp.set_content_ratings({
+            mkt.ratingsbodies.GENERIC: mkt.ratingsbodies.GENERIC_18
+        })
+
+        exclude_games.Command().handle('de')
+        self._assert_listed(self.de)
+
+    def test_germany_case_usk(self):
+        amo.tests.make_game(self.webapp, rated=False)
+        self.webapp.set_content_ratings({
+            mkt.ratingsbodies.USK: mkt.ratingsbodies.USK_18
+        })
+
+        exclude_games.Command().handle('de')
+        self._assert_listed(self.de)


### PR DESCRIPTION
We need to exclude un-rated Brazil + Germany games. 

Fix up the 'exclude_games' command to run on prod.

**Notes:**
- how do we get them unexcluded once they get rated, does the developer know to flip the region?
- allow Germany games with Generic ratings to stay live
