### PR TITLE
hook up login + logout with commonplace via shared token (bug 970598)

### DIFF
--- a/mkt/account/tests/test_api.py
+++ b/mkt/account/tests/test_api.py
@@ -336,6 +336,7 @@ class TestLoginHandler(TestCase):
     def setUp(self):
         super(TestLoginHandler, self).setUp()
         self.url = reverse('account-login')
+        self.logout_url = reverse('account-logout')
 
     def post(self, data):
         return self.client.post(self.url, json.dumps(data),
@@ -428,6 +429,16 @@ class TestLoginHandler(TestCase):
         eq_(res.status_code, 400)
         assert 'assertion' in data
         assert not 'apps' in data
+
+    def test_logout(self):
+        profile = UserProfile.objects.create(email='cvan@mozilla.com')
+        profile.create_django_user(
+            backend='django_browserid.auth.BrowserIDBackend')
+        data = self._test_login()
+
+        r = self.client.delete(self.logout_url, {'_user': data['token']},
+                               content_type='application/json')
+        eq_(r.status_code, 204)
 
 
 class TestFeedbackHandler(TestPotatoCaptcha, RestOAuth):

--- a/mkt/account/urls.py
+++ b/mkt/account/urls.py
@@ -1,13 +1,15 @@
 from django.conf.urls import include, patterns, url
 
 from mkt.account.views import (AccountView, FeedbackView, InstalledView,
-                               LoginView, NewsletterView, PermissionsView)
+                               LoginView, LogoutView, NewsletterView,
+                               PermissionsView)
 
 
 drf_patterns = patterns('',
     url('^feedback/$', FeedbackView.as_view(), name='account-feedback'),
     url('^installed/mine/$', InstalledView.as_view(), name='installed-apps'),
     url('^login/$', LoginView.as_view(), name='account-login'),
+    url('^logout/$', LogoutView.as_view(), name='account-logout'),
     url('^newsletter/$', NewsletterView.as_view(), name='account-newsletter'),
     url('^permissions/(?P<pk>[^/]+)/$', PermissionsView.as_view(),
         name='account-permissions'),

--- a/mkt/developers/templates/developers/skeleton_impala.html
+++ b/mkt/developers/templates/developers/skeleton_impala.html
@@ -48,7 +48,7 @@
         data-user="{{ user_data(amo_user)|json }}"
         data-readonly="{{ settings.READ_ONLY|json }}"
         data-media-url="{{ MEDIA_URL }}"
-        data-login-url="{{ url('users.browserid_login') }}"
+        data-login-url="{{ url('account-login') }}"
         data-persona-url="{{ settings.BROWSERID_JS_URL }}"
         data-native-persona-url="{{ settings.NATIVE_BROWSERID_JS_URL }}"
         data-persona-unverified-issuer="{{ settings.UNVERIFIED_ISSUER }}"


### PR DESCRIPTION
(Related to https://github.com/mozilla/commonplace/pull/24): "Not sure if this is what we want, but this allows centralized login/logout so there is no disparity between who you are logged in as no matter which component of Marketplace you are on."
- Set token in localStorage when logging in. Clear token from localStorage when logging out.
- Have Marketplace login use `accounts` API rather than `users.views:browserid_authenticate`.
- When logging in via `accounts` Login API view, also log into Django's auth.
- Add a `accounts` Logout API view that logs out from Django's auth.
