### PR TITLE
Handle Connection Errors in Developers App Keys Page (bug 926630)

### DIFF
--- a/mkt/developers/templates/developers/payments/in-app-keys.html
+++ b/mkt/developers/templates/developers/payments/in-app-keys.html
@@ -29,7 +29,7 @@
         <tr id="in-app-public-key">
           <th class="label">{{ _('Application Key') }}</th>
           {% if key %}
-            <td><input type="text" value="{{ key.public_id() }}" readonly></td>
+            <td><input type="text" value="{{ key_public_id }}" readonly></td>
           {% else %}
             <td class="not-generated">({{ _('Not yet generated.') }})</td>
           {% endif %}


### PR DESCRIPTION
- Move the external call from the template to the view
- If a connection to solitude fails or raises non 200 catch the exception
- Log the problem
- Display a message to the user
- Added an appropriate test
