### PR TITLE
Initializing migration from django-piston to django-restframework (bug 974952)

### DIFF
--- a/apps/api/renderers.py
+++ b/apps/api/renderers.py
@@ -1,0 +1,37 @@
+import json
+
+from rest_framework.renderers import (JSONRenderer as BaseJSONRenderer,
+                                      XMLRenderer)
+
+from amo.utils import JSONEncoder
+
+from .views import render_xml_to_string
+
+
+class JSONRenderer(BaseJSONRenderer):
+
+    encoder_class = JSONEncoder
+
+    def render(self, data, *args, **kwargs):
+        """
+        Serialize with JSONEncoder and reload the json to generate
+        a valid dict.
+        """
+        data = json.loads(json.dumps(data, cls=self.encoder_class))
+        return super(JSONRenderer, self).render(data, *args, **kwargs)
+
+
+class XMLTemplateRenderer(XMLRenderer):
+    """
+    Renders an XML template. Supports `template_name` kwargs from `Response`
+    object or as class attribute.
+    """
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        request = renderer_context['request']
+        response = renderer_context['response']
+        if not hasattr(self, 'template_name') and not response.template_name:
+            raise Exception('the Response object is missing a "template_name"'
+                            ' attribute.')
+        template_name = response.template_name or self.template_name
+        return render_xml_to_string(request, template_name, data)

--- a/apps/api/tests/test_urls.py
+++ b/apps/api/tests/test_urls.py
@@ -1,0 +1,15 @@
+from mock import Mock
+from nose.tools import eq_
+
+from amo.tests import TestCase
+
+from ..urls import SwitchToDRF
+
+
+class TestDRFSwitch(TestCase):
+
+    def test_piston_view(self):
+        view = SwitchToDRF('LanguageView')
+        eq_(view(Mock(), 1).__module__, 'django.http')
+        self.create_switch('drf', db=True)
+        eq_(view(Mock()).__module__, 'rest_framework.response')

--- a/apps/api/tests/test_views.py
+++ b/apps/api/tests/test_views.py
@@ -43,6 +43,27 @@ def test_json_not_implemented():
     eq_(api.views.APIView().render_json({}), '{"msg": "Not implemented yet."}')
 
 
+class DRFMixin(object):
+    """
+    Tests should be run with Piston and DRF.
+    Inheriting this class will waffle switch the tests to DRF views.
+
+    A `test_module_url` property must be set. It should point to any URL
+    referring to the testing view (a 404 is fine). The goal of this property
+    is to ensure that the test collection does use DRF.
+    """
+    def setUp(self):
+        super(DRFMixin, self).setUp()
+        self.create_switch('drf', db=True)
+
+    def test_drf_running(self):
+        """
+        This test makes sure that is it DRF that is running in this test suite.
+        """
+        response = self.client.get(self.test_module_url, follow=True)
+        self.assertTrue('rest_framework' in response.__module__)
+
+
 class UtilsTest(TestCase):
     fixtures = ['base/addon_3615']
 
@@ -581,6 +602,13 @@ class APITest(TestCase):
 
         eq_(response['Access-Control-Allow-Origin'], '*')
         eq_(response['Access-Control-Allow-Methods'], 'GET')
+
+
+class DRFAPITest(DRFMixin, APITest):
+    """
+    Run all APITest tests with DRF.
+    """
+    test_module_url = reverse('api.addon_detail', args=['1.5', 999999])
 
 
 class ListTest(TestCase):
@@ -1303,3 +1331,10 @@ class LanguagePacks(UploadTest):
                                                 <strings><![CDATA[
                                             title=اختر لغة
                                                 ]]></strings>"""))
+
+
+class DRFLanguagePacks(DRFMixin, LanguagePacks):
+    """
+    Run all LanguagePack tests with DRF.
+    """
+    test_module_url = reverse('api.language', args=['1.5'])

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -1,10 +1,11 @@
 from django.conf import settings
 from django.conf.urls import include, patterns, url
 
+import waffle
 from piston.resource import Resource
 
 from addons.urls import ADDON_ID
-from api import authentication, handlers, views
+from api import authentication, handlers, views, views_drf
 
 API_CACHE_TIMEOUT = getattr(settings, 'API_CACHE_TIMEOUT', 500)
 
@@ -52,11 +53,26 @@ appendages.insert(0, '/(?P<list_type>[^/]+)')
 list_regexps = build_urls(base_list_regexp, appendages)
 
 
+class SwitchToDRF(object):
+    """
+    Waffle switch to move from Piston to DRF.
+    """
+    def __init__(self, view_name):
+        self.view_name = view_name
+
+    def __call__(self, *args, **kwargs):
+        if waffle.switch_is_active('drf'):
+            return (getattr(views_drf, self.view_name)
+                    .as_view()(*args, **kwargs))
+        else:
+            return class_view(getattr(views, self.view_name))(*args, **kwargs)
+
+
 api_patterns = patterns('',
     # Addon_details
-    url('addon/%s$' % ADDON_ID, class_view(views.AddonDetailView),
+    url('addon/%s$' % ADDON_ID, SwitchToDRF('AddonDetailView'),
         name='api.addon_detail'),
-    url(r'^get_language_packs$', class_view(views.LanguageView),
+    url(r'^get_language_packs$', SwitchToDRF('LanguageView'),
         name='api.language'),)
 
 for regexp in search_regexps:

--- a/apps/api/views_drf.py
+++ b/apps/api/views_drf.py
@@ -1,0 +1,78 @@
+"""
+This view is a port of the views.py file (using Piston) to DRF.
+It is a work in progress that is supposed to replace the views.py completely.
+"""
+from django.conf import settings
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from tower import ugettext_lazy
+
+import amo
+from addons.models import Addon
+from amo.decorators import allow_cross_site_request
+import api
+
+from .renderers import JSONRenderer, XMLTemplateRenderer
+from .utils import addon_to_dict
+
+
+ERROR = 'error'
+OUT_OF_DATE = ugettext_lazy(
+    u'The API version, {0:.1f}, you are using is not valid.  '
+    u'Please upgrade to the current version {1:.1f} API.')
+
+
+class AddonDetailView(APIView):
+
+    renderer_classes = (XMLTemplateRenderer, JSONRenderer)
+
+    @allow_cross_site_request
+    def get(self, request, addon_id, api_version, format=None):
+        # `settings.URL_FORMAT_OVERRIDE` referers to
+        # https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/negotiation.py#L39
+        self.format = format or request.QUERY_PARAMS.get(
+            getattr(settings, 'URL_FORMAT_OVERRIDE'), 'xml')
+        version = float(api_version)
+        # Check valid version.
+        if version < api.MIN_VERSION or version > api.MAX_VERSION:
+            msg = OUT_OF_DATE.format(version, api.CURRENT_VERSION)
+            return Response({'msg': msg}, template_name='api/message.xml',
+                            status=403)
+        # Retrieve addon.
+        try:
+            addon = (Addon.objects.id_or_slug(addon_id)
+                                  .exclude(type=amo.ADDON_WEBAPP).get())
+        except Addon.DoesNotExist:
+            return Response({'msg': 'Add-on not found!'},
+                            template_name='api/message.xml', status=404)
+        if addon.is_disabled:
+            return Response({'error_level': ERROR, 'msg': 'Add-on disabled.'},
+                            template_name='api/message.xml', status=404)
+        # Context.
+        if self.format == 'json':
+            context = addon_to_dict(addon)
+        else:
+            context = {
+                'api_version': version,
+                'addon': addon,
+                'amo': amo,
+                'version': version
+            }
+        # `template_name` is only used here for XML format. Refactor this if
+        # needed some other way.
+        return Response(context, template_name='api/addon_detail.xml')
+
+
+class LanguageView(APIView):
+
+    renderer_classes = (XMLTemplateRenderer,)
+
+    def get(self, request, api_version):
+        addons = Addon.objects.filter(status=amo.STATUS_PUBLIC,
+                                      type=amo.ADDON_LPAPP,
+                                      appsupport__app=self.request.APP.id,
+                                      disabled_by_user=False).order_by('pk')
+        return Response({'addons': addons, 'show_localepicker': True,
+                         'api_version': api_version},
+                        template_name='api/list.xml')

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1654,3 +1654,6 @@ PAYMENT_PROVIDERS = []
 # The currently-recommended version of the API. Any requests to versions older
 # than this will include the `API-Status: Deprecated` header.
 API_CURRENT_VERSION = 1
+
+# Allow URL style format override. eg. "?format=json"
+URL_FORMAT_OVERRIDE = 'format'

--- a/migrations/756-piston-to-drf.sql
+++ b/migrations/756-piston-to-drf.sql
@@ -1,0 +1,2 @@
+INSERT INTO waffle_switch_amo (name, active, note, created, modified)
+    VALUES ('drf', 0, 'Move from Piston to DRF.', NOW(), NOW());


### PR DESCRIPTION
Moving `api.views` to `api.views_drf` while migrating piston to DRF.

See [bug 974952](https://bugzilla.mozilla.org/show_bug.cgi?id=974952) for further details.
This is part 1: moving `AddonDetailView` and `LanguageView`.
The ticket is being splitted.

Latests tests results are here: https://ci-addons.allizom.org/job/marketplace-build-branch/31/ (passing)
