### PR TITLE
create comm notes for each review from reviewer tools (bug 974680)

### DIFF
--- a/media/js/devreg/reviewers/reviewers_commbadge.js
+++ b/media/js/devreg/reviewers/reviewers_commbadge.js
@@ -12,16 +12,15 @@ define('reviewersCommbadge', [], function() {
         return urlparams(url, {'_user': localStorage.getItem('0::user')});
     }
 
-    // Get all of the app's threads.
-    $.get(_userArg(commThreadUrl), function(data) {
-        $threads = $(data.objects);
+    // Fetch all of the app's threads.
+    $.get(_userArg(commThreadUrl), function(threads) {
+        threads = threads.objects;
 
         // Show "this version has not been reviewed" for table w/ no results.
-        var versionIds = [];
-        $threads.each(function(i, thread) {
-            // A roundabout way of finding which tables have no threads, but it
-            // don't have many choices since it depends on the API call.
-            versionIds.push(thread.version);
+        // Gets all version IDs, then adds "No Results" to tables whose
+        // data-version is not in the version IDs list.
+        var versionIds = _.map(threads, function(thread) {
+            return thread.version;
         });
         $('table.activity').each(function(i, table) {
             var $table = $(table);
@@ -33,26 +32,36 @@ define('reviewersCommbadge', [], function() {
             }
         });
 
-        $threads.each(function(i, thread) {
+        function appendNotesToTable(notes, $table) {
+            // Given a list of notes, passes each note into the template
+            // and appends to review history table.
+            notes = notes.objects;
+            for (var i = 0; i < notes.length; i++) {
+                var note = notes[i];
+                var author = note.author_meta.name;
+                var created = moment(note.created).format('MMMM Do YYYY, h:mm:ss a');
+
+                // Append notes to table.
+                $table.append(noteTemplate({
+                    attachments: note.attachments,
+                    body: note.body,
+                    // L10n: {0} is author of note, {1} is a datetime. (e.g. "by Kevin on 2014-01-16").
+                    metadata: format(gettext('By {0} on {1}'),
+                                     [author, created]),
+                    noteType: noteTypes[note.note_type],
+                }));
+            }
+        }
+
+        // Fetch all of the notes for each thread.
+        for (var i = 0; i < threads.length; i++) {
+            var thread = threads[i];
             var $table = $('table.activity[data-version=' + thread.version + ']');
             var commNoteUrl = $itemHistory.data('comm-note-url').replace(threadIdPlaceholder, thread.id);
 
-            // Get all of the thread's notes.
-            $.get(_userArg(commNoteUrl), function(data) {
-                $(data.objects).each(function(i, note) {
-                    var author = note.author_meta.name;
-                    var created = moment(note.created).format('MMMM Do YYYY, h:mm:ss a');
-
-                    // Append notes to table.
-                    $table.append(noteTemplate({
-                        attachments: note.attachments,
-                        body: note.body,
-                        metadata: format(gettext('By {0} on {1}'),
-                                         [author, created]),
-                        noteType: noteTypes[note.note_type],
-                     }));
-                 });
+            $.get(_userArg(commNoteUrl), function(notes) {
+                appendNotesToTable(notes, $table);
             });
-        });
+        }
     });
 });

--- a/media/js/devreg/utils.js
+++ b/media/js/devreg/utils.js
@@ -137,28 +137,12 @@ function baseurl(url) {
 }
 
 
-function getVars(qs, excl_undefined) {
-    if (!qs) qs = location.search;
-    if (!qs || qs === '?') return {};
-    if (qs && qs[0] == '?') {
-        qs = qs.substr(1);  // Filter off the leading ? if it's there.
-    }
-
-    return _.chain(qs.split('&'))  // ['a=b', 'c=d']
-            .map(function(c) {return c.split('=').map(decodeURIComponent);}) //  [['a', 'b'], ['c', 'd']]
-            .filter(function(p) {  // [['a', 'b'], ['c', undefined]] -> [['a', 'b']]
-                return !!p[0] && (!excl_undefined || !_.isUndefined(p[1]));
-            }).object()  // {'a': 'b', 'c': 'd'}
-            .value();
-}
-
-
 function querystring(url) {
     var qpos = url.indexOf('?');
     if (qpos === -1) {
         return {};
     } else {
-        return getVars(url.substr(qpos + 1));
+        return z.getVars(url.substr(qpos + 1));
     }
 }
 

--- a/mkt/comm/__init__.py
+++ b/mkt/comm/__init__.py
@@ -1,1 +1,1 @@
-from mkt.constants.comm import NOTE_TYPES_JSON
+from mkt.constants.comm import U_NOTE_TYPES

--- a/mkt/comm/management/commands/migrate_activity_log.py
+++ b/mkt/comm/management/commands/migrate_activity_log.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
 def _migrate_activity_log(logs, **kwargs):
     """For migrate_activity_log.py script."""
     for log in logs:
-        action = _action_map(log.action)
+        action = cmb.ACTION_MAP(log.action)
 
         # Create thread.
         thread, tc = CommunicationThread.objects.safer_get_or_create(
@@ -72,20 +72,3 @@ def _migrate_activity_log(logs, **kwargs):
                 filepath=attachment.filepath, mimetype=attachment.mimetype,
                 description=attachment.description)
             note_attachment.update(created=attachment.created)
-
-
-def _action_map(activity_action):
-    """Maps ActivityLog action ids to Commbadge note types."""
-    return {
-        amo.LOG.APPROVE_VERSION.id: cmb.APPROVAL,
-        amo.LOG.APPROVE_VERSION_WAITING.id: cmb.APPROVAL,
-        amo.LOG.REJECT_VERSION.id: cmb.REJECTION,
-        amo.LOG.APP_DISABLED.id: cmb.DISABLED,
-        amo.LOG.REQUEST_INFORMATION.id: cmb.MORE_INFO_REQUIRED,
-        amo.LOG.ESCALATE_VERSION.id: cmb.ESCALATION,
-        amo.LOG.ESCALATION_CLEARED.id: cmb.ESCALATION,
-        amo.LOG.ESCALATED_HIGH_ABUSE.id: cmb.ESCALATION,
-        amo.LOG.ESCALATED_HIGH_REFUNDS.id: cmb.ESCALATION,
-        amo.LOG.COMMENT_VERSION.id: cmb.REVIEWER_COMMENT,
-        amo.LOG.WEBAPP_RESUBMIT.id: cmb.RESUBMISSION,
-    }.get(activity_action, cmb.NO_ACTION)

--- a/mkt/comm/utils.py
+++ b/mkt/comm/utils.py
@@ -198,7 +198,7 @@ def send_mail_comm(note):
 
 
 def create_comm_note(app, version, author, body, note_type=comm.NO_ACTION,
-                     perms=None):
+                     perms=None, no_switch=False):
     """
     Creates a note on an app version's thread.
     Creates a thread if a thread doesn't already exist.
@@ -214,7 +214,7 @@ def create_comm_note(app, version, author, body, note_type=comm.NO_ACTION,
              (e.g. {'developer': False, 'staff': True}).
 
     """
-    if not waffle.switch_is_active('comm-dashboard'):
+    if not no_switch and not waffle.switch_is_active('comm-dashboard'):
         return None, None
 
     # Dict of {'read_permission_GROUP_TYPE': boolean}.

--- a/mkt/constants/comm.py
+++ b/mkt/constants/comm.py
@@ -1,5 +1,3 @@
-import json
-
 from tower import ugettext_lazy as _
 
 
@@ -20,6 +18,12 @@ ESCALATION = 5
 REVIEWER_COMMENT = 6
 RESUBMISSION = 7
 
+APPROVE_VERSION_WAITING = 8
+ESCALATION_HIGH_ABUSE = 9
+ESCALATION_HIGH_REFUNDS = 10
+ESCALATION_CLEARED = 11
+REREVIEW_CLEARED = 12
+
 NOTE_TYPES = {
     NO_ACTION: _('No action'),
     APPROVAL: _('Approved'),
@@ -28,7 +32,12 @@ NOTE_TYPES = {
     MORE_INFO_REQUIRED: _('More information requested'),
     ESCALATION: _('Escalated'),
     REVIEWER_COMMENT: _('Comment'),
-    RESUBMISSION: _('App Resubmission'),
+    RESUBMISSION: _('App resubmission'),
+    APPROVE_VERSION_WAITING: _('Approved but waiting to be made public'),
+    ESCALATION_CLEARED: _('Escalation cleared'),
+    ESCALATION_HIGH_ABUSE: _('Escalated due to High Abuse Reports'),
+    ESCALATION_HIGH_REFUNDS: _('Escalated due to High Refund Requests'),
+    REREVIEW_CLEARED: _('Re-review cleared')
 }
 
 
@@ -39,3 +48,29 @@ def NOTE_TYPES_JSON():
 
 # Prefix of the reply to address in comm emails.
 REPLY_TO_PREFIX = 'commreply+'
+
+
+def U_NOTE_TYPES():
+    return dict((key, unicode(value)) for (key, value) in
+                NOTE_TYPES.iteritems())
+
+
+def ACTION_MAP(activity_action):
+    """Maps ActivityLog action ids to Commbadge note types."""
+    import amo
+
+    return {
+        amo.LOG.APPROVE_VERSION.id: APPROVAL,
+        amo.LOG.APPROVE_VERSION_WAITING.id: APPROVAL,
+        amo.LOG.APP_DISABLED.id: DISABLED,
+        amo.LOG.ESCALATE_MANUAL.id: ESCALATION,
+        amo.LOG.ESCALATE_VERSION.id: ESCALATION,
+        amo.LOG.ESCALATED_HIGH_ABUSE.id: ESCALATION_HIGH_ABUSE,
+        amo.LOG.ESCALATED_HIGH_REFUNDS.id: ESCALATION_HIGH_REFUNDS,
+        amo.LOG.ESCALATION_CLEARED.id: ESCALATION_CLEARED,
+        amo.LOG.REQUEST_INFORMATION.id: MORE_INFO_REQUIRED,
+        amo.LOG.REJECT_VERSION.id: REJECTION,
+        amo.LOG.REREVIEW_CLEARED.id: REREVIEW_CLEARED,
+        amo.LOG.WEBAPP_RESUBMIT.id: RESUBMISSION,
+        amo.LOG.COMMENT_VERSION.id: REVIEWER_COMMENT,
+    }.get(activity_action, NO_ACTION)

--- a/mkt/reviewers/templates/reviewers/includes/commbadge_note_template.html
+++ b/mkt/reviewers/templates/reviewers/includes/commbadge_note_template.html
@@ -8,13 +8,13 @@
         <div class="log-group log-attachments">
           <strong>{{ _('Attachments') }}</strong>
           <ul>
-            <% _.each(attachments, function(attachment){ %>
+            <% _.each(attachments, function(attachment) { %>
               <li<% if (attachment.is_image) { %> class="image"<% } %>>
                 <a href="<%= attachment.url %>">
                   <%= attachment.display_name %>
                 </a>
               </li>
-            <% }); %>
+            <% }) %>
           </ul>
         </div>
       <% } %>
@@ -25,7 +25,7 @@
 <script type="text/template" id="no-notes">
   <tr>
     <td class="no-activity">
-      {{ _('This version has not been reviewed.') }}
+      {{ _('This version has not been reviewed') }}
     </td>
   </tr>
 </script>

--- a/mkt/reviewers/templates/reviewers/includes/review_history.html
+++ b/mkt/reviewers/templates/reviewers/includes/review_history.html
@@ -1,109 +1,107 @@
 <div id="history" class="island alpha c">
   <div id="review-files-header">
-    <h3>
-      {{ _('App History') }}
-    </h3>
+    <h3>{{ _('App History') }}</h3>
   </div>
   <table id="review-files" class="item-history">
     {% for i in range(pager.object_list.count(), 0, -1) %}
-    {% set version = pager.object_list[i-1] %}
-    <tr class="listing-header">
-      <th colspan="2">
-        {% trans version = version.version, created = version.created|datetime, version_status = version_status(product, version), developer_name = version.developer_name %}
-        Version {{ version }} &middot; {{ developer_name }} &middot; {{ created }} <span class="light">&middot; {{ version_status }}</span>
-        {% endtrans %}
-      </th>
-    </tr>
-    <tr class="listing-body">
-      {% if product.is_packaged %}
-        <td class="files">
-          {% set version_files = version.all_files %}
-          {% if version_files %}
-            <div><strong>{{ _('Files in this version:') }}</strong></div>
-            <ul>
-            {% for file in version_files %}
-            <li class="file-info">
-              <span class="light">
-                <div>
-                  {{ file_review_status(product, file) }}
-                </div>
-                <a href="{{ url('mkt.developers.apps.file_validation', product.app_slug, file) }}">{{ _('Validation') }}</a>
-                &middot;
-                <a href="{{ url('mkt.files.list', file) }}">{{ _('Contents') }}</a>
-                {% if show_diff and version == product.latest_version %}
-                  &middot;
-                  <a class="compare" href="{{ url('mkt.files.compare', file, file_compare(file, show_diff)) }}">{{ _('Compare') }}</a>
-                {% endif %}
-              </span>
-            </li>
-            {% endfor %}
-            </ul>
-          {% endif %}
-        </td>
-      {% endif %}
-      <td>
-        <table class="activity">
-          {% if version.releasenotes %}
-          <tr>
-            <th>{{ _('Version Notes') }}</th>
-            <td class="activity_version">
-              <div class="history-notes">
-                {{ version.releasenotes|nl2br }}
-              </div>
-            </td>
-          </tr>
-          {% endif %}
-          {% if version.approvalnotes %}
-          <tr>
-            <th>{{ _('Notes for Reviewers') }}</th>
-            <td class="activity_approval">
-              <div class="history-notes">
-                {{ version.approvalnotes|urlize(100)|nl2br }}
-              </div>
-            </td>
-          </tr>
-          {% endif %}
-          {% set records = version.all_activity %}
-          {% for record_version in records %}
-            {% set record = record_version.activity_log %}
-            <tr>
-              <th>
-                {{ record.log.short }}
-              </th>
-              <td>
-                {% trans user=record.user|user_link,
-                         date=record.created|babel_datetime %}
-                  <div>By {{ user }} on {{ date }}</div>
-                {% endtrans %}
-                {% if record.details %}
-                  <div class="log-group log-comments">{{ record.details.comments|nl2br }}</div>
-                {% endif %}
-                {% set attachments = record.activitylogattachment_set.all() %}
-                {% if attachments %}
-                  <div class="log-group log-attachments">
-                    <strong>Attachments</strong>
-                    <ul>
-                      {% for attachment in attachments %}
-                        <li{% if attachment.is_image() %} class="image"{% endif %}>
-                          <a href="{{ attachment.get_absolute_url() }}">{{ attachment.display_name() }}</a>
-                        </li>
-                      {% endfor %}
-                    </ul>
+      {% set version = pager.object_list[i - 1] %}
+      <tr class="listing-header">
+        <th colspan="2">
+          {% trans version = version.version, created = version.created|datetime, version_status = version_status(product, version), developer_name = version.developer_name %}
+          Version {{ version }} &middot; {{ developer_name }} &middot; {{ created }} <span class="light">&middot; {{ version_status }}</span>
+          {% endtrans %}
+        </th>
+      </tr>
+      <tr class="listing-body">
+        {% if product.is_packaged %}
+          <td class="files">
+            {% set version_files = version.all_files %}
+            {% if version_files %}
+              <div><strong>{{ _('Files in this version:') }}</strong></div>
+              <ul>
+              {% for file in version_files %}
+              <li class="file-info">
+                <span class="light">
+                  <div>
+                    {{ file_review_status(product, file) }}
                   </div>
-                {% endif %}
+                  <a href="{{ url('mkt.developers.apps.file_validation', product.app_slug, file) }}">{{ _('Validation') }}</a>
+                  &middot;
+                  <a href="{{ url('mkt.files.list', file) }}">{{ _('Contents') }}</a>
+                  {% if show_diff and version == product.latest_version %}
+                    &middot;
+                    <a class="compare" href="{{ url('mkt.files.compare', file, file_compare(file, show_diff)) }}">{{ _('Compare') }}</a>
+                  {% endif %}
+                </span>
+              </li>
+              {% endfor %}
+              </ul>
+            {% endif %}
+          </td>
+        {% endif %}
+        <td>
+          <table class="activity">
+            {% if version.releasenotes %}
+              <tr>
+                <th>{{ _('Version Notes') }}</th>
+                <td class="activity_version">
+                  <div class="history-notes">
+                    {{ version.releasenotes|nl2br }}
+                  </div>
+                </td>
+              </tr>
+            {% endif %}
+            {% if version.approvalnotes %}
+              <tr>
+                <th>{{ _('Notes for Reviewers') }}</th>
+                <td class="activity_approval">
+                  <div class="history-notes">
+                    {{ version.approvalnotes|urlize(100)|nl2br }}
+                  </div>
+                </td>
+              </tr>
+            {% endif %}
+            {% set records = version.all_activity %}
+            {% for record_version in records %}
+              {% set record = record_version.activity_log %}
+              <tr>
+                <th>
+                  {{ record.log.short }}
+                </th>
+                <td>
+                  {% trans user=record.user|user_link,
+                           date=record.created|babel_datetime %}
+                    <div>By {{ user }} on {{ date }}</div>
+                  {% endtrans %}
+                  {% if record.details %}
+                    <div class="log-group log-comments">{{ record.details.comments|nl2br }}</div>
+                  {% endif %}
+                  {% set attachments = record.activitylogattachment_set.all() %}
+                  {% if attachments %}
+                    <div class="log-group log-attachments">
+                      <strong>Attachments</strong>
+                      <ul>
+                        {% for attachment in attachments %}
+                          <li{% if attachment.is_image() %} class="image"{% endif %}>
+                            <a href="{{ attachment.get_absolute_url() }}">{{ attachment.display_name() }}</a>
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+            {% if not version.releasenotes and not version.approvalnotes and not records %}
+            <tr>
+              <td class="no-activity">
+                {{ _('This version has not been reviewed') }}
               </td>
             </tr>
-          {% endfor %}
-          {% if not version.releasenotes and not version.approvalnotes and not records %}
-          <tr>
-            <td class="no-activity">
-              {{ _('This version has not been reviewed.') }}
-            </td>
-          </tr>
-          {% endif %}
-        </table>
-      </td>
-    </tr>
+            {% endif %}
+          </table>
+        </td>
+      </tr>
     {% endfor %}
   </table>
 </div>

--- a/mkt/reviewers/templates/reviewers/includes/review_history_commbadge.html
+++ b/mkt/reviewers/templates/reviewers/includes/review_history_commbadge.html
@@ -2,7 +2,7 @@
   <div id="review-files-header"><h3>{{ _('App History') }}</h3></div>
 
   <table id="review-files" class="item-history"
-         data-slug="{{ product.app_slug }}" data-note-types="{{ mkt.comm.NOTE_TYPES_JSON() }}"
+         data-slug="{{ product.app_slug }}" data-note-types="{{ mkt.comm.U_NOTE_TYPES()|json }}"
          data-comm-thread-url="{{ url('comm-thread-list')|urlparams(app=product.app_slug) }}"
          data-thread-id-placeholder="0" data-comm-note-url="{{ url('comm-note-list', 0) }}">
     {# Results populated below by reviewers_commbadge.js (Commbadge API) #}
@@ -22,25 +22,32 @@
           <td class="files">
             {% set version_files = version.all_files %}
             {% if version_files %}
-              <div><strong>{{ _('Files in this version:') }}</strong></div>
+              <h4>{{ _('Files in this version:') }}</h4>
               <ul>
-              {% for file in version_files %}
-                <li class="file-info">
-                  <span class="light">
-                    <div>{{ file_review_status(product, file) }}</div>
-                    <a href="{{ url('mkt.developers.apps.file_validation', product.app_slug, file) }}">{{ _('Validation') }}</a>
-                    {% if not version.deleted %}
+                {% for file in version_files %}
+                  <li class="file-info">
+                    <span class="light">
+                      <div>{{ file_review_status(product, file) }}</div>
                       <a href="{{ url('mkt.developers.apps.file_validation', product.app_slug, file) }}">{{ _('Validation') }}</a>
-                      &middot;
-                      <a href="{{ url('mkt.files.list', file) }}">{{ _('Contents') }}</a>
-                      {% if show_diff and version == product.latest_version %}
+                      {% if not version.deleted %}
+                        <a href="{{ url('mkt.developers.apps.file_validation', product.app_slug, file) }}">{{ _('Validation') }}</a>
                         &middot;
-                        <a class="compare" href="{{ url('mkt.files.compare', file, file_compare(file, show_diff)) }}">{{ _('Compare') }}</a>
+                        <a href="{{ url('mkt.files.list', file) }}">{{ _('Contents') }}</a>
+                        {% if show_diff and version == product.latest_version %}
+                          &middot;
+                          <a class="compare" href="{{ url('mkt.files.compare', file, file_compare(file, show_diff)) }}">{{ _('Compare') }}</a>
+                        {% endif %}
                       {% endif %}
-                    {% endif %}
-                  </span>
-                </li>
-              {% endfor %}
+                    </span>
+                  </li>
+                {% endfor %}
+                {% for file in version_files %}
+                  <li class="file-info">
+                    <span class="light">
+                      <div>{{ file_review_status(product, file) }}</div>
+                    </span>
+                  </li>
+                {% endfor %}
               </ul>
             {% endif %}
           </td>


### PR DESCRIPTION
Breaking https://github.com/mozilla/zamboni/pull/1607 up. [Screencast](http://screencast.com/t/d4S8e8Bi9FIf)

~~Part 1: In a waffle, use a separate template for reviewers app history that is populated by the Commbadge API rather than passing in ActivityLog objects through the view.~~

~~[Part 2](https://github.com/ngokevin/zamboni/commit/a42d10a156bea1315070bb192fcaef2153d66ce4): Display Commbadge attachments along with the notes.~~

**[Part 3](https://github.com/ngokevin/zamboni/commit/4482bd15451bb6b122cac6acf42cd9d8784bbd8c): Create Commbadge notes for all review actions.**
- Map ActivityLog action types to Commbadge note types (and create more note types for those that are missing).
- Every time in Reviewer Tools we log an action, create a Commbadge note.
- Lot of the changes are correctly indenting the review history template.

[Part 4](https://github.com/ngokevin/zamboni/commit/1605848103a934f1a8d1264d23ad32bf1afdbecc): Create Commbadge attachments from reviewer tools.

[Part 5](https://github.com/ngokevin/zamboni/commit/1d9acc274afe7a7a29d468b4bf78dee6b527ea89): Paginate Commbadge notes if a lot exist for a version.
