### PR TITLE
Remove fields we don't need in Webapp._meta.translated_fields (bug 961719)

### DIFF
--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1753,8 +1753,16 @@ class WebappIndexer(MappingType, Indexable):
                 .order_by('-id').values_list('id', flat=True))
 
 
-# Pull all translated_fields from Addon over to Webapp.
-Webapp._meta.translated_fields = Addon._meta.translated_fields
+# Set translated_fields manually to avoid querying translations for addon
+# fields we don't use.
+Webapp._meta.translated_fields = [
+    Webapp._meta.get_field('homepage'),
+    Webapp._meta.get_field('privacy_policy'),
+    Webapp._meta.get_field('name'),
+    Webapp._meta.get_field('description'),
+    Webapp._meta.get_field('support_email'),
+    Webapp._meta.get_field('support_url'),
+]
 
 
 @receiver(dbsignals.post_save, sender=Webapp,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=961719

Before:

```
 SELECT `addons`.id, IF(!ISNULL(t1_homepage.localized_string), t1_homepage.created, t2_homepage.created)
            AS homepage_created,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.modified, t2_homepage.modified)
            AS homepage_modified,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.autoid, t2_homepage.autoid)
            AS homepage_autoid,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.id, t2_homepage.id)
            AS homepage_id,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.locale, t2_homepage.locale)
            AS homepage_locale,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.localized_string, t2_homepage.localized_string)
            AS homepage_localized_string,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.localized_string_clean, t2_homepage.localized_string_clean)
            AS homepage_localized_string_clean,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.created, t2_privacypolicy.created)
            AS privacypolicy_created,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.modified, t2_privacypolicy.modified)
            AS privacypolicy_modified,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.autoid, t2_privacypolicy.autoid)
            AS privacypolicy_autoid,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.id, t2_privacypolicy.id)
            AS privacypolicy_id,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.locale, t2_privacypolicy.locale)
            AS privacypolicy_locale,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.localized_string, t2_privacypolicy.localized_string)
            AS privacypolicy_localized_string,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.localized_string_clean, t2_privacypolicy.localized_string_clean)
            AS privacypolicy_localized_string_clean,IF(!ISNULL(t1_thankyou_note.localized_string), t1_thankyou_note.created, t2_thankyou_note.created)
            AS thankyou_note_created,IF(!ISNULL(t1_thankyou_note.localized_string), t1_thankyou_note.modified, t2_thankyou_note.modified)
            AS thankyou_note_modified,IF(!ISNULL(t1_thankyou_note.localized_string), t1_thankyou_note.autoid, t2_thankyou_note.autoid)
            AS thankyou_note_autoid,IF(!ISNULL(t1_thankyou_note.localized_string), t1_thankyou_note.id, t2_thankyou_note.id)
            AS thankyou_note_id,IF(!ISNULL(t1_thankyou_note.localized_string), t1_thankyou_note.locale, t2_thankyou_note.locale)
            AS thankyou_note_locale,IF(!ISNULL(t1_thankyou_note.localized_string), t1_thankyou_note.localized_string, t2_thankyou_note.localized_string)
            AS thankyou_note_localized_string,IF(!ISNULL(t1_thankyou_note.localized_string), t1_thankyou_note.localized_string_clean, t2_thankyou_note.localized_string_clean)
            AS thankyou_note_localized_string_clean,IF(!ISNULL(t1_name.localized_string), t1_name.created, t2_name.created)
            AS name_created,IF(!ISNULL(t1_name.localized_string), t1_name.modified, t2_name.modified)
            AS name_modified,IF(!ISNULL(t1_name.localized_string), t1_name.autoid, t2_name.autoid)
            AS name_autoid,IF(!ISNULL(t1_name.localized_string), t1_name.id, t2_name.id)
            AS name_id,IF(!ISNULL(t1_name.localized_string), t1_name.locale, t2_name.locale)
            AS name_locale,IF(!ISNULL(t1_name.localized_string), t1_name.localized_string, t2_name.localized_string)
            AS name_localized_string,IF(!ISNULL(t1_name.localized_string), t1_name.localized_string_clean, t2_name.localized_string_clean)
            AS name_localized_string_clean,IF(!ISNULL(t1_summary.localized_string), t1_summary.created, t2_summary.created)
            AS summary_created,IF(!ISNULL(t1_summary.localized_string), t1_summary.modified, t2_summary.modified)
            AS summary_modified,IF(!ISNULL(t1_summary.localized_string), t1_summary.autoid, t2_summary.autoid)
            AS summary_autoid,IF(!ISNULL(t1_summary.localized_string), t1_summary.id, t2_summary.id)
            AS summary_id,IF(!ISNULL(t1_summary.localized_string), t1_summary.locale, t2_summary.locale)
            AS summary_locale,IF(!ISNULL(t1_summary.localized_string), t1_summary.localized_string, t2_summary.localized_string)
            AS summary_localized_string,IF(!ISNULL(t1_summary.localized_string), t1_summary.localized_string_clean, t2_summary.localized_string_clean)
            AS summary_localized_string_clean,IF(!ISNULL(t1_eula.localized_string), t1_eula.created, t2_eula.created)
            AS eula_created,IF(!ISNULL(t1_eula.localized_string), t1_eula.modified, t2_eula.modified)
            AS eula_modified,IF(!ISNULL(t1_eula.localized_string), t1_eula.autoid, t2_eula.autoid)
            AS eula_autoid,IF(!ISNULL(t1_eula.localized_string), t1_eula.id, t2_eula.id)
            AS eula_id,IF(!ISNULL(t1_eula.localized_string), t1_eula.locale, t2_eula.locale)
            AS eula_locale,IF(!ISNULL(t1_eula.localized_string), t1_eula.localized_string, t2_eula.localized_string)
            AS eula_localized_string,IF(!ISNULL(t1_eula.localized_string), t1_eula.localized_string_clean, t2_eula.localized_string_clean)
            AS eula_localized_string_clean,IF(!ISNULL(t1_description.localized_string), t1_description.created, t2_description.created)
            AS description_created,IF(!ISNULL(t1_description.localized_string), t1_description.modified, t2_description.modified)
            AS description_modified,IF(!ISNULL(t1_description.localized_string), t1_description.autoid, t2_description.autoid)
            AS description_autoid,IF(!ISNULL(t1_description.localized_string), t1_description.id, t2_description.id)
            AS description_id,IF(!ISNULL(t1_description.localized_string), t1_description.locale, t2_description.locale)
            AS description_locale,IF(!ISNULL(t1_description.localized_string), t1_description.localized_string, t2_description.localized_string)
            AS description_localized_string,IF(!ISNULL(t1_description.localized_string), t1_description.localized_string_clean, t2_description.localized_string_clean)
            AS description_localized_string_clean,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.created, t2_supportemail.created)
            AS supportemail_created,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.modified, t2_supportemail.modified)
            AS supportemail_modified,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.autoid, t2_supportemail.autoid)
            AS supportemail_autoid,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.id, t2_supportemail.id)
            AS supportemail_id,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.locale, t2_supportemail.locale)
            AS supportemail_locale,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.localized_string, t2_supportemail.localized_string)
            AS supportemail_localized_string,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.localized_string_clean, t2_supportemail.localized_string_clean)
            AS supportemail_localized_string_clean,IF(!ISNULL(t1_developercomments.localized_string), t1_developercomments.created, t2_developercomments.created)
            AS developercomments_created,IF(!ISNULL(t1_developercomments.localized_string), t1_developercomments.modified, t2_developercomments.modified)
            AS developercomments_modified,IF(!ISNULL(t1_developercomments.localized_string), t1_developercomments.autoid, t2_developercomments.autoid)
            AS developercomments_autoid,IF(!ISNULL(t1_developercomments.localized_string), t1_developercomments.id, t2_developercomments.id)
            AS developercomments_id,IF(!ISNULL(t1_developercomments.localized_string), t1_developercomments.locale, t2_developercomments.locale)
            AS developercomments_locale,IF(!ISNULL(t1_developercomments.localized_string), t1_developercomments.localized_string, t2_developercomments.localized_string)
            AS developercomments_localized_string,IF(!ISNULL(t1_developercomments.localized_string), t1_developercomments.localized_string_clean, t2_developercomments.localized_string_clean)
            AS developercomments_localized_string_clean,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.created, t2_supporturl.created)
            AS supporturl_created,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.modified, t2_supporturl.modified)
            AS supporturl_modified,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.autoid, t2_supporturl.autoid)
            AS supporturl_autoid,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.id, t2_supporturl.id)
            AS supporturl_id,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.locale, t2_supporturl.locale)
            AS supporturl_locale,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.localized_string, t2_supporturl.localized_string)
            AS supporturl_localized_string,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.localized_string_clean, t2_supporturl.localized_string_clean)
            AS supporturl_localized_string_clean,IF(!ISNULL(t1_the_future.localized_string), t1_the_future.created, t2_the_future.created)
            AS the_future_created,IF(!ISNULL(t1_the_future.localized_string), t1_the_future.modified, t2_the_future.modified)
            AS the_future_modified,IF(!ISNULL(t1_the_future.localized_string), t1_the_future.autoid, t2_the_future.autoid)
            AS the_future_autoid,IF(!ISNULL(t1_the_future.localized_string), t1_the_future.id, t2_the_future.id)
            AS the_future_id,IF(!ISNULL(t1_the_future.localized_string), t1_the_future.locale, t2_the_future.locale)
            AS the_future_locale,IF(!ISNULL(t1_the_future.localized_string), t1_the_future.localized_string, t2_the_future.localized_string)
            AS the_future_localized_string,IF(!ISNULL(t1_the_future.localized_string), t1_the_future.localized_string_clean, t2_the_future.localized_string_clean)
            AS the_future_localized_string_clean,IF(!ISNULL(t1_the_reason.localized_string), t1_the_reason.created, t2_the_reason.created)
            AS the_reason_created,IF(!ISNULL(t1_the_reason.localized_string), t1_the_reason.modified, t2_the_reason.modified)
            AS the_reason_modified,IF(!ISNULL(t1_the_reason.localized_string), t1_the_reason.autoid, t2_the_reason.autoid)
            AS the_reason_autoid,IF(!ISNULL(t1_the_reason.localized_string), t1_the_reason.id, t2_the_reason.id)
            AS the_reason_id,IF(!ISNULL(t1_the_reason.localized_string), t1_the_reason.locale, t2_the_reason.locale)
            AS the_reason_locale,IF(!ISNULL(t1_the_reason.localized_string), t1_the_reason.localized_string, t2_the_reason.localized_string)
            AS the_reason_localized_string,IF(!ISNULL(t1_the_reason.localized_string), t1_the_reason.localized_string_clean, t2_the_reason.localized_string_clean)
            AS the_reason_localized_string_clean FROM `addons` LEFT OUTER JOIN translations t1_homepage
          ON (t1_homepage.id=`addons`.homepage AND t1_homepage.locale='en-us')
LEFT OUTER JOIN translations t2_homepage
          ON (t2_homepage.id=`addons`.homepage AND t2_homepage.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_privacypolicy
          ON (t1_privacypolicy.id=`addons`.privacypolicy AND t1_privacypolicy.locale='en-us')
LEFT OUTER JOIN translations t2_privacypolicy
          ON (t2_privacypolicy.id=`addons`.privacypolicy AND t2_privacypolicy.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_thankyou_note
          ON (t1_thankyou_note.id=`addons`.thankyou_note AND t1_thankyou_note.locale='en-us')
LEFT OUTER JOIN translations t2_thankyou_note
          ON (t2_thankyou_note.id=`addons`.thankyou_note AND t2_thankyou_note.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_name
          ON (t1_name.id=`addons`.name AND t1_name.locale='en-us')
LEFT OUTER JOIN translations t2_name
          ON (t2_name.id=`addons`.name AND t2_name.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_summary
          ON (t1_summary.id=`addons`.summary AND t1_summary.locale='en-us')
LEFT OUTER JOIN translations t2_summary
          ON (t2_summary.id=`addons`.summary AND t2_summary.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_eula
          ON (t1_eula.id=`addons`.eula AND t1_eula.locale='en-us')
LEFT OUTER JOIN translations t2_eula
          ON (t2_eula.id=`addons`.eula AND t2_eula.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_description
          ON (t1_description.id=`addons`.description AND t1_description.locale='en-us')
LEFT OUTER JOIN translations t2_description
          ON (t2_description.id=`addons`.description AND t2_description.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_supportemail
          ON (t1_supportemail.id=`addons`.supportemail AND t1_supportemail.locale='en-us')
LEFT OUTER JOIN translations t2_supportemail
          ON (t2_supportemail.id=`addons`.supportemail AND t2_supportemail.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_developercomments
          ON (t1_developercomments.id=`addons`.developercomments AND t1_developercomments.locale='en-us')
LEFT OUTER JOIN translations t2_developercomments
          ON (t2_developercomments.id=`addons`.developercomments AND t2_developercomments.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_supporturl
          ON (t1_supporturl.id=`addons`.supporturl AND t1_supporturl.locale='en-us')
LEFT OUTER JOIN translations t2_supporturl
          ON (t2_supporturl.id=`addons`.supporturl AND t2_supporturl.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_the_future
          ON (t1_the_future.id=`addons`.the_future AND t1_the_future.locale='en-us')
LEFT OUTER JOIN translations t2_the_future
          ON (t2_the_future.id=`addons`.the_future AND t2_the_future.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_the_reason
          ON (t1_the_reason.id=`addons`.the_reason AND t1_the_reason.locale='en-us')
LEFT OUTER JOIN translations t2_the_reason
          ON (t2_the_reason.id=`addons`.the_reason AND t2_the_reason.locale=`addons`.`defaultlocale`)
             WHERE `addons`.id IN (87); args=('en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us')
```

After:

```
SELECT `addons`.id, IF(!ISNULL(t1_homepage.localized_string), t1_homepage.created, t2_homepage.created)
            AS homepage_created,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.modified, t2_homepage.modified)
            AS homepage_modified,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.autoid, t2_homepage.autoid)
            AS homepage_autoid,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.id, t2_homepage.id)
            AS homepage_id,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.locale, t2_homepage.locale)
            AS homepage_locale,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.localized_string, t2_homepage.localized_string)
            AS homepage_localized_string,IF(!ISNULL(t1_homepage.localized_string), t1_homepage.localized_string_clean, t2_homepage.localized_string_clean)
            AS homepage_localized_string_clean,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.created, t2_privacypolicy.created)
            AS privacypolicy_created,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.modified, t2_privacypolicy.modified)
            AS privacypolicy_modified,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.autoid, t2_privacypolicy.autoid)
            AS privacypolicy_autoid,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.id, t2_privacypolicy.id)
            AS privacypolicy_id,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.locale, t2_privacypolicy.locale)
            AS privacypolicy_locale,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.localized_string, t2_privacypolicy.localized_string)
            AS privacypolicy_localized_string,IF(!ISNULL(t1_privacypolicy.localized_string), t1_privacypolicy.localized_string_clean, t2_privacypolicy.localized_string_clean)
            AS privacypolicy_localized_string_clean,IF(!ISNULL(t1_name.localized_string), t1_name.created, t2_name.created)
            AS name_created,IF(!ISNULL(t1_name.localized_string), t1_name.modified, t2_name.modified)
            AS name_modified,IF(!ISNULL(t1_name.localized_string), t1_name.autoid, t2_name.autoid)
            AS name_autoid,IF(!ISNULL(t1_name.localized_string), t1_name.id, t2_name.id)
            AS name_id,IF(!ISNULL(t1_name.localized_string), t1_name.locale, t2_name.locale)
            AS name_locale,IF(!ISNULL(t1_name.localized_string), t1_name.localized_string, t2_name.localized_string)
            AS name_localized_string,IF(!ISNULL(t1_name.localized_string), t1_name.localized_string_clean, t2_name.localized_string_clean)
            AS name_localized_string_clean,IF(!ISNULL(t1_description.localized_string), t1_description.created, t2_description.created)
            AS description_created,IF(!ISNULL(t1_description.localized_string), t1_description.modified, t2_description.modified)
            AS description_modified,IF(!ISNULL(t1_description.localized_string), t1_description.autoid, t2_description.autoid)
            AS description_autoid,IF(!ISNULL(t1_description.localized_string), t1_description.id, t2_description.id)
            AS description_id,IF(!ISNULL(t1_description.localized_string), t1_description.locale, t2_description.locale)
            AS description_locale,IF(!ISNULL(t1_description.localized_string), t1_description.localized_string, t2_description.localized_string)
            AS description_localized_string,IF(!ISNULL(t1_description.localized_string), t1_description.localized_string_clean, t2_description.localized_string_clean)
            AS description_localized_string_clean,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.created, t2_supportemail.created)
            AS supportemail_created,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.modified, t2_supportemail.modified)
            AS supportemail_modified,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.autoid, t2_supportemail.autoid)
            AS supportemail_autoid,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.id, t2_supportemail.id)
            AS supportemail_id,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.locale, t2_supportemail.locale)
            AS supportemail_locale,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.localized_string, t2_supportemail.localized_string)
            AS supportemail_localized_string,IF(!ISNULL(t1_supportemail.localized_string), t1_supportemail.localized_string_clean, t2_supportemail.localized_string_clean)
            AS supportemail_localized_string_clean,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.created, t2_supporturl.created)
            AS supporturl_created,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.modified, t2_supporturl.modified)
            AS supporturl_modified,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.autoid, t2_supporturl.autoid)
            AS supporturl_autoid,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.id, t2_supporturl.id)
            AS supporturl_id,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.locale, t2_supporturl.locale)
            AS supporturl_locale,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.localized_string, t2_supporturl.localized_string)
            AS supporturl_localized_string,IF(!ISNULL(t1_supporturl.localized_string), t1_supporturl.localized_string_clean, t2_supporturl.localized_string_clean)
            AS supporturl_localized_string_clean FROM `addons` LEFT OUTER JOIN translations t1_homepage
          ON (t1_homepage.id=`addons`.homepage AND t1_homepage.locale='en-us')
LEFT OUTER JOIN translations t2_homepage
          ON (t2_homepage.id=`addons`.homepage AND t2_homepage.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_privacypolicy
          ON (t1_privacypolicy.id=`addons`.privacypolicy AND t1_privacypolicy.locale='en-us')
LEFT OUTER JOIN translations t2_privacypolicy
          ON (t2_privacypolicy.id=`addons`.privacypolicy AND t2_privacypolicy.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_name
          ON (t1_name.id=`addons`.name AND t1_name.locale='en-us')
LEFT OUTER JOIN translations t2_name
          ON (t2_name.id=`addons`.name AND t2_name.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_description
          ON (t1_description.id=`addons`.description AND t1_description.locale='en-us')
LEFT OUTER JOIN translations t2_description
          ON (t2_description.id=`addons`.description AND t2_description.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_supportemail
          ON (t1_supportemail.id=`addons`.supportemail AND t1_supportemail.locale='en-us')
LEFT OUTER JOIN translations t2_supportemail
          ON (t2_supportemail.id=`addons`.supportemail AND t2_supportemail.locale=`addons`.`defaultlocale`)
LEFT OUTER JOIN translations t1_supporturl
          ON (t1_supporturl.id=`addons`.supporturl AND t1_supporturl.locale='en-us')
LEFT OUTER JOIN translations t2_supporturl
          ON (t2_supporturl.id=`addons`.supporturl AND t2_supporturl.locale=`addons`.`defaultlocale`)
             WHERE `addons`.id IN (87); args=('en-us', 'en-us', 'en-us', 'en-us', 'en-us', 'en-us')
```

Still unreadable, buy a lot less useless `JOIN`s.
