### PR TITLE
redirect / to /edit on devhub (bug 963407)

### DIFF
--- a/mkt/developers/tests/test_views_edit.py
+++ b/mkt/developers/tests/test_views_edit.py
@@ -145,6 +145,10 @@ class TestEditListingWebapp(TestEdit):
         eq_(pq(r.content)('title').text(),
             'Edit Listing | %s | Firefox Marketplace' % self.webapp.name)
 
+    def test_redirect(self):
+        r = self.client.get(self.url.replace('edit', ''))
+        self.assert3xx(r, self.url)
+
     def test_nav_links(self):
         r = self.client.get(self.url)
         doc = pq(r.content)('.edit-addon-nav')

--- a/mkt/developers/urls.py
+++ b/mkt/developers/urls.py
@@ -7,6 +7,8 @@ from lib.misc.urlconf_decorator import decorate
 
 import amo
 from amo.decorators import write
+from amo.urlresolvers import reverse
+
 from mkt.api.base import SubRouter
 from mkt.developers.api import ContentRatingList, ContentRatingsPingback
 from mkt.developers.api_payments import (
@@ -45,6 +47,9 @@ def provider_patterns(prefix):
 
 # These will all start with /app/<app_slug>/
 app_detail_patterns = patterns('',
+    # Redirect people who go to / instead of /edit.
+    ('^$', lambda r, app_slug: http.HttpResponseRedirect(
+     reverse('mkt.developers.apps.edit', args=[app_slug]))),
     url('^edit$', views.edit, name='mkt.developers.apps.edit'),
     url('^edit_(?P<section>[^/]+)(?:/(?P<editable>[^/]+))?$',
         views.addons_section, name='mkt.developers.apps.section'),


### PR DESCRIPTION
- `/app/APP_SLUG` leads to detail page
- `/comm/app/APP_SLUG` leads to communication page
- `/developers/app/APP_SLUG` gives a 404

Let's redirect `/developers/app/APP_SLUG` to `/developers/app/APP_SLUG/edit`
