### PR TITLE
set storefront data on get app info form (bug 960078)

### DIFF
--- a/mkt/developers/api.py
+++ b/mkt/developers/api.py
@@ -130,8 +130,4 @@ class ContentRatingsPingback(CORSMixin, SlugOrIdMixin, CreateAPIView):
 
             remove_iarc_exclusions(app)
 
-            # Call SET_STOREFRONT_DATA. If the app is approved already we'll
-            # need to let IARC know.
-            app.set_iarc_storefront_data()
-
         return Response('ok')

--- a/mkt/developers/tests/test_api.py
+++ b/mkt/developers/tests/test_api.py
@@ -191,7 +191,9 @@ class TestContentRatingPingback(RestOAuth):
         eq_(res.status_code, 415)
 
     @mock.patch('mkt.webapps.models.Webapp.details_complete')
-    def test_post_content_ratings_pingback(self, details_mock):
+    @mock.patch('mkt.webapps.models.Webapp.set_iarc_storefront_data')
+    def test_post_content_ratings_pingback(self, details_mock,
+                                           storefront_mock):
         details_mock.return_value = True
         eq_(self.app.status, amo.STATUS_NULL)
 
@@ -204,6 +206,7 @@ class TestContentRatingPingback(RestOAuth):
         # IARC info.
         eq_(app.iarc_info.submission_id, 321)
         eq_(app.iarc_info.security_code, 'AB12CD3')
+        assert storefront_mock.called
 
         # Ratings.
         eq_(app.content_ratings.count(), 5)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1160,6 +1160,7 @@ class Webapp(Addon):
                 ratings_body=ratings_body.id, defaults={'rating': rating.id})
             if not created:
                 cr.update(rating=rating.id, modified=datetime.datetime.now())
+        self.set_iarc_storefront_data()  # Ratings updated, sync with IARC.
 
     def set_descriptors(self, data):
         """


### PR DESCRIPTION
Moves the storefront call to set_content_ratings, which effectively makes the storefront call get called in pingback + getappinfo form.
