### PR TITLE
Ensure collection add-on comments get saved properly (Bug 961906)

### DIFF
--- a/apps/bandwagon/models.py
+++ b/apps/bandwagon/models.py
@@ -307,11 +307,14 @@ class Collection(CollectionBase, amo.models.ModelBase):
              .update(ordering=ordering, modified=now))
 
         for addon, comment in comments.iteritems():
-            c = (CollectionAddon.objects.using('default')
-                 .filter(collection=self.id, addon=addon))
-            if c.exists():
-                c[0].comments = comment
-                c[0].save(force_update=True)
+            try:
+                c = (CollectionAddon.objects.using('default')
+                     .get(collection=self.id, addon=addon))
+            except CollectionAddon.DoesNotExist:
+                pass
+            else:
+                c.comments = comment
+                c.save(force_update=True)
 
         self.save()
 

--- a/apps/bandwagon/tests/test_models.py
+++ b/apps/bandwagon/tests/test_models.py
@@ -9,8 +9,8 @@ import amo
 import amo.tests
 from access.models import Group
 from addons.models import Addon, AddonRecommendation
-from bandwagon.models import (Collection, CollectionUser, CollectionWatcher,
-                              RecommendedCollection)
+from bandwagon.models import (Collection, CollectionAddon, CollectionUser,
+                              CollectionWatcher, RecommendedCollection)
 from devhub.models import ActivityLog
 from bandwagon import tasks
 from users.models import UserProfile
@@ -121,6 +121,15 @@ class TestCollections(amo.tests.TestCase):
         eq_(activitylog_count(amo.LOG.REMOVE_FROM_COLLECTION), delete_cnt)
         eq_(get_addons(c), addons)
         eq_(c.addons.count(), len(addons))
+
+    def test_set_addons_comment(self):
+        addons = list(Addon.objects.values_list('id', flat=True))
+        c = Collection.objects.create(author=self.user)
+
+        c.set_addons(addons, {addons[0]: 'This is a comment.'});
+        collection_addon = CollectionAddon.objects.get(collection=c,
+                                                       addon=addons[0])
+        eq_(collection_addon.comments, 'This is a comment.')
 
     def test_publishable_by(self):
         c = Collection(pk=512, author=self.other)


### PR DESCRIPTION
As mentioned in [Bug 961906](https://bugzilla.mozilla.org/show_bug.cgi?id=961906), any comments added to add-ons within collections were not being persisted. This should fix the issue by using slightly different syntax.

I believe the original problem stemmed from the fact that every time `c[0]` is referenced we actually get a new instance of the object.
