### PR TITLE
Exclude deleted / incomplete apps from queue position calculations (bug 976800)

### DIFF
--- a/apps/editors/helpers.py
+++ b/apps/editors/helpers.py
@@ -363,14 +363,17 @@ def get_position(addon):
         return {'pos': position, 'total': total}
     elif addon.is_webapp():
         excluded_ids = EscalationQueue.objects.values_list('addon', flat=True)
-        # Look at all regular versions of webapps which have pending files. This
-        # includes both new apps and updates to existing apps, to combine both
-        # the regular and updates queue in one big list (In theory, reviewers
-        # should take the same time to process an app in either queue).
+        # Look at all regular versions of webapps which have pending files.
+        # This includes both new apps and updates to existing apps, to combine
+        # both the regular and updates queue in one big list (In theory, it
+        # should take the same time for reviewers to process an app in either
+        # queue). Escalated apps are excluded just like in reviewer tools.
         qs = (Version.objects.filter(addon__type=amo.ADDON_WEBAPP,
                                      addon__disabled_by_user=False,
                                      files__status=amo.STATUS_PENDING,
                                      deleted=False)
+              .exclude(addon__status__in=(amo.STATUS_DISABLED,
+                                          amo.STATUS_DELETED, amo.STATUS_NULL))
               .exclude(addon__id__in=excluded_ids)
               .order_by('nomination', 'created').select_related('addon')
               .no_transforms().values_list('addon_id', 'nomination'))

--- a/apps/editors/tests/test_helpers.py
+++ b/apps/editors/tests/test_helpers.py
@@ -778,6 +778,12 @@ class TestGetPosition(amo.tests.TestCase):
             file_kw={'status': amo.STATUS_PENDING},
             version_kw={'nomination': self.days_ago(1)})
 
+        # A deleted app that shouldn't change calculations.
+        amo.tests.app_factory(
+            status=amo.STATUS_DELETED,
+            file_kw={'status': amo.STATUS_PENDING},
+            version_kw={'nomination': self.days_ago(1)})
+
     def test_min(self):
         pending_app = amo.tests.app_factory(
             status=amo.STATUS_PENDING,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=976800
