### PR TITLE
Add API endpoint returning consumer information (bug 964524)

### DIFF
--- a/docs/api/topics/fireplace.rst
+++ b/docs/api/topics/fireplace.rst
@@ -59,3 +59,25 @@ Error reporter
     **Response**
 
     :status 204: Message sent.
+
+Consumer Information
+====================
+
+.. http:get:: /api/v1/fireplace/consumer-info/
+
+    Return information about the client making the request.
+
+    **Response**
+
+    :param region: The region slug for this client.
+    :type region: string
+
+    If user authentication information is passed to the request, the following
+    will also be added to the response:
+
+    :param developed: IDs of apps the user has developed.
+    :type active: array
+    :param installed: IDs of apps the user has installed.
+    :type active: array
+    :param purchased: IDs of apps the user has purchased.
+    :type active: array

--- a/mkt/fireplace/urls.py
+++ b/mkt/fireplace/urls.py
@@ -2,13 +2,16 @@ from django.conf.urls import include, patterns, url
 
 from rest_framework.routers import SimpleRouter
 
-from mkt.fireplace.api import AppViewSet, FeaturedSearchView
+from mkt.fireplace.api import AppViewSet, ConsumerInfoView, FeaturedSearchView
 
 apps = SimpleRouter()
 apps.register(r'app', AppViewSet, base_name='fireplace-app')
 
 urlpatterns = patterns('',
     url(r'^fireplace/', include(apps.urls)),
+    url(r'^fireplace/consumer-info/',
+        ConsumerInfoView.as_view(),
+        name='fireplace-consumer-info'),
     url(r'^fireplace/search/featured/',
         FeaturedSearchView.as_view(),
         name='fireplace-featured-search-api'),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=964524

This new API endppoint returns the region slug, and if the user is logged in, the list of apps ids he has installed, developed and purchased.

Note that we can't remove the user-specific info from the endpoints that use them for the moment, because some API users might be using it, but that's a topic for another bug.

r? @cvan
