### PR TITLE
assert set_content_ratings triggers es reindex (bug 932324)

### DIFF
--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -630,6 +630,15 @@ class TestApi(RestOAuth, ESTestCase):
         eq_(data['meta']['offset'], 2)
         eq_(data['meta']['next'], None)
 
+    def test_content_ratings_reindex(self):
+        self.webapp.set_content_ratings({
+            mkt.ratingsbodies.ESRB: mkt.ratingsbodies.ESRB_T
+        })
+        self.refresh('webapp')
+        res = self.client.get(self.url)
+        obj = res.json['objects'][0]
+        ok_(obj['content_ratings']['ratings'])
+
 
 class TestApiFeatures(RestOAuth, ESTestCase):
     fixtures = fixture('webapp_337141')


### PR DESCRIPTION
The search view returns null content ratings for apps that do have content ratings. The index is out of date of such apps. Make sure to update the index whenever they update their content ratings.
