### PR TITLE
Don't throw a 500 for DiffViewer with a deleted version (Bug 855894)

### DIFF
--- a/apps/files/decorators.py
+++ b/apps/files/decorators.py
@@ -81,7 +81,11 @@ def compare_file_view(func, **kwargs):
             result = allowed(request, obj)
             if result is not True:
                 return result
-        obj = DiffHelper(one, two, is_webapp=kwargs.get('is_webapp', False))
+        try:
+            obj = DiffHelper(one, two, is_webapp=kwargs.get('is_webapp', False))
+        except ObjectDoesNotExist:
+            raise http.Http404
+
         response = func(request, obj, *args, **kw)
         if obj.left.selected:
             response['ETag'] = '"%s"' % obj.left.selected.get('md5')


### PR DESCRIPTION
After merging https://github.com/mozilla/zamboni/commit/bc91059b804ff82dd769b75e5f8cc377aee3a4dc, we learned that both the file view and the compare file view were susceptible to throwing a traceback when  viewing a file that has had its version deleted.

This should address that and fix the test that broke.
