### PR TITLE
Fixes tests broken by b89e5e0, part 2

### DIFF
--- a/mkt/api/serializers.py
+++ b/mkt/api/serializers.py
@@ -1,5 +1,4 @@
-from django.http import QueryDict
-from django.utils.simplejson import JSONDecodeError
+from django.conf import settings
 
 import commonware.log
 from rest_framework import serializers
@@ -95,7 +94,10 @@ class URLSerializerMixin(serializers.ModelSerializer):
 
     def get_url(self, obj):
         if 'request' in self.context and hasattr(self.Meta, 'url_basename'):
-            return reverse('%s-detail' % self.Meta.url_basename,
-                           request=self.context['request'],
-                           kwargs={'pk': obj.pk})
+            request = self.context['request']
+            namespace = ''
+            if request.API_VERSION != settings.API_CURRENT_VERSION:
+                namespace = 'api-v%d:' % request.API_VERSION
+            return reverse('%s%s-detail' % (namespace, self.Meta.url_basename,),
+                           request=request, kwargs={'pk': obj.pk})
         return None

--- a/mkt/feed/tests/test_views.py
+++ b/mkt/feed/tests/test_views.py
@@ -4,7 +4,6 @@ import json
 from nose.tools import eq_, ok_
 
 from django.core.urlresolvers import reverse
-from django.test.utils import override_settings
 
 import mkt.carriers
 import mkt.regions
@@ -59,7 +58,6 @@ class FeedAppMixin(object):
         return feedapps
 
 
-@override_settings(API_CURRENT_VERSION=2)
 class BaseTestFeedItemViewSet(RestOAuth):
     def setUp(self):
         super(BaseTestFeedItemViewSet, self).setUp()
@@ -78,7 +76,7 @@ class TestFeedItemViewSetList(CollectionMixin, BaseTestFeedItemViewSet):
     """
     def setUp(self):
         super(TestFeedItemViewSetList, self).setUp()
-        self.url = reverse('feeditem-list')
+        self.url = reverse('api-v2:feeditem-list')
         self.item = FeedItem.objects.create(collection=self.collection)
 
     def list(self, client, **kwargs):
@@ -112,7 +110,7 @@ class TestFeedItemViewSetCreate(CollectionMixin, BaseTestFeedItemViewSet):
     """
     def setUp(self):
         super(TestFeedItemViewSetCreate, self).setUp()
-        self.url = reverse('feeditem-list')
+        self.url = reverse('api-v2:feeditem-list')
 
     def create(self, client, **kwargs):
         res = client.post(self.url, json.dumps(kwargs))
@@ -148,7 +146,8 @@ class TestFeedItemViewSetDetail(CollectionMixin, BaseTestFeedItemViewSet):
     def setUp(self):
         super(TestFeedItemViewSetDetail, self).setUp()
         self.item = FeedItem.objects.create(collection=self.collection)
-        self.url = reverse('feeditem-detail', kwargs={'pk': self.item.pk})
+        self.url = reverse('api-v2:feeditem-detail',
+                           kwargs={'pk': self.item.pk})
 
     def detail(self, client, **kwargs):
         res = client.get(self.url, kwargs)
@@ -179,7 +178,8 @@ class TestFeedItemViewSetUpdate(CollectionMixin, BaseTestFeedItemViewSet):
     def setUp(self):
         super(TestFeedItemViewSetUpdate, self).setUp()
         self.item = FeedItem.objects.create(collection=self.collection)
-        self.url = reverse('feeditem-detail', kwargs={'pk': self.item.pk})
+        self.url = reverse('api-v2:feeditem-detail',
+                           kwargs={'pk': self.item.pk})
 
     def update(self, client, **kwargs):
         res = client.patch(self.url, json.dumps(kwargs))
@@ -215,7 +215,8 @@ class TestFeedItemViewSetDelete(CollectionMixin, BaseTestFeedItemViewSet):
     def setUp(self):
         super(TestFeedItemViewSetDelete, self).setUp()
         self.item = FeedItem.objects.create(collection=self.collection)
-        self.url = reverse('feeditem-detail', kwargs={'pk': self.item.pk})
+        self.url = reverse('api-v2:feeditem-detail',
+                           kwargs={'pk': self.item.pk})
 
     def delete(self, client, **kwargs):
         res = client.delete(self.url)
@@ -236,7 +237,6 @@ class TestFeedItemViewSetDelete(CollectionMixin, BaseTestFeedItemViewSet):
         eq_(res.status_code, 204)
 
 
-@override_settings(API_CURRENT_VERSION=2)
 class BaseTestFeedAppViewSet(FeedAppMixin, RestOAuth):
     fixtures = FeedAppMixin.fixtures + RestOAuth.fixtures
 
@@ -260,7 +260,7 @@ class TestFeedAppViewSetList(BaseTestFeedAppViewSet):
 
     def setUp(self):
         super(TestFeedAppViewSetList, self).setUp()
-        self.url = reverse('feedapp-list')
+        self.url = reverse('api-v2:feedapp-list')
         self.create_feedapps(self.num)
 
     def list(self, client):
@@ -296,7 +296,7 @@ class TestFeedAppViewSetCreate(BaseTestFeedAppViewSet):
 
     def setUp(self):
         super(TestFeedAppViewSetCreate, self).setUp()
-        self.url = reverse('feedapp-list')
+        self.url = reverse('api-v2:feedapp-list')
 
     def create(self, client, **kwargs):
         res = client.post(self.url, json.dumps(kwargs))
@@ -380,7 +380,8 @@ class TestFeedAppViewSetDetail(BaseTestFeedAppViewSet):
     def setUp(self):
         super(TestFeedAppViewSetDetail, self).setUp()
         self.feedapp = self.create_feedapps(1)[0]
-        self.url = reverse('feedapp-detail', kwargs={'pk': self.feedapp.pk})
+        self.url = reverse('api-v2:feedapp-detail',
+                           kwargs={'pk': self.feedapp.pk})
 
     def detail(self, client, **kwargs):
         res = client.get(self.url)
@@ -416,7 +417,8 @@ class TestFeedAppViewSetUpdate(BaseTestFeedAppViewSet):
     def setUp(self):
         super(TestFeedAppViewSetUpdate, self).setUp()
         self.feedapp = self.create_feedapps(1)[0]
-        self.url = reverse('feedapp-detail', kwargs={'pk': self.feedapp.pk})
+        self.url = reverse('api-v2:feedapp-detail',
+                           kwargs={'pk': self.feedapp.pk})
 
     def update(self, client, **kwargs):
         res = client.patch(self.url, json.dumps(kwargs))
@@ -461,7 +463,8 @@ class TestFeedAppViewSetDelete(BaseTestFeedAppViewSet):
     def setUp(self):
         super(TestFeedAppViewSetDelete, self).setUp()
         self.feedapp = self.create_feedapps(1)[0]
-        self.url = reverse('feedapp-detail', kwargs={'pk': self.feedapp.pk})
+        self.url = reverse('api-v2:feedapp-detail',
+                           kwargs={'pk': self.feedapp.pk})
 
     def delete(self, client, **kwargs):
         res = client.delete(self.url)


### PR DESCRIPTION
Since URL patterns are cached, using `override_settings` to change `API_CURRENT_VERSION` for one module of tests does not also change the URL patterns dependent on that setting. This patch hardcodes the namespace into the reverses of that module (accomplishing the same thing as `override_settings`) and refactors `URLSerializerMixin` to be sensitive to the changes in b89e5e0 that affect URL reversal for different API versions.

r? @diox
