### PR TITLE
fixed missing icon in collection autosuggest (bug 959584)

### DIFF
--- a/media/js/zamboni/collections.js
+++ b/media/js/zamboni/collections.js
@@ -402,7 +402,7 @@ if (addon_ac.length) {
         if (!$("#addons-list input[value=" + item.id + "]").length) {
             return $('<li>')
                 .data('item.autocomplete', item)
-                .append('<a><img src="' + item.icon + '">' + item.name + '</a>')
+                .append('<a><img src="' + item.icons[32] + '">' + item.name + '</a>')
                 .appendTo(ul);
         }
     };


### PR DESCRIPTION
Refers to [bug 959584](https://bugzilla.mozilla.org/show_bug.cgi?id=959584).
The 32px icon is displayed.
