### PR TITLE
Remove magic that automatically updates *_version when accessed (bug 963662)

### DIFF
--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1129,12 +1129,10 @@ class TestHome(amo.tests.TestCase):
                     (amo.STATUS_LITE, amo.STATUS_UNREVIEWED)]
 
         for addon_status in statuses:
-            addon.status = addon_status[0]
-            addon.save()
-
             file = addon.latest_version.files.all()[0]
-            file.status = addon_status[1]
-            file.save()
+            file.update(status=addon_status[1])
+
+            addon.update(status=addon_status[0])
 
             doc = self.get_pq()
             addon_item = doc('#my-addons .addon-item')

--- a/apps/devhub/tests/test_views_versions.py
+++ b/apps/devhub/tests/test_views_versions.py
@@ -510,8 +510,8 @@ class TestVersionEditFiles(TestVersionEdit):
         eq_(ActivityLog.objects.count(), 0)
         r = self.client.post(self.url, self.formset(*forms, prefix='files'))
 
-        eq_(ActivityLog.objects.count(), 3)
-        log = ActivityLog.objects.order_by('created')[2]
+        eq_(ActivityLog.objects.count(), 2)
+        log = ActivityLog.objects.order_by('created')[1]
         eq_(log.to_string(), u'File delicious_bookmarks-2.1.072-fx.xpi deleted'
                               ' from <a href="/en-US/firefox/addon/a3615'
                               '/versions/2.1.072">Version 2.1.072</a> of <a '

--- a/apps/editors/tests/test_helpers.py
+++ b/apps/editors/tests/test_helpers.py
@@ -331,8 +331,8 @@ class TestReviewHelper(amo.tests.TestCase):
     def setup_data(self, status, delete=[]):
         mail.outbox = []
         ActivityLog.objects.for_addons(self.helper.addon).delete()
+        self.addon.update(status=status)
         self.file.update(status=status)
-        self.addon.status = status
         self.helper = self.get_helper()
         data = self.get_data().copy()
         for key in delete:
@@ -369,12 +369,13 @@ class TestReviewHelper(amo.tests.TestCase):
     def test_nomination_to_public_and_current_version(self):
         for status in helpers.NOMINATED_STATUSES:
             self.setup_data(status, ['addon_files'])
+            self.addon = Addon.objects.get(pk=3615)
             self.addon.update(_current_version=None)
+            assert not self.addon.current_version
 
-            addon = Addon.objects.get(pk=3615)
-            assert not addon.current_version
             self.helper.handler.process_public()
-            assert addon.current_version
+            self.addon = Addon.objects.get(pk=3615)
+            assert self.addon.current_version
 
     def test_nomination_to_public_new_addon(self):
         """ Make sure new add-ons can be made public (bug 637959) """

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -2119,9 +2119,9 @@ class TestReviewPending(ReviewBase):
 
     def setUp(self):
         super(TestReviewPending, self).setUp()
-        self.addon.update(status=amo.STATUS_PUBLIC)
         self.file = File.objects.create(version=self.version,
                                         status=amo.STATUS_UNREVIEWED)
+        self.addon.update(status=amo.STATUS_PUBLIC)
 
     def pending_dict(self):
         files = list(self.version.files.values_list('id', flat=True))
@@ -2133,8 +2133,8 @@ class TestReviewPending(ReviewBase):
         eq_(list(statuses), [amo.STATUS_UNREVIEWED, amo.STATUS_LITE])
 
         r = self.client.post(self.url, self.pending_dict())
-        self.assertRedirects(r, reverse('editors.queue_pending'))
         eq_(self.get_addon().status, amo.STATUS_PUBLIC)
+        self.assertRedirects(r, reverse('editors.queue_pending'))
 
         statuses = (self.version.files.values_list('status', flat=True)
                     .order_by('status'))

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -523,7 +523,7 @@ class Version(amo.models.ModelBase):
 def update_status(sender, instance, **kw):
     if not kw.get('raw'):
         try:
-            instance.addon.update_status(using='default')
+            instance.addon.update_status()
             instance.addon.update_version()
         except models.ObjectDoesNotExist:
             log.info('Got ObjectDoesNotExist processing Version change signal',

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -755,7 +755,7 @@ class TestDownloadsLatest(TestDownloadsBase):
     def test_platform_multiple_objects(self):
         p = Platform.objects.create(id=3)
         f = File.objects.create(platform=p, version=self.file.version,
-                                filename='unst.xpi')
+                                filename='unst.xpi', status=self.file.status)
         url = reverse('downloads.latest',
                       kwargs={'addon_id': self.addon.slug, 'platform': 3})
         self.assert_served_locally(self.client.get(url), file_=f)

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -395,6 +395,7 @@ class TestPublicise(amo.tests.TestCase):
     fixtures = fixture('webapp_337141')
 
     def setUp(self):
+        self.create_switch('iarc')
         self.webapp = self.get_webapp()
         self.webapp.update(status=amo.STATUS_PUBLIC_WAITING)
         self.file = self.webapp.versions.latest().all_files[0]
@@ -424,13 +425,12 @@ class TestPublicise(amo.tests.TestCase):
     def test_publicise(self, update_name, update_locales,
                        update_cached_manifests, index_webapps,
                        storefront_mock):
-        self.create_switch('iarc')
-
         index_webapps.delay.reset_mock()
         eq_(update_name.call_count, 0)
         eq_(update_locales.call_count, 0)
         eq_(update_cached_manifests.delay.call_count, 0)
         eq_(storefront_mock.call_count, 0)
+        eq_(self.get_webapp().status, amo.STATUS_PUBLIC_WAITING)
 
         res = self.client.post(self.publicise_url)
         eq_(res.status_code, 302)

--- a/mkt/developers/tests/test_views_versions.py
+++ b/mkt/developers/tests/test_views_versions.py
@@ -150,8 +150,8 @@ class TestAddVersion(BasePackagedAppTest):
 
     def setUp(self):
         super(TestAddVersion, self).setUp()
-        self.app = amo.tests.app_factory(is_packaged=True,
-                                         version_kw=dict(version='1.0'))
+        self.app = amo.tests.app_factory(
+            complete=True, is_packaged=True, version_kw=dict(version='1.0'))
         self.url = self.app.get_dev_url('versions')
         self.user = UserProfile.objects.get(username='regularuser')
         AddonUser.objects.create(user=self.user, addon=self.app)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -573,6 +573,10 @@ class Webapp(Addon):
             _log('no versions with files')
             return
 
+        # If the app is incomplete, don't update status.
+        if not self.is_fully_complete():
+            return
+
         # If there are no public versions and at least one pending, set status
         # to pending.
         public_statuses = amo.WEBAPPS_APPROVED_STATUSES


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=963662

This removes the magic that sets `_current_version` and `_latest_version` when they are `None` and accessed. Instead, we call both `update_status()` and `update_version()` on the `Addon` everytime a `File` or a `Version` is changed. It will be overkill in some cases but should make sure we always have a `status` on `Addon` that matches the attached `Version` and `File` instances.

In addition, on Marketplace, `update_status()` is different from AMO, and I had to make sure the app was fully complete before changing it to `STATUS_PENDING`.

This broke lots of tests that were cheating and setting the `Addon` in a status that wasn't coherent with its files, so I fixed those tests one by one and it appears to be working fine now.

Tests:
https://ci-addons.allizom.org/job/marketplace-build-branch/24/
https://ci-addons.allizom.org/job/amo-build-branch/45/
