### PR TITLE
remove the EULA button in the search results in the mobile template (bug 962336)

### DIFF
--- a/media/css/mobile/search.less
+++ b/media/css/mobile/search.less
@@ -55,7 +55,8 @@
         margin: 0;
     }
     .buttons,
-    .privacy-policy {
+    .privacy-policy,
+    .eula {
         display: none;
     }
 }


### PR DESCRIPTION
I hided it, as for the privacy-policy button/link on the same page.
