### PR TITLE
call save instead of update in pingback api (bug 962717)

### DIFF
--- a/mkt/developers/api.py
+++ b/mkt/developers/api.py
@@ -116,9 +116,9 @@ class ContentRatingsPingback(CORSMixin, SlugOrIdMixin, CreateAPIView):
                 app.is_fully_complete(ignore_ratings=True)):
                 log.info('Updating app status from IARC pingback for app:%s' %
                          app.id)
-                # Prevent recursion in Webapp.update_status.
+                # Don't call update to prevent recursion in update_status.
                 app.status = amo.STATUS_PENDING
-                app.update(status=amo.STATUS_PENDING)
+                app.save()
             elif app.has_incomplete_status():
                 log.info('Reasons for app:%s incompleteness after IARC '
                          'pingback: %s' % (app.id, app.completion_errors()))

--- a/mkt/developers/tests/test_api.py
+++ b/mkt/developers/tests/test_api.py
@@ -234,6 +234,7 @@ class TestContentRatingPingback(RestOAuth):
             ['has_shares_info', 'has_shares_location'])
 
         eq_(app.status, amo.STATUS_PENDING)
+        assert app.current_version.nomination
 
     @override_settings(SECRET_KEY='foo')
     def test_token_mismatch(self):
@@ -247,7 +248,7 @@ class TestContentRatingPingback(RestOAuth):
         self.app._geodata.update(region_br_iarc_exclude=True,
                                  region_de_iarc_exclude=True)
 
-        res = self.anon.post(self.url, data=json.dumps(self.data))
+        self.anon.post(self.url, data=json.dumps(self.data))
 
         # Verify things were saved to the database.
         geodata = Geodata.objects.get(addon=self.app)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -547,7 +547,7 @@ class Webapp(Addon):
         """When the submission process is done, update status accordingly."""
         self.update(status=amo.WEBAPPS_UNREVIEWED_STATUS)
 
-    def update_status(self, using=None):
+    def update_status(self, **kwargs):
         if (self.is_deleted or self.is_disabled or
             self.status == amo.STATUS_BLOCKED):
             return


### PR DESCRIPTION
eviljeff reported 2 issues:
- Before the push, some apps were having trouble getting to the pending state.
- After the push, 20+ apps don't have a nomination date set.

We fixed the first issue:
- Before the push, we were getting a [recursion error](http://sentry.dmz.phx1.mozilla.com/addons/marketplace-dev/group/17692/) while updating the app status, causing some apps to not achieve pending state.
- Fixed by https://github.com/mozilla/zamboni/pull/1645 where we checked whether the app was already pending first. In the pingback, we set (but not saved) the app's status to pending in https://github.com/mozilla/zamboni/commit/51845d2f2a796911b650521e181ea542c81d56f9 to make sure this check passed.

However, the second issue:
- Somehow the version's signal to update the nomination date isn't being called or isn't being completed.

**Solution:**

Use save instead of update to
- still prevent the recursion since app.status is set before we save and we keep the is_pending check
- still have the version nomination post_save get triggered by calling save.
