### PR TITLE
improve devhub navigation bar (bug 750904)

### DIFF
--- a/apps/devhub/templates/devhub/addons/edit.html
+++ b/apps/devhub/templates/devhub/addons/edit.html
@@ -19,7 +19,7 @@
 <header>
   {{ dev_breadcrumbs(addon) }}
   {{ l10n_menu(addon.default_locale) }}
-  <h2>{{ title }}</h2>
+  <h2>{{ addon.name }}</h2>
 </header>
 
 <section class="primary" role="main">

--- a/apps/devhub/templates/devhub/addons/owner.html
+++ b/apps/devhub/templates/devhub/addons/owner.html
@@ -22,7 +22,7 @@
   {% if not webapp %}
     {{ l10n_menu(addon.default_locale) }}
   {% endif %}
-  <h2>{{ title }}</h2>
+  <h2>{{ addon.name }}</h2>
 </header>
 <section id="edit-addon" class="primary devhub-form" role="main">
 <form method="post" class="item" action="">

--- a/apps/devhub/templates/devhub/addons/profile.html
+++ b/apps/devhub/templates/devhub/addons/profile.html
@@ -7,7 +7,7 @@
 <header>
   {{ dev_breadcrumbs(addon, items=[(None, title)]) }}
   {{ l10n_menu(addon.default_locale) }}
-  <h2>{{ title }}</h2>
+  <h2>{{ addon.name }}</h2>
 </header>
 <section class="primary" role="main">
   {% set remove_url = addon.get_dev_url('profile.remove') %}

--- a/apps/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/apps/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -1,29 +1,160 @@
+{% from "includes/forms.html" import tip %}
 {% set urls = [
   (addon.get_dev_url(), _('Edit Listing')),
-  (addon.get_dev_url('owner'), _('Manage Authors') if webapp
-                               else _('Manage Authors & License')),
+  (addon.get_dev_url('owner'), _('Manage Authors & License')),
   (addon.get_dev_url('profile'), _('Manage Developer Profile')),
   (addon.get_dev_url('payments'), _('Manage Payments')),
-  (addon.get_dev_url('versions'), _('Manage App Status') if webapp
-                                  else _('Manage Status & Versions')),
+  (addon.get_dev_url('versions'), _('Manage Status & Versions')),
 ] %}
+
+{% macro status_and_tip(addon, tip) %}
+  <span class="{{ status_class(addon) }}"><b>{{ amo.STATUS_CHOICES[addon.status] }}</b></span>
+  <span class="tip tooltip" title="{{ tip }}">?</span>
+{% endmacro %}
+
 {% if addon.is_premium() and waffle.switch('allow-refund') %}
   {% do urls.insert(4, (addon.get_dev_url('refunds'), loc('Manage Refunds'))) %}
 {% endif %}
-{% if addon.is_webapp() %}
-  {% do urls.insert(4,
-    (addon.get_dev_url('in_app_config'), _('Manage In-App Payments'))
-  ) %}
-{% endif %}
 
 <section class="secondary" role="complementary">
+  <div class="addon-status">
+    <img class="addon-icon" src="{{ addon.icon_url }}">
+    <ul class="addon-details">
+      <li>
+        <strong>
+          {{ _('Status:') }}
+
+          {% if addon.disabled_by_user and addon.status != amo.STATUS_DISABLED %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon,
+                                _("Your add-on's listing is disabled and is not showing
+                                   anywhere in our gallery or update service.")) }}
+            </a>
+          {% elif addon.status == amo.STATUS_NULL %}
+            <a href="{{ url('devhub.submit.resume', addon.slug) }}">
+              {{ status_and_tip(addon, _('Please complete your add-on.')) }}
+            </a>
+          {% elif addon.status == amo.STATUS_PENDING %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon, _('You will receive an email when the review is complete.')) }}
+            </a>
+          {% elif addon.status == amo.STATUS_UNREVIEWED %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon,
+                                _("You will receive an email when the review is complete. Until
+                                   then, your add-on is not listed in our gallery but can be
+                                   accessed directly from its details page.")) }}
+            </a>
+          {% elif addon.status == amo.STATUS_NOMINATED %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon,
+                                _("You will receive an email when the review is complete. Until
+                                   then, your add-on is not listed in our gallery but can be
+                                   accessed directly from its details page. ")) }}
+            </a>
+          {% elif addon.status == amo.STATUS_PUBLIC %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon,
+                                _("Your add-on is displayed in our gallery and users are
+                                   receiving automatic updates.")) }}
+            </a>
+          {% elif addon.status == amo.STATUS_DISABLED %}
+            <a href="{{ addon.get_dev_url('versions') }}#version-upload" class="version-upload">
+              {{ status_and_tip(addon,
+                                _("Your add-on was disabled by a site administrator and is no
+                                   longer shown in our gallery. If you have any questions,
+                                   please email marketplace-staff@mozilla.org.")) }}
+            </a>
+          {% elif addon.status == amo.STATUS_LITE %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon,
+                                _("Your add-on is displayed in our gallery as experimental
+                                   and users are receiving automatic updates. Some features
+                                   are unavailable to your add-on.")) }}
+            </a>
+          {% elif addon.status == amo.STATUS_LITE_AND_NOMINATED %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon,
+                                _("You will receive an email when the full review is complete.
+                                   Until then, your add-on is displayed in our gallery as
+                                   experimental and users are receiving automatic updates.
+                                   Some features are unavailable to your add-on.")) }}
+            </a>
+          {% elif addon.status == amo.STATUS_PURGATORY %}
+            <a href="{{ addon.get_dev_url('versions') }}">
+              {{ status_and_tip(addon,
+                                _("All add-ons hosted in our gallery must now be reviewed by an
+                                   editor. If you wish to continue hosting your add-on, please
+                                   click to select a review process.")) }}
+            </a>
+          {% endif %}
+        </strong>
+      </li>
+      {% if addon.current_version %}
+        <li>
+          <strong>{{ _('Current Version:') }}</strong>
+          <a href="{{ addon.current_version.get_url_path() }}">
+            {{ addon.current_version }}
+            <span class="tip tooltip" title="{{ _('This is the version of your add-on that will
+                                                   be installed if someone clicks the Install
+                                                   button on addons.mozilla.org.') }}">?</span>
+          </a>
+        </li>
+      {% endif %}
+      <li>
+        <strong>{{ _('Last Updated:') }}</strong>
+          {{ addon.last_updated|datetime(_('%b %e, %Y')) }}
+      </li>
+      {% if addon.latest_version and addon.latest_version != addon.current_version %}
+        <li>
+          <strong>{{ _('Next Version:') }}</strong>
+          <a href="{{ addon.latest_version.get_url_path() }}">
+            {{ addon.latest_version.version }}
+            <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however
+                                                   it isn’t live on the site yet.') }}">?</span>
+          </a>
+        </li>
+      {% endif %}
+      {% with position = get_position(addon) %}
+        {% if position and position.pos and position.total %}
+          <li>
+            <strong>{{ _('Queue Position:') }}</strong>
+            {% trans position=position.pos|numberfmt,
+                     total=position.total|numberfmt %}
+              {{ position }} of {{ total }}
+            {% endtrans %}
+          </li>
+        {% endif %}
+      {% endwith %}
+    </ul>
+    <p class="addon-upload">
+      {% if not addon.is_incomplete() and not addon.is_disabled %}
+        <strong>
+          <a href="{{ addon.get_dev_url('versions') }}#version-upload" class="version-upload">{{ _('Upload New Version') }}</a>
+        </strong>
+        &middot;
+      {% endif %}
+      <a href="{{ addon.get_dev_url('versions') }}">{{ _('View All' ) }}</a>
+    </p>
+  </div>
   <div class="highlight" id="edit-addon-nav">
-    <h3>{{ addon.name }}</h3>
     <ul class="refinements">
       {% for url, title in urls %}
         <li {% if url in request.path %}class="selected"{% endif %}>
           <a href="{{ url }}">{{ title }}</a></li>
       {% endfor %}
+      <li class="addon-manage">
+        {% if check_addon_ownership(request, addon, dev=True) %}
+          {% if addon.disabled_by_user and addon.status != amo.STATUS_DISABLED %}
+            <a href="{{ addon.get_dev_url('enable') }}" class="enable-addon">{{ _('Enable Add-on') }}</a>
+          {% elif not addon.is_disabled %}
+            <a href="{{ addon.get_dev_url('versions') }}#disable-addon" class="disable-addon">{{ _('Disable Add-on') }}</a>
+          {% endif %}
+        {% endif %}
+        {% if check_addon_ownership(request, addon) and addon.can_be_deleted() %}
+          <a href="{{ addon.get_dev_url('versions') }}#delete-addon" class="delete-addon">{{ _('Delete Add-on') }}</a>
+        {% endif %}
+      </li>
     </ul>
     <ul class="refinements">
       <li><a href="{{ addon.get_url_path() }}">

--- a/apps/devhub/templates/devhub/payments/payments.html
+++ b/apps/devhub/templates/devhub/payments/payments.html
@@ -11,7 +11,7 @@
 {% block content %}
 <header>
   {{ dev_breadcrumbs(addon, items=[(None, title)]) }}
-  <h2>{{ title }}</h2>
+  <h2>{{ addon.name }}</h2>
 </header>
 <section class="primary payments devhub-form" role="main">
   {% set contrib = addon.takes_contributions and addon.has_full_profile() or errors %}

--- a/apps/devhub/templates/devhub/versions/list.html
+++ b/apps/devhub/templates/devhub/versions/list.html
@@ -14,7 +14,7 @@
 {% block content %}
 <header>
   {{ dev_breadcrumbs(addon, items=[(None, title)]) }}
-  <h2>{{ title }}</h2>
+  <h2>{{ addon.name }}</h2>
 </header>
 <section id="edit-addon" class="primary devhub-form" role="main">
   <h3>{{ _('Current Status') }}</h3>
@@ -134,15 +134,15 @@
         {% endif %}
         {% if check_addon_ownership(request, addon, dev=True) %}
           {% if addon.disabled_by_user and addon.status != amo.STATUS_DISABLED %}
-            <a href="{{ addon.get_dev_url('enable') }}" id="enable-addon">
+            <a href="{{ addon.get_dev_url('enable') }}" class="enable-addon">
               {{ loc('Enable App') if webapp else _('Enable Add-on') }}</a>
           {% elif not addon.is_disabled %}
-            <a href="#" id="disable-addon">
+            <a href="#" class="disable-addon">
               {{ loc('Disable App') if webapp else _('Disable Add-on') }}</a>
           {% endif %}
         {% endif %}
         {% if check_addon_ownership(request, addon) and addon.can_be_deleted() %}
-            &middot; <a href="#" id="delete-addon">
+            &middot; <a href="#" class="delete-addon">
               {{ loc('Delete App') if webapp else _('Delete Add-on') }}</a>
         {% endif %}
         {% if not webapp %}

--- a/apps/devhub/tests/test_views_versions.py
+++ b/apps/devhub/tests/test_views_versions.py
@@ -221,25 +221,25 @@ class TestVersion(amo.tests.TestCase):
         res = self.client.get(self.url)
         doc = pq(res.content)
         assert doc('#modal-disable')
-        assert doc('#disable-addon')
-        assert not doc('#enable-addon')
+        assert doc('.disable-addon')
+        assert not doc('.enable-addon')
 
     def test_not_show_disable(self):
         self.addon.update(status=amo.STATUS_DISABLED, disabled_by_user=False)
         res = self.client.get(self.url)
         doc = pq(res.content)
         assert not doc('#modal-disable')
-        assert not doc('#disable-addon')
+        assert not doc('.disable-addon')
 
     def test_show_enable_button(self):
         self.addon.update(disabled_by_user=True)
         res = self.client.get(self.url)
         doc = pq(res.content)
-        a = doc('#enable-addon')
+        a = doc('.enable-addon')
         assert a, "Expected Enable addon link"
         eq_(a.attr('href'), self.enable_url)
         assert not doc('#modal-disable')
-        assert not doc('#disable-addon')
+        assert not doc('.disable-addon')
 
     def test_cancel_get(self):
         cancel_url = reverse('devhub.addons.cancel', args=['a3615'])

--- a/media/css/impala/developers.less
+++ b/media/css/impala/developers.less
@@ -69,6 +69,13 @@
                 right: 0;
             }
         }
+        ul.refinements li a {
+            padding: 0 10px 0 0;
+        }
+
+        ul.refinements li.selected a {
+            background: url("../../img/zamboni/arrow-left-blue.png") 100% .5em no-repeat;
+        }
     }
 }
 
@@ -353,6 +360,79 @@
     #link-view-all {
         display: block;
         margin-top: 12px;
+    }
+}
+
+/* Devhub navigation panel */
+.secondary {
+    .addon-status {
+        background: white;
+        border: 1px solid @border-blue;
+        border-radius: 8px;
+        clear: both;
+        color: @medium-gray;
+        margin: 0 0 12px;
+        padding: 10px;
+        position: relative;
+        img {
+            left: 10px;
+            position: absolute;
+            top: 12px;
+        }
+        .addon-details {
+            font-size: 12px;
+            margin: 0 0 5px 45px;
+            li:first-child {
+                color: #444;
+            }
+            .tip {
+                border-radius: 6px;
+                font-size: 10px;
+                height: 12px;
+                line-height: 14px;
+                margin-left: 3px;
+                width: 12px;
+            }
+        }
+        .addon-upload {
+            border-top: 1px dotted #94bfce;
+            font-size: 11px;
+            margin: 0;
+            padding-top: 5px;
+        }
+    }
+    ul.refinements {
+        border-bottom: 1px dotted #94bfce;
+        margin-bottom: 1em;
+        padding-bottom: 1em;
+        &:last-child {
+            border-bottom: none;
+        }
+        li a {
+            color: #3d6db5;
+            font-size: .923em;
+            padding: 0 0 0 10px;
+        }
+        li.addon-manage a {
+            display: inline;
+            &:last-child {
+                padding-left: 0;
+                &:before {
+                    content: "\00b7";
+                    padding-right: 5px;
+                }
+            }
+            &:only-child {
+                padding-left: 10px;
+                &:before {
+                    content: "";
+                    padding: 0;
+                }
+            }
+        }
+        li.selected a {
+            background: url("../../img/zamboni/arrow-right-blue.png") 0 .5em no-repeat;
+        }
     }
 }
 

--- a/media/css/zamboni/zamboni.css
+++ b/media/css/zamboni/zamboni.css
@@ -2252,35 +2252,10 @@ form .error .note.error {
     color: #235;
 }
 
-.secondary ul.refinements {
-    border-bottom: 1px dotted #94bfce;
-    padding-bottom: 1em;
-    margin-bottom: 1em;
-}
-
 #refine-results div:last-child ul.refinements {
     border-bottom: 0;
     margin-bottom: 0;
     padding-bottom: 0;
-}
-
-.secondary ul.refinements li a {
-    color: #3d6db5;
-    padding: 0 0 0 10px;
-    font-weight: bold;
-    font-size: .923em;
-}
-
-.html-rtl .secondary ul.refinements li a {
-    padding: 0 10px 0 0;
-}
-
-.secondary ul.refinements li.selected a {
-    background: transparent url("../../img/zamboni/arrow-right-blue.png") 0 .5em no-repeat;
-}
-
-.html-rtl .secondary ul.refinements li.selected a {
-    background: transparent url("../../img/zamboni/arrow-left-blue.png") 100% .5em no-repeat;
 }
 
 /** =Report abuse form *********/

--- a/media/js/zamboni/devhub.js
+++ b/media/js/zamboni/devhub.js
@@ -78,7 +78,7 @@ $(document).ready(function() {
         $('.addon-upload-failure-dependant').attr('disabled', true);
     }
 
-    if ($(".version-upload").length) {
+    if ($(".add-file-modal").length) {
         $modal = $(".add-file-modal").modal(".version-upload", {
             width: '450px',
             hideme: false,
@@ -288,21 +288,31 @@ $(document).ready(function() {
 
     // hook up various links related to current version status
     $('#modal-cancel').modal('#cancel-review', {width: 400});
-    $('#modal-delete').modal('#delete-addon', {
-        width: 400,
-        callback: function(obj) {
-            return fixPasswordField(this);
+    if ($("#modal-delete").length) {
+        $('#modal-delete').modal('.delete-addon', {
+            width: 400,
+            callback: function(obj) {
+                return fixPasswordField(this);
+            }
+        });
+        if (window.location.hash === '#delete-addon') {
+            $modal.render();
         }
-    });
-    $('#modal-disable').modal('#disable-addon', {
-        width: 400,
-        callback: function(d){
-            $('.version_id', this).val($(d.click_target).attr('data-version'));
-            return true;
+    }
+    if ($("#modal-disable").length) {
+        $modal = $('#modal-disable').modal('.disable-addon', {
+            width: 400,
+            callback: function(d){
+                $('.version_id', this).val($(d.click_target).attr('data-version'));
+                return true;
+            }
+        });
+        if (window.location.hash === '#disable-addon') {
+            $modal.render();
         }
-    });
+    }
 
-    $('#enable-addon').bind('click', _pd(function() {
+    $('.enable-addon').bind('click', _pd(function() {
         $.ajax({
             'type': 'POST',
             'url': $(this).attr('href'),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=750904

What that does:
- change the red title (h2) to display add-on name
- modify navigation panel to only bold current link
- create the new "status box" at the top
  - add version information (current/latest version, position in the review queue)
  - add tooltip on status
  - add specific information when a version is being reviewed/rejected

![devhub status box and nav panel](https://f.cloud.github.com/assets/167767/2139483/547d9108-933f-11e3-962b-0aff46308252.png)
