### PR TITLE
Fix URL for the app preview posting API (bug 974957)

### DIFF
--- a/mkt/submit/tests/test_api.py
+++ b/mkt/submit/tests/test_api.py
@@ -324,7 +324,7 @@ class TestPreviewHandler(RestOAuth, amo.tests.AMOPaths):
         self.user = UserProfile.objects.get(pk=2519)
         AddonUser.objects.create(user=self.user, addon=self.app)
         self.file = base64.b64encode(open(self.preview_image(), 'r').read())
-        self.list_url = reverse('app-preview-list',
+        self.list_url = reverse('app-preview',
                                 kwargs={'pk': self.app.pk})
         self.good = {'file': {'data': self.file, 'type': 'image/jpg'},
                      'position': 1}
@@ -344,7 +344,7 @@ class TestPreviewHandler(RestOAuth, amo.tests.AMOPaths):
         eq_(previews.all()[0].position, 1)
 
     def test_wrong_url(self):
-        self.list_url = reverse('app-preview-list',
+        self.list_url = reverse('app-preview',
                                 kwargs={'pk': 'booyah'})
         res = self.client.post(self.list_url, data=json.dumps(self.good))
         eq_(res.status_code, 404)

--- a/mkt/webapps/api.py
+++ b/mkt/webapps/api.py
@@ -504,7 +504,7 @@ class AppViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
 
     @action(methods=['POST'],
             cors_allowed_methods=PreviewViewSet.cors_allowed_methods)
-    def preview_list(self, request, *args, **kwargs):
+    def preview(self, request, *args, **kwargs):
         kwargs['app'] = self.get_object()
         view = PreviewViewSet.as_view({'post': '_create'})
         return view(request, *args, **kwargs)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=974957

DRF automatically generates it, and we want/documented /preview/,
not /preview_list/ !
