### PR TITLE
endpoint to serve comm attachment downloads (bug 958382)

### DIFF
--- a/docs/api/topics/comm.rst
+++ b/docs/api/topics/comm.rst
@@ -320,7 +320,7 @@ Attachment
 
 .. _attachment-post-label:
 
-.. http:post:: /api/v1/comm/thread/(int:thread_id)/note/(int:note_id)/attachment
+.. http:post:: /api/v1/comm/note/(int:note_id)/attachment
 
     .. note:: Requires authentication and the user to be the author of the note.
 

--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -208,7 +208,7 @@ class CommAttachment(amo.models.ModelBase):
         return 'Note %s - %s' % (self.note.id, self.filepath)
 
     def get_absolute_url(self):
-        return reverse('reviewers.apps.review.attachment', args=[self.pk])
+        return reverse('comm-attachment-detail', args=[self.note_id, self.pk])
 
     def filename(self):
         """Returns the attachment's file name."""

--- a/mkt/comm/urls.py
+++ b/mkt/comm/urls.py
@@ -14,7 +14,7 @@ api_thread.register(
     r'thread/(?P<thread_id>\d+)/note/(?P<note_id>\d+)/replies', ReplyViewSet,
     base_name='comm-note-replies')
 api_thread.register(
-    r'thread/(?P<thread_id>\d+)/note/(?P<note_id>\d+)/attachment',
+    r'note/(?P<note_id>\d+)/attachment',
     AttachmentViewSet, base_name='comm-attachment')
 
 api_patterns = patterns('',


### PR DESCRIPTION
- Was previously pointed towards the reviewers attachment URL which was incorrect.
- Copied the reviewers attachment code.
- Unable to serve download files locally since I probably need to set up my webserver, but it theoretically should work since the code is copied from reviewers.
- Related to https://github.com/mozilla/commbadge/pull/47
