### PR TITLE
rename EULA to End-User License Agreement (bug 962265)

### DIFF
--- a/apps/addons/templates/addons/button.html
+++ b/apps/addons/templates/addons/button.html
@@ -86,8 +86,7 @@
   {% endif %}
   {% if addon.eula %}
     <a class="eula" href="{{ url('addons.eula', addon.slug) }}">
-      {# L10n: EULA stands for End-User License Agreement. #}
-      <strong>{{ _('View EULA') }}</strong>
+      <strong>{{ _('View End-User License Agreement') }}</strong>
     </a>
   {% endif %}
 

--- a/apps/addons/templates/addons/details_box.html
+++ b/apps/addons/templates/addons/details_box.html
@@ -125,7 +125,7 @@
                   <th>{{ _('EULA') }}</th>
                   <td>
                     <a href="{{ url('addons.eula', addon.slug) }}">
-                      {{ _('View EULA') }}</a>
+                      {{ _('View End-User License Agreement') }}</a>
                   </td>
                 </tr>
                 {% endif %}

--- a/apps/addons/templates/addons/eula.html
+++ b/apps/addons/templates/addons/eula.html
@@ -12,10 +12,9 @@
 {% block primary %}
 <section class="primary" id="eula">
   <hgroup class="hero">
-    {# L10n: EULA stand for End User License Agreement #}
     {{ impala_breadcrumbs([(addon.type_url(), amo.ADDON_TYPES[addon.type]),
                            (detail_url, addon.name),
-                           (None, _('EULA'))]) }}
+                           (None, _('End-User License Agreement'))]) }}
     {{ addon_heading(addon, version) }}
   </hgroup>
   <div class="prose">

--- a/apps/addons/templates/addons/impala/button.html
+++ b/apps/addons/templates/addons/impala/button.html
@@ -47,7 +47,7 @@
   {% endif %}
   {% if addon.eula %}
     <a class="eula badge" href="{{ url('addons.eula', addon.slug) }}">
-      {{ _('EULA') }}
+      {{ _('End-User License Agreement') }}
     </a>
   {% endif %}
 

--- a/apps/addons/templates/addons/mobile/button.html
+++ b/apps/addons/templates/addons/mobile/button.html
@@ -30,8 +30,7 @@
   {% endif %}
   {% if addon.eula %}
     <a class="eula" href="{{ url('addons.eula', addon.slug) }}">
-      {# L10n: EULA stands for End-User License Agreement. #}
-      {{ _('View EULA') }}
+      {{ _('View End-User License Agreement') }}
     </a>
   {% endif %}
 </div> {# install #}

--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -221,10 +221,10 @@ class LicenseForm(AMOModelForm):
 class PolicyForm(TranslationFormMixin, AMOModelForm):
     """Form for editing the add-ons EULA and privacy policy."""
     has_eula = forms.BooleanField(required=False,
-        label=_lazy(u'This add-on has an End User License Agreement'))
+        label=_lazy(u'This add-on has an End-User License Agreement'))
     eula = TransField(widget=TransTextarea(), required=False,
         label=_lazy(u"Please specify your add-on's "
-                    "End User License Agreement:"))
+                    "End-User License Agreement:"))
     has_priv = forms.BooleanField(
         required=False, label=_lazy(u"This add-on has a Privacy Policy"))
     privacy_policy = TransField(widget=TransTextarea(), required=False,

--- a/apps/devhub/templates/devhub/includes/policy_form.html
+++ b/apps/devhub/templates/devhub/includes/policy_form.html
@@ -1,6 +1,6 @@
 {% from "devhub/includes/macros.html" import tip, some_html_tip %}
 <tr>
-  <th>{{ tip(_('EULA'),
+  <th>{{ tip(_('End-User License Agreement'),
              _('Users will be required to accept the following End-User License Agreement (EULA) prior to installing your add-on. The presence of a EULA significantly affects the number of downloads an add-on receives. Please note that a EULA is not the same as a code license, such as the GPL or MPL.')) }}</th>
   <td>
     {{ policy_form.has_eula }}

--- a/apps/discovery/templates/discovery/addons/detail.html
+++ b/apps/discovery/templates/discovery/addons/detail.html
@@ -31,7 +31,7 @@
   {% endif %}
   {% if addon.eula %}
     <li class="eula"><a href="{{ url('addons.eula', addon.slug, src='discovery-learnmore') }}">
-      {{ _('View EULA') }}</a></li>
+      {{ _('View End-User License Agreement') }}</a></li>
   {% endif %}
 </ul>
 

--- a/apps/discovery/tests/test_views.py
+++ b/apps/discovery/tests/test_views.py
@@ -413,7 +413,7 @@ class TestDetails(amo.tests.TestCase):
     def test_install_button_eula(self):
         doc = pq(self.client.get(self.detail_url).content)
         eq_(doc('#install .install-button').text(), 'Download Now')
-        eq_(doc('#install .eula').text(), 'View EULA')
+        eq_(doc('#install .eula').text(), 'View End-User License Agreement')
         doc = pq(self.client.get(self.eula_url).content)
         eq_(doc('#install .install-button').text(), 'Download Now')
 

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1928,14 +1928,14 @@ class TestReview(ReviewBase):
         eq_(bool(self.addon.has_eula), False)
         r = self.client.get(self.url)
         eq_(r.status_code, 200)
-        self.assertNotContains(r, 'View EULA')
+        self.assertNotContains(r, 'View End-User License Agreement')
 
         self.addon.eula = 'Test!'
         self.addon.save()
         eq_(bool(self.addon.has_eula), True)
         r = self.client.get(self.url)
         eq_(r.status_code, 200)
-        self.assertContains(r, 'View EULA')
+        self.assertContains(r, 'View End-User License Agreement')
 
     def test_privacy_policy_displayed(self):
         eq_(self.addon.privacy_policy, None)


### PR DESCRIPTION
Changed in the following templates:
- apps/addons/templates/addons/button.html
- apps/addons/templates/addons/impala/button.html
- apps/addons/templates/addons/mobile/button.html
- apps/discovery/templates/discovery/addons/detail.html
