### PR TITLE
Move installed/purchased/developed lists in a separate 'apps' key (bug 969433)

### DIFF
--- a/docs/api/topics/fireplace.rst
+++ b/docs/api/topics/fireplace.rst
@@ -75,9 +75,9 @@ Consumer Information
     If user authentication information is passed to the request, the following
     will also be added to the response:
 
-    :param developed: IDs of apps the user has developed.
+    :param apps.developed: IDs of apps the user has developed.
     :type active: array
-    :param installed: IDs of apps the user has installed.
+    :param apps.installed: IDs of apps the user has installed.
     :type active: array
-    :param purchased: IDs of apps the user has purchased.
+    :param apps.purchased: IDs of apps the user has purchased.
     :type active: array

--- a/mkt/account/tests/test_api.py
+++ b/mkt/account/tests/test_api.py
@@ -364,9 +364,9 @@ class TestLoginHandler(TestCase):
              'webpay': False,
              'stats': False,
              'revenue_stats': False})
-        eq_(data['installed'], [])
-        eq_(data['purchased'], [])
-        eq_(data['developed'], [])
+        eq_(data['apps']['installed'], [])
+        eq_(data['apps']['purchased'], [])
+        eq_(data['apps']['developed'], [])
 
     @patch('users.models.UserProfile.purchase_ids')
     def test_relevant_apps(self, purchase_ids):
@@ -381,9 +381,9 @@ class TestLoginHandler(TestCase):
         installed_app.installed.create(user=profile)
 
         data = self._test_login()
-        eq_(data['installed'], [installed_app.pk])
-        eq_(data['purchased'], [purchased_app.pk])
-        eq_(data['developed'], [developed_app.pk])
+        eq_(data['apps']['installed'], [installed_app.pk])
+        eq_(data['apps']['purchased'], [purchased_app.pk])
+        eq_(data['apps']['developed'], [developed_app.pk])
 
     @patch('requests.post')
     def test_login_failure(self, http_request):
@@ -411,6 +411,7 @@ class TestLoginHandler(TestCase):
         data = json.loads(res.content)
         eq_(res.status_code, 400)
         assert 'assertion' in data
+        assert not 'apps' in data
 
 
 class TestFeedbackHandler(TestPotatoCaptcha, RestOAuth):

--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -188,7 +188,7 @@ class LoginView(CORSMixin, CreateAPIViewWithoutModel):
         data.update(permissions.data)
 
         # Add ids of installed/purchased/developed apps.
-        data.update(user_relevant_apps(profile))
+        data['apps'] = user_relevant_apps(profile)
 
         return data
 

--- a/mkt/fireplace/api.py
+++ b/mkt/fireplace/api.py
@@ -52,7 +52,7 @@ class ConsumerInfoView(CORSMixin, RetrieveAPIView):
             'region': request.REGION.slug
         }
         if request.amo_user:
-          data.update(user_relevant_apps(request.amo_user))
+          data['apps'] = user_relevant_apps(request.amo_user)
 
         # Return an HttpResponse directly to be as fast as possible.
         return HttpResponse(json.dumps(data),

--- a/mkt/fireplace/tests/test_api.py
+++ b/mkt/fireplace/tests/test_api.py
@@ -90,9 +90,7 @@ class TestConsumerInfoView(RestOAuth, TestCase):
         res = self.anon.get(self.url)
         data = json.loads(res.content)
         eq_(data['region'], 'uk')
-        ok_(not 'developed' in data)
-        ok_(not 'installed' in data)
-        ok_(not 'purchased' in data)
+        ok_(not 'apps' in data)
 
     @patch('mkt.regions.middleware.RegionMiddleware.region_from_request')
     def test_with_user_developed(self, region_from_request):
@@ -103,9 +101,9 @@ class TestConsumerInfoView(RestOAuth, TestCase):
         res = self.client.get(self.url)
         data = json.loads(res.content)
         eq_(data['region'], 'br')
-        eq_(data['installed'], [])
-        eq_(data['developed'], [developed_app.pk])
-        eq_(data['purchased'], [])
+        eq_(data['apps']['installed'], [])
+        eq_(data['apps']['developed'], [developed_app.pk])
+        eq_(data['apps']['purchased'], [])
 
     @patch('mkt.regions.middleware.RegionMiddleware.region_from_request')
     def test_with_user_installed(self, region_from_request):
@@ -116,9 +114,9 @@ class TestConsumerInfoView(RestOAuth, TestCase):
         res = self.client.get(self.url)
         data = json.loads(res.content)
         eq_(data['region'], 'br')
-        eq_(data['installed'], [installed_app.pk])
-        eq_(data['developed'], [])
-        eq_(data['purchased'], [])
+        eq_(data['apps']['installed'], [installed_app.pk])
+        eq_(data['apps']['developed'], [])
+        eq_(data['apps']['purchased'], [])
 
     @patch('users.models.UserProfile.purchase_ids')
     @patch('mkt.regions.middleware.RegionMiddleware.region_from_request')
@@ -130,6 +128,6 @@ class TestConsumerInfoView(RestOAuth, TestCase):
         res = self.client.get(self.url)
         data = json.loads(res.content)
         eq_(data['region'], 'br')
-        eq_(data['installed'], [])
-        eq_(data['developed'], [])
-        eq_(data['purchased'], [purchased_app.pk])
+        eq_(data['apps']['installed'], [])
+        eq_(data['apps']['developed'], [])
+        eq_(data['apps']['purchased'], [purchased_app.pk])


### PR DESCRIPTION
This will make the consumer side a little easier to implement, and since it's private API nobody is using yet we can do it without fear of breaking backwards-compatibility.
