### PR TITLE
update bleach to 1.4, html5lib to 0.999 (bug 968226)

### DIFF
--- a/apps/addons/tests/test_models.py
+++ b/apps/addons/tests/test_models.py
@@ -933,12 +933,14 @@ class TestAddonModels(amo.tests.TestCase):
 
         eq_(self.newlines_helper(before), after)
 
-    def test_newlines_attribute_link_doublequote(self):
+    @patch('amo.helpers.urlresolvers.get_outgoing_url')
+    def test_newlines_attribute_link_doublequote(self, mock_get_outgoing_url):
+        mock_get_outgoing_url.return_value = 'http://google.com'
         before = '<a href="http://google.com">test</a>'
 
         parsed = self.newlines_helper(before)
 
-        assert parsed.endswith('google.com" rel="nofollow">test</a>')
+        eq_(parsed, '<a rel="nofollow" href="http://google.com">test</a>')
 
     def test_newlines_attribute_singlequote(self):
         before = "<abbr title='laugh out loud'>lol</abbr>"

--- a/apps/amo/tests/test_helpers.py
+++ b/apps/amo/tests/test_helpers.py
@@ -282,7 +282,7 @@ def test_linkify_bounce_url_callback(mock_get_outgoing_url):
 
 
 @patch('amo.helpers.urlresolvers.linkify_bounce_url_callback')
-def test_linkify_with_outgoing(mock_linkify_bounce_url_callback):
+def test_linkify_with_outgoing_text_links(mock_linkify_bounce_url_callback):
     def side_effect(attrs, new=False):
         attrs['href'] = 'bar'
         return attrs
@@ -290,17 +290,42 @@ def test_linkify_with_outgoing(mock_linkify_bounce_url_callback):
     mock_linkify_bounce_url_callback.side_effect = side_effect
 
     # Without nofollow.
-    res = urlresolvers.linkify_with_outgoing('http://example.com',
+    res = urlresolvers.linkify_with_outgoing('a text http://example.com link',
                                              nofollow=False)
-    eq_(res, '<a href="bar">http://example.com</a>')
+    eq_(res, 'a text <a href="bar">http://example.com</a> link')
 
     # With nofollow (default).
-    res = urlresolvers.linkify_with_outgoing('http://example.com')
-    eq_(res, '<a href="bar" rel="nofollow">http://example.com</a>')
+    res = urlresolvers.linkify_with_outgoing('a text http://example.com link')
+    eq_(res, 'a text <a rel="nofollow" href="bar">http://example.com</a> link')
 
-    res = urlresolvers.linkify_with_outgoing('http://example.com',
+    res = urlresolvers.linkify_with_outgoing('a text http://example.com link',
                                              nofollow=True)
-    eq_(res, '<a href="bar" rel="nofollow">http://example.com</a>')
+    eq_(res, 'a text <a rel="nofollow" href="bar">http://example.com</a> link')
+
+
+@patch('amo.helpers.urlresolvers.linkify_bounce_url_callback')
+def test_linkify_with_outgoing_markup_links(mock_linkify_bounce_url_callback):
+    def side_effect(attrs, new=False):
+        attrs['href'] = 'bar'
+        return attrs
+
+    mock_linkify_bounce_url_callback.side_effect = side_effect
+
+    # Without nofollow.
+    res = urlresolvers.linkify_with_outgoing(
+        'a markup <a href="http://example.com">link</a> with text',
+        nofollow=False)
+    eq_(res, 'a markup <a href="bar">link</a> with text')
+
+    # With nofollow (default).
+    res = urlresolvers.linkify_with_outgoing(
+        'a markup <a href="http://example.com">link</a> with text')
+    eq_(res, 'a markup <a rel="nofollow" href="bar">link</a> with text')
+
+    res = urlresolvers.linkify_with_outgoing(
+        'a markup <a href="http://example.com">link</a> with text',
+        nofollow=True)
+    eq_(res, 'a markup <a rel="nofollow" href="bar">link</a> with text')
 
 
 class TestLicenseLink(amo.tests.TestCase):

--- a/apps/amo/tests/test_utils_.py
+++ b/apps/amo/tests/test_utils_.py
@@ -83,17 +83,15 @@ class TestAttachTransDict(amo.tests.TestCase):
                  ('fr', 'French 2 Name')]))
 
 
-class TestRemoveLinks(amo.tests.TestCase):
+def test_has_links():
+    html = 'a text <strong>without</strong> links'
+    assert not amo.utils.has_links(html)
 
-    def test_remove_links(self):
-        html = 'a <a href="http://example.com">link</a> with markup'
-        eq_(amo.utils.remove_links(html), 'a  with markup')
+    html = 'a <a href="http://example.com">link</a> with markup'
+    assert amo.utils.has_links(html)
 
-        html = 'a http://example.com text link'
-        eq_(amo.utils.remove_links(html), 'a  text link')
+    html = 'a http://example.com text link'
+    assert amo.utils.has_links(html)
 
-        html = ('a <a href="http://example.com" title="title" class="class" '
-                'ref="ref">link</a> with markup and '
-                'another link without markup: http://other.com, other stuff')
-        eq_(amo.utils.remove_links(html),
-            'a  with markup and another link without markup: , other stuff')
+    html = 'a badly markuped <a href="http://example.com">link'
+    assert amo.utils.has_links(html)

--- a/apps/bandwagon/forms.py
+++ b/apps/bandwagon/forms.py
@@ -8,7 +8,7 @@ import commonware.log
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 import amo
-from amo.utils import clean_nl, remove_links, slug_validator, slugify
+from amo.utils import clean_nl, has_links, slug_validator, slugify
 from happyforms import Form, ModelForm
 from translations.widgets import TranslationTextInput, TranslationTextarea
 from users.models import UserProfile
@@ -147,7 +147,7 @@ class CollectionForm(ModelForm):
     def clean_description(self):
         description = self.cleaned_data['description']
         normalized = clean_nl(description)
-        if remove_links(normalized) != normalized:
+        if has_links(normalized):
             # There's some links, we don't want them.
             raise forms.ValidationError(_('No links are allowed.'))
         return description

--- a/apps/translations/tests/test_models.py
+++ b/apps/translations/tests/test_models.py
@@ -280,8 +280,8 @@ class TranslationTestCase(TestCase):
         s = '<a id=xx href="http://xxx.com">yay</a> <i>http://yyy.com</i>'
         m = FancyModel.objects.create(purified=s)
         eq_(m.purified.localized_string_clean,
-            '<a href="http://xxx.com" rel="nofollow">yay</a> '
-            '<i><a href="http://yyy.com" rel="nofollow">'
+            '<a rel="nofollow" href="http://xxx.com">yay</a> '
+            '<i><a rel="nofollow" href="http://yyy.com">'
             'http://yyy.com</a></i>')
         eq_(m.purified.localized_string, s)
 
@@ -289,8 +289,8 @@ class TranslationTestCase(TestCase):
         s = '<a id=xx href="http://xxx.com">yay</a> <i>http://yyy.com</i>'
         m = FancyModel.objects.create(linkified=s)
         eq_(m.linkified.localized_string_clean,
-            '<a href="http://xxx.com" rel="nofollow">yay</a> '
-            '&lt;i&gt;<a href="http://yyy.com" rel="nofollow">'
+            '<a rel="nofollow" href="http://xxx.com">yay</a> '
+            '&lt;i&gt;<a rel="nofollow" href="http://yyy.com">'
             'http://yyy.com</a>&lt;/i&gt;')
         eq_(m.linkified.localized_string, s)
 
@@ -300,8 +300,8 @@ class TranslationTestCase(TestCase):
         m.purified = s
         m.save()
         eq_(m.purified.localized_string_clean,
-            '<a href="http://xxx.com" rel="nofollow">yay</a> '
-            '<i><a href="http://yyy.com" rel="nofollow">'
+            '<a rel="nofollow" href="http://xxx.com">yay</a> '
+            '<i><a rel="nofollow" href="http://yyy.com">'
             'http://yyy.com</a></i>')
         eq_(m.purified.localized_string, s)
 
@@ -311,8 +311,8 @@ class TranslationTestCase(TestCase):
         m.linkified = s
         m.save()
         eq_(m.linkified.localized_string_clean,
-            '<a href="http://xxx.com" rel="nofollow">yay</a> '
-            '&lt;i&gt;<a href="http://yyy.com" rel="nofollow">'
+            '<a rel="nofollow" href="http://xxx.com">yay</a> '
+            '&lt;i&gt;<a rel="nofollow" href="http://yyy.com">'
             'http://yyy.com</a>&lt;/i&gt;')
         eq_(m.linkified.localized_string, s)
 
@@ -320,13 +320,13 @@ class TranslationTestCase(TestCase):
         m = FancyModel.objects.get(id=1)
         eq_(u'%s' % m.purified,
             '<i>x</i> '
-            '<a href="http://yyy.com" rel="nofollow">http://yyy.com</a>')
+            '<a rel="nofollow" href="http://yyy.com">http://yyy.com</a>')
 
     def test_linkified_field_str(self):
         m = FancyModel.objects.get(id=1)
         eq_(u'%s' % m.linkified,
             '&lt;i&gt;x&lt;/i&gt; '
-            '<a href="http://yyy.com" rel="nofollow">http://yyy.com</a>')
+            '<a rel="nofollow" href="http://yyy.com">http://yyy.com</a>')
 
     def test_purifed_linkified_fields_in_template(self):
         m = FancyModel.objects.get(id=1)
@@ -346,10 +346,10 @@ class TranslationTestCase(TestCase):
         s = 'I like http://example.org/awesomepage.html .'
         m = FancyModel.objects.create(linkified=s)
         eq_(m.linkified.localized_string_clean,
-            'I like <a href="http://example.com/'
+            'I like <a rel="nofollow" href="http://example.com/'
             '40979175e3ef6d7a9081085f3b99f2f05447b22ba790130517dd62b7ee59ef94/'
             'http%3A//example.org/'
-            'awesomepage.html" rel="nofollow">http://example.org/awesomepage'
+            'awesomepage.html">http://example.org/awesomepage'
             '.html</a> .')
         eq_(m.linkified.localized_string, s)
 
@@ -501,8 +501,8 @@ class PurifiedTranslationTest(TestCase):
         s = u'<b>markup</b> <a href="http://addons.mozilla.org/foo">bar</a>'
         x = PurifiedTranslation(localized_string=s)
         eq_(x.__html__(),
-            u'<b>markup</b> <a href="http://addons.mozilla.org/foo" '
-            u'rel="nofollow">bar</a>')
+            u'<b>markup</b> <a rel="nofollow" '
+            u'href="http://addons.mozilla.org/foo">bar</a>')
 
     @patch('amo.urlresolvers.get_outgoing_url')
     def test_external_link(self, get_outgoing_url_mock):
@@ -510,8 +510,8 @@ class PurifiedTranslationTest(TestCase):
         s = u'<b>markup</b> <a href="http://example.com">bar</a>'
         x = PurifiedTranslation(localized_string=s)
         eq_(x.__html__(),
-            u'<b>markup</b> <a href="http://external.url" '
-            u'rel="nofollow">bar</a>')
+            u'<b>markup</b> <a rel="nofollow" '
+            u'href="http://external.url">bar</a>')
 
     @patch('amo.urlresolvers.get_outgoing_url')
     def test_external_text_link(self, get_outgoing_url_mock):
@@ -519,8 +519,8 @@ class PurifiedTranslationTest(TestCase):
         s = u'<b>markup</b> http://example.com'
         x = PurifiedTranslation(localized_string=s)
         eq_(x.__html__(),
-            u'<b>markup</b> <a href="http://external.url" '
-            u'rel="nofollow">http://example.com</a>')
+            u'<b>markup</b> <a rel="nofollow" '
+            u'href="http://external.url">http://example.com</a>')
 
 
 class LinkifiedTranslationTest(TestCase):
@@ -531,7 +531,7 @@ class LinkifiedTranslationTest(TestCase):
         s = u'<a href="http://example.com">bar</a>'
         x = LinkifiedTranslation(localized_string=s)
         eq_(x.__html__(),
-            u'<a href="http://external.url" rel="nofollow">bar</a>')
+            u'<a rel="nofollow" href="http://external.url">bar</a>')
 
     def test_forbidden_tags(self):
         s = u'<script>some naughty xss</script> <b>bold</b>'
@@ -554,9 +554,24 @@ class NoLinksTranslationTest(TestCase):
         eq_(x.__html__(), '&lt;script&gt;some naughty xss&lt;/script&gt;')
 
     def test_links_stripped(self):
-        s = u'<a href="http://example.com">bar</a> foo bar'
+        # Link with markup.
+        s = u'a <a href="http://example.com">link</a> with markup'
         x = NoLinksTranslation(localized_string=s)
-        eq_(x.__html__(), u'foo bar')
+        eq_(x.__html__(), u'a  with markup')
+
+        # Text link.
+        s = u'a text http://example.com link'
+        x = NoLinksTranslation(localized_string=s)
+        eq_(x.__html__(), u'a text  link')
+
+        # Text link, markup link, allowed tags, forbidden tags and bad markup.
+        s = (u'a <a href="http://example.com">link</a> with markup, a text '
+             u'http://example.com link, <b>with allowed tags</b>, '
+             u'<script>forbidden tags</script> and <http://bad.markup.com')
+        x = NoLinksTranslation(localized_string=s)
+        eq_(x.__html__(), u'a  with markup, a text  link, '
+                          u'<b>with allowed tags</b>, '
+                          u'&lt;script&gt;forbidden tags&lt;/script&gt; and')
 
 
 class NoLinksNoMarkupTranslationTest(TestCase):
@@ -569,9 +584,24 @@ class NoLinksNoMarkupTranslationTest(TestCase):
             '&lt;b&gt;bold&lt;/b&gt;')
 
     def test_links_stripped(self):
-        s = u'<a href="http://example.com">bar</a> foo bar'
+        # Link with markup.
+        s = u'a <a href="http://example.com">link</a> with markup'
         x = NoLinksNoMarkupTranslation(localized_string=s)
-        eq_(x.__html__(), u'foo bar')
+        eq_(x.__html__(), u'a  with markup')
+
+        # Text link.
+        s = u'a text http://example.com link'
+        x = NoLinksNoMarkupTranslation(localized_string=s)
+        eq_(x.__html__(), u'a text  link')
+
+        # Text link, markup link, forbidden tags and bad markup.
+        s = (u'a <a href="http://example.com">link</a> with markup, a text '
+             u'http://example.com link, <b>with forbidden tags</b>, '
+             u'<script>forbidden tags</script> and <http://bad.markup.com')
+        x = NoLinksNoMarkupTranslation(localized_string=s)
+        eq_(x.__html__(), u'a  with markup, a text  link, '
+                          u'&lt;b&gt;with forbidden tags&lt;/b&gt;, '
+                          u'&lt;script&gt;forbidden tags&lt;/script&gt; and')
 
 
 def test_translation_bool():

--- a/apps/translations/tests/test_util.py
+++ b/apps/translations/tests/test_util.py
@@ -1,15 +1,28 @@
 from nose.tools import eq_
 
 from translations.models import Translation
-from translations.utils import transfield_changed, truncate
+from translations.utils import transfield_changed, truncate, truncate_text
+
+
+def test_truncate_text():
+    eq_(truncate_text('foobar', 5), ('...', 0))
+    eq_(truncate_text('foobar', 5, True), ('fooba...', 0))
+    eq_(truncate_text('foobar', 5, True, 'xxx'), ('foobaxxx', 0))
+    eq_(truncate_text('foobar', 6), ('foobar...', 0))
+    eq_(truncate_text('foobar', 7), ('foobar', 1))
 
 
 def test_truncate():
-    s = '   <p>one</p><ol><li>two</li><li> three</li> </ol><p> four five</p>'
+    s = '   <p>one</p><ol><li>two</li><li> three</li> </ol> four <p>five</p>'
 
     eq_(truncate(s, 100), s)
-    eq_(truncate(s, 6), '   <p>one</p><ol><li>two...</li></ol>')
-    eq_(truncate(s, 11), '   <p>one</p><ol><li>two</li><li>three...</li></ol>')
+    eq_(truncate(s, 6), '<p>one</p><ol><li>two...</li></ol>')
+    eq_(truncate(s, 5, True), '<p>one</p><ol><li>tw...</li></ol>')
+    eq_(truncate(s, 11), '<p>one</p><ol><li>two</li><li>three...</li></ol>')
+    eq_(truncate(s, 15),
+        '<p>one</p><ol><li>two</li><li>three</li></ol>four...')
+    eq_(truncate(s, 13, True, 'xxx'),
+        '<p>one</p><ol><li>two</li><li>three</li></ol>foxxx')
 
 
 def test_transfield_changed():

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -14,7 +14,7 @@ import happyforms
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 import amo
-from amo.utils import clean_nl, log_cef, remove_links, slug_validator
+from amo.utils import clean_nl, has_links, log_cef, slug_validator
 from .models import (UserProfile, UserNotification, BlacklistedUsername,
                      BlacklistedEmailDomain, BlacklistedPassword, DjangoUser)
 from translations.widgets import TranslationTextarea
@@ -335,7 +335,7 @@ class UserEditForm(UserRegisterForm, PasswordMixin):
     def clean_bio(self):
         bio = self.cleaned_data['bio']
         normalized = clean_nl(unicode(bio))
-        if remove_links(normalized) != normalized:
+        if has_links(normalized):
             # There's some links, we don't want them.
             raise forms.ValidationError(_('No links are allowed.'))
         return bio

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,7 +4,7 @@ argparse==1.2.1
 babel==0.9.6
 basket-client==0.3.7
 billiard==2.7.3.34
-bleach==1.2.2
+bleach==1.4
 boto==2.20.0
 cef==0.5
 celery==3.0.24
@@ -50,7 +50,7 @@ GitPython==0.1.7
 google-api-python-client==1.2
 gunicorn==0.17.4
 hera==0.1.2
-html5lib==0.95
+html5lib==0.999
 httplib2==0.8.0
 importlib-no-failure==1.0.2
 jingo==0.7


### PR DESCRIPTION
Bleach 1.4 uses a new version of html5lib (0.999) which deprecated the use of
simpletree.

Two different places were using html5lib, with simpletree, so the code had to
be modified.

Because of the way `bleach.linkify` now works, the `remove_links` hack
isn't working properly, so I splitted the fonctionality in half:
- `has_links`, used in forms to check if there's links (text or markup)
- the "remove links" part is now in `NoLinksMixin.clean_localized_string`
  and uses a combination of `bleach.clean` and `bleach.linkify`

Also, the order of links attributes have changed, so tests needed to be
modified accordingly.
