### PR TITLE
Don't call update_cached_manifests task for hosted apps (bug 945236)

### DIFF
--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -1423,7 +1423,9 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         eq_(update_name.call_count, 1)
         eq_(update_locales.call_count, 1)
         eq_(index_webapps.delay.call_count, 1)
-        eq_(update_cached_manifests.delay.call_count, 1)
+
+        # App is not packaged, no need to call update_cached_manifests.
+        eq_(update_cached_manifests.delay.call_count, 0)
         eq_(storefront_mock.call_count, 1)
 
     @mock.patch('mkt.reviewers.views.messages.success', new=mock.Mock)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1751,7 +1751,7 @@ models.signals.pre_save.connect(save_signal, sender=Webapp,
 
 @receiver(version_changed, dispatch_uid='update_cached_manifests')
 def update_cached_manifests(sender, **kw):
-    if not kw.get('raw'):
+    if not kw.get('raw') and sender.is_packaged:
         from mkt.webapps.tasks import update_cached_manifests
         update_cached_manifests.delay(sender.id)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=945236

Also improve publicise/publicise_version developer pages tests. Similar to the work done for https://bugzilla.mozilla.org/show_bug.cgi?id=960132 except this time more focused on the developer pages. 

The `update_cached_manifests` _task_ already has a similar check, but also doing that check before even calling the task should help Celery - it'll have fewer useless tasks to process.
