### PR TITLE
prevent recursion when calling app.update(status) (bug 960044)

### DIFF
--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -560,7 +560,8 @@ class Webapp(Addon):
         )
         has_pending = (
             self.versions.filter(files__status=amo.STATUS_PENDING).exists())
-        if not has_public and has_pending:
+        # Check for self.is_pending() first to prevent possible recursion.
+        if not has_public and has_pending and not self.is_pending():
             self.update(status=amo.STATUS_PENDING)
             _log('has pending but no public files')
             return


### PR DESCRIPTION
The stack:
- app.update(status=amo.STATUS_PENDING)
- The status update triggers Webapp.watch_status which calls update to update the version’s nomination.
- The nomination update triggers Version.update_status which updates status by calling Webapp.update_status.
- Webapp.update_status calls app.update(status=amo.STATUS_PENDING)
- recurse

I couldn't reproduce this yet in a test, but I'm pretty sure adding that check would stop it from recursing.

http://sentry.mktmon.services.phx1.mozilla.com/mkt/marketplacefirefoxcom/group/3215/events/101466/
