### PR TITLE
Fix incorrect URLs in content ratings API documentation (bug 975074).

### DIFF
--- a/docs/api/topics/content_ratings.rst
+++ b/docs/api/topics/content_ratings.rst
@@ -9,7 +9,7 @@ API for IARC (International Age Rating Coalition) app content ratings.
 Content Rating
 ==============
 
-.. http:get:: /api/v1/apps/app/(int:id|string:app_slug)/content-ratings
+.. http:get:: /api/v1/apps/app/(int:id|string:app_slug)/content_ratings
 
     Returns the list of content ratings of an app.
 

--- a/docs/api/topics/submission.rst
+++ b/docs/api/topics/submission.rst
@@ -273,7 +273,7 @@ Content ratings
 
 .. _content-ratings:
 
-.. http:post:: /api/v1/apps/(int:app_id)/content-ratings/
+.. http:post:: /api/v1/apps/app/(int:id|string:app_slug)/content_ratings/
 
     **Request**
 


### PR DESCRIPTION
r? @ngoke @robhudson
