### PR TITLE
modify rating instance rather than the constant class on serialize (bug 963217)

### DIFF
--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -365,11 +365,13 @@ def slugify_iarc_name(obj):
     return obj.iarc_name.lower().replace(' ', '-')
 
 
-def dehydrate_rating(rating):
+def dehydrate_rating(rating_class):
     """
     Returns a rating with translated fields attached and with fields that are
     easily created dynamically.
     """
+    rating = rating_class()
+
     if rating.label is None:
         rating.label = str(rating.age) or slugify_iarc_name(rating)
     if rating.name is None:
@@ -388,8 +390,10 @@ def dehydrate_rating(rating):
     return rating
 
 
-def dehydrate_ratings_body(body):
+def dehydrate_ratings_body(body_class):
     """Returns a rating body with translated fields attached."""
+    body = body_class()
+
     if body.label is None:
         body.label = slugify_iarc_name(body)
 

--- a/mkt/constants/tests/test_ratingsbodies.py
+++ b/mkt/constants/tests/test_ratingsbodies.py
@@ -1,4 +1,7 @@
+from contextlib import contextmanager
+
 from nose.tools import eq_
+from tower import activate
 
 import amo.tests
 
@@ -65,3 +68,25 @@ class TestRatingsBodies(amo.tests.TestCase):
             assert isinstance(body.name, unicode)
             assert body.label and body.label != str(None)
             assert isinstance(body.description, unicode)
+
+    @contextmanager
+    def tower_activate(self, region):
+        try:
+            activate(region)
+            yield
+        finally:
+            activate('en-US')
+
+    def test_dehydrate_rating_language(self):
+        self.create_switch('iarc')
+
+        with self.tower_activate('es'):
+            rating = ratingsbodies.dehydrate_rating(ratingsbodies.ESRB_T)
+            eq_(rating.name, 'Adolescente')
+
+        with self.tower_activate('fr'):
+            rating = ratingsbodies.dehydrate_rating(ratingsbodies.ESRB_T)
+            eq_(rating.name, 'Adolescents')
+
+        rating = ratingsbodies.dehydrate_rating(ratingsbodies.ESRB_T)
+        eq_(rating.name, 'Teen')

--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -136,13 +136,13 @@ class TestAppSerializer(amo.tests.TestCase):
              'body_label': 'classind',
              'rating': 'For ages 18+',
              'rating_label': '18',
-             'description': unicode(ratingsbodies.CLASSIND_18.description)})
+             'description': unicode(ratingsbodies.DESC_LAZY) % 18})
         eq_(res['content_ratings']['ratings']['generic'],
             {'body': 'Generic',
              'body_label': 'generic',
              'rating': 'For ages 18+',
              'rating_label': '18',
-             'description': unicode(ratingsbodies.GENERIC_18.description)})
+             'description': unicode(ratingsbodies.DESC_LAZY) % 18})
 
     def test_content_ratings_by_region(self):
         self.create_switch('iarc')
@@ -530,13 +530,13 @@ class TestESAppToDict(amo.tests.ESTestCase):
              'body_label': 'classind',
              'rating': 'For ages 18+',
              'rating_label': '18',
-             'description': unicode(ratingsbodies.CLASSIND_18.description)})
+             'description': unicode(ratingsbodies.DESC_LAZY) % 18})
         eq_(res['content_ratings']['ratings']['generic'],
             {'body': 'Generic',
              'body_label': 'generic',
              'rating': 'For ages 18+',
              'rating_label': '18',
-             'description': unicode(ratingsbodies.GENERIC_18.description)})
+             'description': unicode(ratingsbodies.DESC_LAZY) % 18})
 
         eq_(dict(res['content_ratings']['descriptors']),
             {'esrb': [{'label': 'blood', 'name': 'Blood'}],


### PR DESCRIPTION
Fixing my blunder found by @diox. I was modifying actual constant classes, causing the classes to be globally modified per user request for an app. 

Make and return instances when dehydrating.
