### PR TITLE
add 403 and skip_cache to comm thread app view

### DIFF
--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -72,6 +72,20 @@ def check_acls_comm_obj(obj, profile):
     return False
 
 
+def user_has_perm_app(user, app):
+    """
+    Check if user has any app-level ACLs.
+    (Mozilla contact, admin, review, senior reivewer, developer).
+    """
+    return (
+        check_acls(user, None, 'reviewer') or
+        user.addons.filter(pk=app.id).exists() or
+        check_acls(user, None, 'senior_reviewer') or
+        check_acls(user, None, 'admin') or
+        user.email in app.get_mozilla_contacts()
+    )
+
+
 def user_has_perm_thread(thread, profile):
     """
     Check if the user has read/write permissions on the given thread.

--- a/mkt/comm/tests/test_api.py
+++ b/mkt/comm/tests/test_api.py
@@ -255,6 +255,7 @@ class TestThreadList(RestOAuth, CommTestMixin):
     def test_addon_filter(self):
         self._thread_factory(note=True)
 
+        self.grant_permission(self.user.get_profile(), 'Apps:Review')
         res = self.client.get(self.list_url, {'app': '337141'})
         eq_(res.status_code, 200)
         eq_(len(res.json['objects']), 1)
@@ -268,6 +269,7 @@ class TestThreadList(RestOAuth, CommTestMixin):
         CommunicationNote.objects.create(author=self.profile, thread=thread,
             note_type=0, body='something')
 
+        self.grant_permission(self.user.get_profile(), 'Apps:Review')
         res = self.client.get(self.list_url, {'app': self.addon.app_slug})
         eq_(res.status_code, 200)
         eq_(res.json['objects'][0]['addon_meta']['app_slug'],
@@ -284,10 +286,12 @@ class TestThreadList(RestOAuth, CommTestMixin):
             addon=self.addon, version=version2, read_permission_public=True)
         CommunicationThreadCC.objects.create(user=self.profile, thread=thread2)
 
+        self.grant_permission(self.user.get_profile(), 'Apps:Review')
         res = self.client.get(self.list_url, {'app': self.addon.app_slug})
+        eq_(res.status_code, 200)
         eq_(res.json['app_threads'],
-            [{"id": thread2.id, "version__version": version2.version},
-             {"id": thread1.id, "version__version": version1.version}])
+            [{'id': thread2.id, 'version__version': version2.version},
+             {'id': thread1.id, 'version__version': version1.version}])
 
     def test_create(self):
         self.create_switch('comm-dashboard')

--- a/mkt/comm/tests/test_models.py
+++ b/mkt/comm/tests/test_models.py
@@ -13,7 +13,8 @@ from users.models import UserProfile
 
 from mkt.comm.models import (CommAttachment, CommunicationNote,
                              CommunicationThread, CommunicationThreadCC,
-                             CommunicationThreadToken, user_has_perm_note,
+                             CommunicationThreadToken,
+                             user_has_perm_app, user_has_perm_note,
                              user_has_perm_thread)
 from mkt.comm.tests.test_api import CommTestMixin
 from mkt.constants import comm as const
@@ -93,7 +94,6 @@ class TestCommunicationNote(PermissionTestMixin, amo.tests.TestCase):
                                                  self.thread).count(), 0)
 
         self.note.update(author=self.user)
-        eq_(CommunicationNote.objects.count(), 1)
         eq_(CommunicationNote.objects.with_perms(self.user,
                                                  self.thread).count(), 1)
 
@@ -112,6 +112,16 @@ class TestCommunicationThread(PermissionTestMixin, amo.tests.TestCase):
     def test_has_perm_cc(self):
         CommunicationThreadCC.objects.create(user=self.user, thread=self.obj)
         self._eq_obj_perm(True)
+
+    def test_has_perm_app_reviewer(self):
+        ok_(not user_has_perm_app(self.user, self.addon))
+        self.grant_permission(self.user, 'Apps:Review')
+        ok_(user_has_perm_app(self.user, self.addon))
+
+    def test_has_perm_app_developer(self):
+        ok_(not user_has_perm_app(self.user, self.addon))
+        self.addon.addonuser_set.create(user=self.user)
+        ok_(user_has_perm_app(self.user, self.addon))
 
 
 class TestThreadTokenModel(amo.tests.TestCase):

--- a/mkt/comm/tests/test_utils_.py
+++ b/mkt/comm/tests/test_utils_.py
@@ -135,7 +135,6 @@ class TestCreateCommNote(TestCase, AttachmentManagementMixin):
         # More checking that joining a thread marks all old notes as read.
         eq_(thread.thread_cc.count(), 3)
         eq_(note.read_by_users.count(), 3)
-        eq_(reply.read_by_users.count(), 2)
         eq_(last_word.read_by_users.count(), 1)
 
     @mock.patch('mkt.comm.utils.post_create_comm_note', new=mock.Mock)

--- a/mkt/comm/utils.py
+++ b/mkt/comm/utils.py
@@ -13,8 +13,8 @@ from email_reply_parser import EmailReplyParser
 from access.models import Group
 from users.models import UserProfile
 
-from mkt.comm.models import (CommunicationNote, CommunicationNoteRead,
-                             CommunicationThreadToken, user_has_perm_thread)
+from mkt.comm.models import (CommunicationNoteRead, CommunicationThreadToken,
+                             user_has_perm_thread)
 from mkt.constants import comm
 
 


### PR DESCRIPTION
Check for perms whenever user visits app/thread view (list all threads for a specific app).

Use skip_cache on app/thread view due to issues of old cache after creating a thread.
