### PR TITLE
prod/settings: use the CDN for LOCAL_MIRROR_URL.

### DIFF
--- a/sites/prod/settings_addons.py
+++ b/sites/prod/settings_addons.py
@@ -10,9 +10,9 @@ SERVER_EMAIL = 'zprod@addons.mozilla.org'
 SECRET_KEY = private_addons.SECRET_KEY
 
 SITE_URL = getattr(private_addons, 'SITE_URL', 'https://' + DOMAIN)
-LOCAL_MIRROR_URL = '%s/_files' % SITE_URL
 SERVICES_URL = 'https://services.addons.mozilla.org'
 STATIC_URL = getattr(private_addons, 'STATIC_URL', 'https://addons.cdn.mozilla.net/')
+LOCAL_MIRROR_URL = '%s_files' % STATIC_URL
 MIRROR_URL = STATIC_URL + 'storage/public-staging'
 
 CSP_STATIC_URL = STATIC_URL[:-1]


### PR DESCRIPTION
This used to need to hit us directly, because there was a delay
uploading content to our mirrors, but now all of that is served from the
CDN, which has no delay.
