### PR TITLE
distinguish between iarc-excluded and developer-excluded AERs

### DIFF
--- a/migrations/733-aer-iarc.sql
+++ b/migrations/733-aer-iarc.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `addons_excluded_regions`
+    ADD COLUMN `is_iarc_excluded` bool NOT NULL DEFAULT false,
+    DROP INDEX `addon_id`,
+    ADD UNIQUE index(`addon_id`, `region`, `is_iarc_excluded`);

--- a/mkt/developers/management/commands/exclude_games.py
+++ b/mkt/developers/management/commands/exclude_games.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
 
             elif region.ratingsbody and not app.content_ratings_in(region):
                 aer, created = app.addonexcludedregion.get_or_create(
-                    region=region.id)
+                    region=region.id, is_iarc_excluded=True)
                 if created:
                     log.info('[App %s - %s] Excluded in region %r'
                              % (app.pk, app.slug, region.slug))

--- a/mkt/developers/tests/test_api.py
+++ b/mkt/developers/tests/test_api.py
@@ -194,6 +194,8 @@ class TestContentRatingPingback(RestOAuth):
     def test_post_content_ratings_pingback(self, details_mock):
         details_mock.return_value = True
         eq_(self.app.status, amo.STATUS_NULL)
+        self.app.addonexcludedregion.create(region=mkt.regions.BR.id,
+                                            is_iarc_excluded=True)
         self.app.addonexcludedregion.create(region=mkt.regions.BR.id)
         self.app.addonexcludedregion.create(region=mkt.regions.CN.id)
 
@@ -234,6 +236,8 @@ class TestContentRatingPingback(RestOAuth):
 
         eq_(app.status, amo.STATUS_PENDING)
         assert not app.addonexcludedregion.filter(
+            region=mkt.regions.BR.id, is_iarc_excluded=True).exists()
+        assert app.addonexcludedregion.filter(
             region=mkt.regions.BR.id).exists()
         assert app.addonexcludedregion.filter(
             region=mkt.regions.CN.id).exists()

--- a/mkt/developers/tests/test_commands.py
+++ b/mkt/developers/tests/test_commands.py
@@ -123,6 +123,8 @@ class TestExcludeUnratedGames(amo.tests.TestCase):
         self._assert_excluded(self.br)
         self._assert_listed(self.de)
 
+        assert self.webapp.addonexcludedregion.all()[0].is_iarc_excluded
+
     def test_dont_exclude_non_game(self):
         exclude_games.Command().handle('br')
         self._assert_listed(self.br)

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -827,7 +827,8 @@ class TestIARCGetAppInfoForm(amo.tests.WebappTestCase):
         with self.assertRaises(IARCInfo.DoesNotExist):
             self.app.iarc_info
 
-        self.app.addonexcludedregion.create(region=mkt.regions.BR.id)
+        self.app.addonexcludedregion.create(region=mkt.regions.BR.id,
+                                            is_iarc_excluded=True)
 
         form = forms.IARCGetAppInfoForm({'submission_id': 1,
                                          'security_code': 'a'})

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1796,10 +1796,11 @@ class AddonExcludedRegion(amo.models.ModelBase):
                               related_name='addonexcludedregion')
     region = models.PositiveIntegerField(
         choices=mkt.regions.REGIONS_CHOICES_ID)
+    is_iarc_excluded = models.BooleanField(default=False)
 
     class Meta:
         db_table = 'addons_excluded_regions'
-        unique_together = ('addon', 'region')
+        unique_together = ('addon', 'region', 'is_iarc_excluded')
 
     def __unicode__(self):
         region = self.get_region()

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -352,8 +352,8 @@ def remove_region_exclusions(app):
     """
     Remove AddonRegionExclusions based on attained content ratings.
     """
-    exclusions = app.addonexcludedregion.exclude(
-        region__in=mkt.regions.SPECIAL_REGION_IDS)
+    exclusions = (app.addonexcludedregion.filter(is_iarc_excluded=True)
+        .exclude(region__in=mkt.regions.SPECIAL_REGION_IDS))
     log.info('Un-excluding app:%s in regions %s' %
              (app.id, exclusions.values_list('region', flat=True)))
     exclusions.delete()


### PR DESCRIPTION
Noticed that if a developer got a rating, then decided to exclude Germany + Brazil, then updated their rating, their exclusions would get wiped out. So this patch distinguishes between when we exclude an app from a region due to IARC, and when we excluded an app from a region because the developer checked it so.

I went with a simple flag, not very extensible in case we ever use AddonExcludedRegion for more purposes, but this'll do short-term.
