### PR TITLE
move game unexcludes to set_content_ratings

### DIFF
--- a/mkt/developers/api.py
+++ b/mkt/developers/api.py
@@ -13,7 +13,6 @@ import lib.iarc
 from mkt.api.base import CORSMixin, SlugOrIdMixin
 from mkt.developers.forms import ContentRatingForm
 from mkt.webapps.models import ContentRating, Webapp
-from mkt.webapps.utils import remove_iarc_exclusions
 
 
 log = commonware.log.getLogger('z.devhub')
@@ -130,7 +129,5 @@ class ContentRatingsPingback(CORSMixin, SlugOrIdMixin, CreateAPIView):
             # Ratings page. We want descriptors and interactives visible by
             # the time it's refreshed.
             app.set_content_ratings(data.get('ratings', {}))
-
-            remove_iarc_exclusions(app)
 
         return Response('ok')

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -47,7 +47,6 @@ from mkt.regions.utils import parse_region
 from mkt.site.forms import AddonChoiceField
 from mkt.webapps.models import Webapp
 from mkt.webapps.tasks import index_webapps
-from mkt.webapps.utils import remove_iarc_exclusions
 
 
 from . import tasks
@@ -1179,7 +1178,6 @@ class IARCGetAppInfoForm(happyforms.Form):
             app.set_interactives(row.get('interactives', []))
             app.set_content_ratings(row.get('ratings', {}))
 
-            remove_iarc_exclusions(app)
         else:
             msg = _('Invalid submission ID or security code.')
             self._errors['submission_id'] = self.error_class([msg])

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -579,6 +579,19 @@ class TestWebapp(amo.tests.TestCase):
         })
         ok_(not Geodata.objects.get(addon=app).region_de_usk_exclude)
 
+    def test_set_content_ratings_iarc_unexclude(self):
+        app = app_factory()
+        app._geodata.update(region_br_iarc_exclude=True,
+                            region_de_iarc_exclude=True)
+
+        app.set_content_ratings({
+            mkt.ratingsbodies.USK: mkt.ratingsbodies.USK_12
+        })
+
+        geodata = Geodata.objects.get(addon=app)
+        ok_(not geodata.region_br_iarc_exclude)
+        ok_(not geodata.region_de_iarc_exclude)
+
     def test_set_descriptors(self):
         app = app_factory()
         eq_(RatingDescriptors.objects.count(), 0)

--- a/mkt/webapps/utils.py
+++ b/mkt/webapps/utils.py
@@ -148,18 +148,3 @@ def filter_content_ratings_by_region(content_ratings, region=None):
         content_ratings['regions'] = _filter_iarc_obj_by_region(
             content_ratings['regions'], region=region)
     return content_ratings
-
-
-def remove_iarc_exclusions(app):
-    """
-    Remove Germany/Brazil exclusions based on attained content ratings.
-    """
-    from mkt.webapps.models import Geodata
-    if not Geodata.objects.filter(addon=app).exists():
-        return
-
-    geodata = app._geodata
-    if geodata.region_br_iarc_exclude or geodata.region_de_iarc_exclude:
-        geodata.update(region_br_iarc_exclude=False,
-                       region_de_iarc_exclude=False)
-        log.info('Un-excluding IARC-excluded app:%s from br/de')


### PR DESCRIPTION
Just a small code quality thing. Centralize stuff that should always happen into the central content ratings method.
