### PR TITLE
fix exclude unrated games + usk rating refused apps (bug 958319)

### DIFF
--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -670,6 +670,14 @@ class TestApi(RestOAuth, ESTestCase):
         obj = res.json['objects'][0]
         ok_(obj['content_ratings']['ratings'])
 
+    def test_usk_refused_exclude(self):
+        geodata = self.webapp._geodata
+        geodata.update(region_de_usk_exclude=True)
+        self.reindex(Webapp, 'webapp')
+
+        res = self.client.get(self.url, {'region': 'de'})
+        ok_(not res.json['objects'])
+
 
 class TestApiFeatures(RestOAuth, ESTestCase):
     fixtures = fixture('webapp_337141')

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -734,8 +734,14 @@ class Webapp(Addon):
             all_regions = set(mkt.regions.ALL_REGION_IDS)
             # Find every region that does not have payments supported
             # and add that into the exclusions.
-            return excluded.union(
+            excluded = excluded.union(
                 all_regions.difference(self.get_price_region_ids()))
+
+        geo = self.geodata
+        if geo.region_de_iarc_exclude or geo.region_de_usk_exclude:
+            excluded.add(mkt.regions.DE.id)
+        if geo.region_br_iarc_exclude:
+            excluded.add(mkt.regions.BR.id)
 
         return sorted(list(excluded))
 

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -960,6 +960,7 @@ class TestExclusions(amo.tests.TestCase):
     def setUp(self):
         self.app = Webapp.objects.create(premium_type=amo.ADDON_PREMIUM)
         self.app.addonexcludedregion.create(region=mkt.regions.US.id)
+        self.geodata = self.app._geodata
 
     def make_tier(self):
         self.price = Price.objects.get(pk=1)
@@ -977,6 +978,17 @@ class TestExclusions(amo.tests.TestCase):
         (self.price.pricecurrency_set
              .filter(region=mkt.regions.PL.id).update(paid=False))
         ok_(mkt.regions.PL.id in self.app.get_excluded_region_ids())
+
+    def test_usk_rating_refused(self):
+        self.geodata.update(region_de_usk_exclude=True)
+        ok_(mkt.regions.DE.id in self.app.get_excluded_region_ids())
+
+    def test_game_iarc(self):
+        self.geodata.update(region_de_iarc_exclude=True,
+                            region_br_iarc_exclude=True)
+        excluded = self.app.get_excluded_region_ids()
+        ok_(mkt.regions.BR.id in excluded)
+        ok_(mkt.regions.DE.id in excluded)
 
 
 class TestPackagedAppManifestUpdates(amo.tests.TestCase):


### PR DESCRIPTION
- I was incorrectly trying to exclude apps via `AppSerializer.get_queryset` -> `get_excluded_in`.
- I missed a spot when hitting the `SearchView` -> `from_search` -> `region_exclusions`.

@robhudson 
