### PR TITLE
fix amo search suggestion icons (bug 959584)

### DIFF
--- a/media/js/impala/formset.js
+++ b/media/js/impala/formset.js
@@ -196,7 +196,7 @@ $.zAutoFormset = function(o) {
         }).data('autocomplete')._renderItem = function(ul, item) {
             if (!findItem(item).visible) {
                 var $a = $(format('<a><img src="{0}">{1}</a>',
-                                  [item.icon, item.name]));
+                                  [item.icons['32'], item.name]));
                 return $('<li>').data('item.autocomplete', item)
                                 .append($a).appendTo(ul);
             }

--- a/media/js/impala/site_suggestions.js
+++ b/media/js/impala/site_suggestions.js
@@ -31,10 +31,10 @@
                             cls: '',
                             subtitle: ''
                         };
-                        if (item.icon) {
+                        if (item.icons['32']) {
                             d.icon = format(
                                 'style="background-image:url({0})"',
-                                escape_(item.icon)
+                                escape_(item.icons['32'])
                             );
                         }
                         if (item.cls) {

--- a/media/js/zamboni/collections.js
+++ b/media/js/zamboni/collections.js
@@ -395,14 +395,14 @@ if (addon_ac.length) {
         },
         select: function(event, ui) {
             $('#addon-ac').val(ui.item.name).attr('data-id', ui.item.id)
-            .attr('data-icon', ui.item.icons[32]);
+            .attr('data-icon', ui.item.icons['32']);
             return false;
         }
     }).data('autocomplete')._renderItem = function(ul, item) {
         if (!$("#addons-list input[value=" + item.id + "]").length) {
             return $('<li>')
                 .data('item.autocomplete', item)
-                .append('<a><img src="' + item.icons[32] + '">' + item.name + '</a>')
+                .append('<a><img src="' + item.icons['32'] + '">' + item.name + '</a>')
                 .appendTo(ul);
         }
     };

--- a/media/js/zamboni/devhub.js
+++ b/media/js/zamboni/devhub.js
@@ -548,7 +548,7 @@ function initRequiredAddons() {
         hiddenField: 'dependent_addon',
         addedCB: function(emptyForm, item) {
             var f = template(emptyForm)({
-                icon: item.icon,
+                icon: item.icons['32'],
                 name: item.name || ''
             });
             // Firefox automatically escapes the contents of `href`, borking

--- a/media/js/zamboni/tests/suggestions_tests.js
+++ b/media/js/zamboni/tests/suggestions_tests.js
@@ -145,10 +145,10 @@ function processResults(settings) {
                         cls: '',
                         subtitle: '',
                     };
-                    if (item.icon) {
+                    if (item.icons['32']) {
                         d.icon = format(
                             'style="background-image:url({0})"',
-                            escape_(item.icon)
+                            escape_(item.icons['32'])
                         );
                     }
                     if (item.cls) {


### PR DESCRIPTION
Applied [@vinyll 's fix](https://github.com/mozilla/zamboni/commit/85c160001ffc9f7e0d5e80a8013d0086764c26a7) to search suggestions.

Icons now an object of different icon sizes rather than one URL. Change search suggestions to reflect as such.
