### PR TITLE
Hide contents and validation links for deleted versions (Bug 855894)

### DIFF
--- a/apps/files/decorators.py
+++ b/apps/files/decorators.py
@@ -59,7 +59,11 @@ def file_view(func, **kwargs):
         result = allowed(request, file_)
         if result is not True:
             return result
-        obj = FileViewer(file_, is_webapp=kwargs.get('is_webapp', False))
+        try:
+            obj = FileViewer(file_, is_webapp=kwargs.get('is_webapp', False))
+        except ObjectDoesNotExist:
+            raise http.Http404
+
         response = func(request, obj, *args, **kw)
         if obj.selected:
             response['ETag'] = '"%s"' % obj.selected.get('md5')

--- a/mkt/files/tests/test_views.py
+++ b/mkt/files/tests/test_views.py
@@ -263,6 +263,11 @@ class FilesBase(object):
         eq_(res.status_code, 302)
         self.assert3xx(res, reverse('mkt.files.list', args=ids))
 
+    def test_browse_deleted_version(self):
+        self.file.version.delete()
+        res = self.client.post(self.file_url(), {'left': self.file.id})
+        eq_(res.status_code, 404)
+
     def test_file_chooser(self):
         res = self.client.get(self.file_url())
         doc = pq(res.content)

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -102,12 +102,14 @@
                   <div>
                     {{ file_review_status(product, file) }}
                   </div>
-                  <a href="{{ url('mkt.developers.apps.file_validation', product.app_slug, file) }}">{{ _('Validation') }}</a>
-                  &middot;
-                  <a href="{{ url('mkt.files.list', file) }}">{{ _('Contents') }}</a>
-                  {% if show_diff and version == product.latest_version %}
+                  {% if not version.deleted %}
+                    <a href="{{ url('mkt.developers.apps.file_validation', product.app_slug, file) }}">{{ _('Validation') }}</a>
                     &middot;
-                    <a class="compare" href="{{ url('mkt.files.compare', file, file_compare(file, show_diff)) }}">{{ _('Compare') }}</a>
+                    <a href="{{ url('mkt.files.list', file) }}">{{ _('Contents') }}</a>
+                    {% if show_diff and version == product.latest_version %}
+                      &middot;
+                      <a class="compare" href="{{ url('mkt.files.compare', file, file_compare(file, show_diff)) }}">{{ _('Compare') }}</a>
+                    {% endif %}
                   {% endif %}
                 </span>
               </li>


### PR DESCRIPTION
From [Bug 855894](https://bugzilla.mozilla.org/show_bug.cgi?id=855894), this will hide the contents and validation links for deleted versions in the app history section. It will also raise a 404 if the file attempting to be browsed has had its version deleted (rather than a 500 with traceback).
