### PR TITLE
Fix ES tests on amo (bug 858447)

### DIFF
--- a/apps/addons/tests/test_views.py
+++ b/apps/addons/tests/test_views.py
@@ -36,8 +36,10 @@ from versions.models import Version
 
 
 def norm(s):
-    """Normalize a string so that whitespace is uniform."""
-    return re.sub(r'[\s]+', ' ', str(s)).strip()
+    """Normalize a string so that whitespace is uniform and remove whitespace
+    between tags."""
+    s = re.sub(r'\s+', ' ', str(s)).strip()
+    return re.sub(r'>\s+<', '><', s)
 
 
 def add_addon_author(original, copy):
@@ -673,7 +675,7 @@ class TestDetailPage(amo.tests.TestCase):
         eq_(norm(doc(".policy-statement strong")),
             "<strong> what the hell..</strong>")
         eq_(norm(doc(".policy-statement ul")),
-            "<ul><li>papparapara</li> <li>todotodotodo</li> </ul>")
+            "<ul><li>papparapara</li><li>todotodotodo</li></ul>")
         eq_(doc(".policy-statement ol a").text(),
             "firefox")
         eq_(norm(doc(".policy-statement ol li:first")),
@@ -1296,7 +1298,7 @@ class TestEula(amo.tests.TestCase):
         eq_(norm(doc('.policy-statement strong')),
             '<strong> what the hell..</strong>')
         eq_(norm(doc('.policy-statement ul')),
-            '<ul><li>papparapara</li> <li>todotodotodo</li> </ul>')
+            '<ul><li>papparapara</li><li>todotodotodo</li></ul>')
         eq_(doc('.policy-statement ol a').text(), 'firefox')
         eq_(norm(doc('.policy-statement ol li:first')),
             '<li>papparapara2</li>')

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -123,15 +123,6 @@ class TestNav(HubTest):
         eq_(doc('#site-nav ul li.top').eq(0).find('li a').eq(7).text(),
             'more add-ons...')
 
-    def test_only_one_header(self):
-        # For bug 682359.
-        # Remove this test when we switch to Impala in the devhub!
-        doc = pq(self.client.get(reverse('devhub.addons')).content)
-        # Make sure we're on a non-impala page.
-        eq_(doc('.is-impala').length, 0,
-            'This test should be run on a non-impala page.')
-        eq_(doc('#header').length, 0, 'Uh oh, there are two headers!')
-
 
 class TestDashboard(HubTest):
 

--- a/apps/stats/tests/test_views.py
+++ b/apps/stats/tests/test_views.py
@@ -346,7 +346,7 @@ class TestLayout(StatsTest):
         eq_(r.status_code, 404)
 
     def get_public_url(self):
-        addon = amo.tests.addon_factory(public_status=True)
+        addon = amo.tests.addon_factory(public_stats=True)
         return reverse('stats.downloads', args=[addon.slug])
 
     def test_public_stats_page_loads(self):

--- a/docs/settings/settings_local.dev.py
+++ b/docs/settings/settings_local.dev.py
@@ -21,9 +21,13 @@ INSTALLED_APPS += (
 #        'LOCATION': 'localhost:11211',
 #    }
 #}
+# Here we use the LocMemCache backend from cache-machine, as it interprets the
+# "0" timeout parameter of ``cache``  in the same way as the Memcached backend:
+# as infinity. Django's LocMemCache backend interprets it as a "0 seconds"
+# timeout (and thus doesn't cache at all).
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'BACKEND': 'caching.backends.locmem.LocMemCache',
         'LOCATION': 'zamboni',
     }
 }

--- a/docs/topics/install-zamboni/settings-changelog.rst
+++ b/docs/topics/install-zamboni/settings-changelog.rst
@@ -1,6 +1,17 @@
 Settings Changelog
 ==================
 
+2014-01-22
+----------
+
+* Changed ``CACHES['default']['BACKEND']`` from
+  ``django.core.cache.backends.locmem.LocMemCache`` to 
+  ``caching.backends.locmem.LocMemCache``.
+  We use the LocMemCache backend from cache-machine, as it interprets the
+  "0" timeout parameter of ``cache`` in the same way as the Memcached backend:
+  as infinity. Django's LocMemCache backend interprets it as a "0 seconds"
+  timeout (and thus doesn't cache at all).
+
 2013-08-09
 ----------
 * Added ``AES_KEYS`` as a settings for encrypting OAuth secrets. Uses a sample

--- a/lib/pay_server/test.py
+++ b/lib/pay_server/test.py
@@ -147,11 +147,11 @@ class TestTransactions(test_utils.TestCase):
 class TestPay(test_utils.TestCase):
 
     def setUp(self):
-        self.user = UserProfile.objects.create()
-        self.addon = Addon.objects.create(type=amo.ADDON_WEBAPP)
         # Temporary until we get AMO solitude support.
         if not settings.MARKETPLACE:
             raise SkipTest
+        self.user = UserProfile.objects.create()
+        self.addon = Addon.objects.create(type=amo.ADDON_WEBAPP)
 
         self.data = {'amount': 1, 'currency': 'USD', 'seller': self.addon,
                      'memo': 'foo'}

--- a/mkt/webapps/tests/test_crons.py
+++ b/mkt/webapps/tests/test_crons.py
@@ -112,7 +112,7 @@ class TestSignApps(amo.tests.TestCase):
         self.app = Addon.objects.get(id=337141)
         self.app.update(is_packaged=True)
         self.app2 = amo.tests.app_factory(
-            name='Mozillaball ょ', app_slug='test',
+            name=u'Mozillaball ょ', app_slug='test',
             is_packaged=True, version_kw={'version': '1.0',
                                           'created': None})
         self.app3 = amo.tests.app_factory(


### PR DESCRIPTION
This PR, together with PR #1614 and #1594 should fix all ES failing tests for AMO.

Details:
- reworking the addon_factory fixed `apps.browse.tests.TestUpdatedSort` and `apps.search.tests.test_view.TestPersonaSearch`
- mocking index_webapps fixes `tests apps.search.tests.test_views.TestSearchSuggestions`
- PR #1614 avoids slug clashes in `apps.search.tests.test_view.TestPersonaSearch`
- PR #1594 avoids `apps.search.tests.test_views.TestESSearch` issues with RequestFactory having no GET attribute
- fix errors on rendered html in `apps/addons/tests/test_views.py` by removing extra space between tags (there was an inconsistency between jenkins and my local tests)
- add a `ESTestCase.tearDownClass` fixes many recurring bug when not forcing the database recreation (fixes [bug 960598](https://bugzilla.mozilla.org/show_bug.cgi?id=960598)
- use cache-machine's `LocMemCache` backend to fix [bug 961139](https://bugzilla.mozilla.org/show_bug.cgi?id=961139)
- add the created addons to `ESTestCase._addons` to have them removed and unindexed after the tests
- skip early in `lib/pay_server/test.py` if we're not running the test to avoid trying to index a Webapp (which fails on AMO)
