### PR TITLE
Don't fuzzy query on multi-word search terms

### DIFF
--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -395,6 +395,12 @@ class TestApi(RestOAuth, ESTestCase):
         obj = res.json['objects'][0]
         eq_(obj['slug'], self.webapp.app_slug)
 
+    def test_fuzzy_match(self):
+        res = self.client.get(self.url, data={'q': 'soemthing'})
+        eq_(res.status_code, 200)
+        obj = res.json['objects'][0]
+        eq_(obj['slug'], self.webapp.app_slug)
+
     def test_icu_folding(self):
         self.webapp.name = {'es': 'Páginas Amarillos'}
         self.webapp.save()

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -52,6 +52,16 @@ class TestSearchFilters(BaseOAuth):
         ok_('"query": "search terms"' in qs_str)
         # TODO: Could do more checking here.
 
+    def test_fuzzy_single_word(self):
+        qs = self._filter(self.req, {'q': 'term'})
+        qs_str = json.dumps(qs)
+        ok_('fuzzy' in qs_str)
+
+    def test_no_fuzzy_multi_word(self):
+        qs = self._filter(self.req, {'q': 'search terms'})
+        qs_str = json.dumps(qs)
+        ok_('fuzzy' not in qs_str)
+
     def _addon_type_check(self, query, expected=amo.ADDON_WEBAPP):
         qs = self._filter(self.req, query)
         ok_({'term': {'type': expected}} in qs['filter']['and'],

--- a/mkt/search/views.py
+++ b/mkt/search/views.py
@@ -39,9 +39,13 @@ def name_only_query(q):
         'term': {'value': q, 'boost': 10},  # Exact match.
         'text': {'query': q, 'boost': 3, 'analyzer': 'standard'},
         'text': {'query': q, 'boost': 4, 'type': 'phrase'},
-        'fuzzy': {'value': q, 'boost': 2, 'prefix_length': 4},
         'startswith': {'value': q, 'boost': 1.5}
     }
+    # Only add fuzzy queries if q is a single word. It doesn't make sense to do
+    # a fuzzy query for multi-word queries.
+    if ' ' not in q:
+        rules['fuzzy'] = {'value': q, 'boost': 2, 'prefix_length': 1}
+
     for k, v in rules.iteritems():
         for field in ('name', 'app_slug', 'author'):
             d['%s__%s' % (field, k)] = v


### PR DESCRIPTION
This is a small improvement for misspelled search terms and also optimizes away the fuzzy query for multi-word searches.
