### PR TITLE
Don't bother respecting Accept if we only have one renderer (bug 956860)

### DIFF
--- a/mkt/api/renderers.py
+++ b/mkt/api/renderers.py
@@ -2,6 +2,7 @@ import json
 
 from django.http.multipartparser import parse_header
 
+from rest_framework.negotiation import DefaultContentNegotiation
 from rest_framework.renderers import JSONRenderer
 
 
@@ -27,3 +28,21 @@ class SuccinctJSONRenderer(JSONRenderer):
 
         return json.dumps(data, cls=self.encoder_class, indent=indent,
                           ensure_ascii=self.ensure_ascii, separators=(',', ':'))
+
+
+class FirstAvailableRenderer(DefaultContentNegotiation):
+    """
+    Content Negotiation class that ignores the Accept header when there is only
+    one renderer set on the view. Since most of our views only use the default
+    renderer list, which contains only SuccinctJSONRenderer, this means we
+    don't have to parse the Accept header for those.
+
+    Override content_negotiation_class in your class if you need something
+    different.
+    """
+    def select_renderer(self, request, renderers, format_suffix=None):
+        if len(renderers) == 1:
+            return renderers[0]
+        else:
+            return super(FirstAvailableRenderer, self).select_renderer(self,
+                request, renderers, format_suffix=format_suffix)

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -280,6 +280,9 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'mkt.api.renderers.SuccinctJSONRenderer',
     ),
+    'DEFAULT_CONTENT_NEGOTIATION_CLASS': (
+        'mkt.api.renderers.FirstAvailableRenderer'
+    ),
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',
         'rest_framework.parsers.FormParser',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=956860

The performance win is probably minimal, but maybe we should try this? The default negotiation class loops over `Accept` values to find an appropriate renderer but we don't particularly care about that, since we only support JSON anyway.
