### PR TITLE
add germany/brazil iarc-specific region exclusions (bug 960308)

### DIFF
--- a/migrations/734-geodata-region-iarc-exclude.sql
+++ b/migrations/734-geodata-region-iarc-exclude.sql
@@ -1,0 +1,3 @@
+ALTER TABLE webapps_geodata
+    ADD COLUMN `region_br_iarc_exclude` bool NOT NULL DEFAULT false,
+    ADD COLUMN `region_de_iarc_exclude` bool NOT NULL DEFAULT false;

--- a/mkt/developers/api.py
+++ b/mkt/developers/api.py
@@ -13,7 +13,7 @@ import lib.iarc
 from mkt.api.base import CORSMixin, SlugOrIdMixin
 from mkt.developers.forms import ContentRatingForm
 from mkt.webapps.models import ContentRating, Webapp
-from mkt.webapps.utils import remove_region_exclusions
+from mkt.webapps.utils import remove_iarc_exclusions
 
 
 log = commonware.log.getLogger('z.devhub')
@@ -128,8 +128,7 @@ class ContentRatingsPingback(CORSMixin, SlugOrIdMixin, CreateAPIView):
             # the time it's refreshed.
             app.set_content_ratings(data.get('ratings', {}))
 
-            # Remove region exclusons.
-            remove_region_exclusions(app)
+            remove_iarc_exclusions(app)
 
             # Call SET_STOREFRONT_DATA. If the app is approved already we'll
             # need to let IARC know.

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -47,7 +47,7 @@ from mkt.regions.utils import parse_region
 from mkt.site.forms import AddonChoiceField
 from mkt.webapps.models import Webapp
 from mkt.webapps.tasks import index_webapps
-from mkt.webapps.utils import remove_region_exclusions
+from mkt.webapps.utils import remove_iarc_exclusions
 
 
 from . import tasks
@@ -1179,8 +1179,7 @@ class IARCGetAppInfoForm(happyforms.Form):
             app.set_interactives(row.get('interactives', []))
             app.set_content_ratings(row.get('ratings', {}))
 
-            # Remove region exclusons.
-            remove_region_exclusions(app)
+            remove_iarc_exclusions(app)
         else:
             msg = _('Invalid submission ID or security code.')
             self._errors['submission_id'] = self.error_class([msg])

--- a/mkt/developers/management/commands/exclude_games.py
+++ b/mkt/developers/management/commands/exclude_games.py
@@ -1,44 +1,47 @@
 import logging
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 import amo
 
 import mkt
 
+
 log = logging.getLogger('z.task')
 
 
 class Command(BaseCommand):
-    help = ('Exclude unrated games in a given region. Syntax: \n'
-            '    ./manage.py exclude_games <region_slug>')
+    help = ('Exclude pre-IARC unrated public games in Brazil/Germany.')
 
     def handle(self, *args, **options):
         # Avoid import error.
-        from mkt.webapps.models import Webapp
+        from mkt.webapps.models import Geodata, Webapp
 
-        try:
-            region_slug = args[0]
-        except IndexError:
-            raise CommandError(self.help)
+        games = Webapp.objects.filter(
+            category__type=amo.ADDON_WEBAPP, category__slug='games',
+            status__in=(amo.STATUS_PUBLIC, amo.STATUS_PUBLIC_WAITING))
 
-        region = mkt.regions.REGIONS_DICT[region_slug]
-
-        games = Webapp.objects.filter(category__type=amo.ADDON_WEBAPP,
-            category__slug='games')
-
-        german_bodies = (mkt.ratingsbodies.USK.id,
-                         mkt.ratingsbodies.GENERIC.id)
         for app in games:
-            if (region == mkt.regions.DE and app.content_ratings.filter(
-                ratings_body__in=german_bodies).exists()):
-                # Special case for Germany, allow to be listed if have USK or
-                # Generic.
-                continue
+            save = False
+            geodata, c = Geodata.objects.safer_get_or_create(addon=app)
 
-            elif region.ratingsbody and not app.content_ratings_in(region):
-                aer, created = app.addonexcludedregion.get_or_create(
-                    region=region.id)
-                if created:
-                    log.info('[App %s - %s] Excluded in region %r'
-                             % (app.pk, app.slug, region.slug))
+            # Germany.
+            german_bodies = (mkt.ratingsbodies.USK.id,
+                             mkt.ratingsbodies.GENERIC.id)
+            if (not app.content_ratings.filter(
+                ratings_body__in=german_bodies).exists()):
+                save = True
+                geodata.region_de_iarc_exclude = True
+                log.info('[App %s - %s] Excluded in region de'
+                         % (app.pk, app.slug))
+
+            # Brazil.
+            if (not app.content_ratings.filter(
+                ratings_body=mkt.ratingsbodies.CLASSIND.id).exists()):
+                save = True
+                geodata.region_br_iarc_exclude = True
+                log.info('[App %s - %s] Excluded in region br'
+                         % (app.pk, app.slug))
+
+            if save:
+                geodata.save()

--- a/mkt/developers/tests/test_api.py
+++ b/mkt/developers/tests/test_api.py
@@ -14,7 +14,7 @@ from amo.utils import urlparams
 
 import mkt
 from mkt.api.tests.test_oauth import RestOAuth
-from mkt.webapps.models import ContentRating
+from mkt.webapps.models import ContentRating, Geodata
 
 
 class TestContentRating(amo.tests.TestCase):
@@ -194,8 +194,6 @@ class TestContentRatingPingback(RestOAuth):
     def test_post_content_ratings_pingback(self, details_mock):
         details_mock.return_value = True
         eq_(self.app.status, amo.STATUS_NULL)
-        self.app.addonexcludedregion.create(region=mkt.regions.BR.id)
-        self.app.addonexcludedregion.create(region=mkt.regions.CN.id)
 
         res = self.anon.post(self.url, data=json.dumps(self.data))
         eq_(res.status_code, 200)
@@ -233,13 +231,22 @@ class TestContentRatingPingback(RestOAuth):
             ['has_shares_info', 'has_shares_location'])
 
         eq_(app.status, amo.STATUS_PENDING)
-        assert not app.addonexcludedregion.filter(
-            region=mkt.regions.BR.id).exists()
-        assert app.addonexcludedregion.filter(
-            region=mkt.regions.CN.id).exists()
 
     @override_settings(SECRET_KEY='foo')
     def test_token_mismatch(self):
         res = self.anon.post(self.url, data=json.dumps(self.data))
         eq_(res.status_code, 400)
         eq_(json.loads(res.content)['detail'], 'Token mismatch')
+
+    @mock.patch('mkt.webapps.models.Webapp.details_complete')
+    def test_post_content_ratings_pingback_iarc_exclude(self, details_mock):
+        details_mock.return_value = True
+        self.app._geodata.update(region_br_iarc_exclude=True,
+                                 region_de_iarc_exclude=True)
+
+        res = self.anon.post(self.url, data=json.dumps(self.data))
+
+        # Verify things were saved to the database.
+        geodata = Geodata.objects.get(addon=self.app)
+        assert not geodata.region_br_iarc_exclude
+        assert not geodata.region_de_iarc_exclude

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -446,7 +446,23 @@ class TestWebapp(amo.tests.TestCase):
         app1 = app_factory()
         region = mkt.regions.BR
         AddonExcludedRegion.objects.create(addon=app1, region=region.id)
-        eq_(get_excluded_in(region.id), [app1.id])
+        self.assertSetEqual(get_excluded_in(region.id), [app1.id])
+
+    def test_excluded_in_iarc(self):
+        app = app_factory()
+        geodata = app._geodata
+        geodata.update(region_br_iarc_exclude=True,
+                       region_de_iarc_exclude=True)
+        self.assertSetEqual(get_excluded_in(mkt.regions.BR.id), [app.id])
+        self.assertSetEqual(get_excluded_in(mkt.regions.DE.id), [app.id])
+
+    def test_excluded_in_iarc_br(self):
+        app = app_factory()
+        geodata = app._geodata
+        geodata.update(region_br_iarc_exclude=False,
+                       region_de_iarc_exclude=True)
+        self.assertSetEqual(get_excluded_in(mkt.regions.BR.id), [])
+        self.assertSetEqual(get_excluded_in(mkt.regions.DE.id), [app.id])
 
     def test_supported_locale_property(self):
         app = app_factory()


### PR DESCRIPTION
**Problem:**
- Exclude pre-IARC unrated public Brazil + Germany games.
- Automatically un-exclude those games once they get a content rating.

**Solution:**
- Add `region_br_iarc_exclude` and `region_de_iarc_exclude` fields to `Geodata` model.
- Unset those fields on the content rating pingback + iarc get app info form
- Exclude Brazil/Germany apps that have their respective Geodata exclude fields set from the AppViewSet
