### PR TITLE
create comm attachments from reviewer tools on reviews (bug 977296)

### DIFF
--- a/mkt/comm/tests/test_api.py
+++ b/mkt/comm/tests/test_api.py
@@ -59,6 +59,14 @@ class CommTestMixin(object):
 
 class AttachmentManagementMixin(object):
 
+    def _attachment_management_form(self, num=1):
+        """
+        Generate and return data for a management form for `num` attachments
+        """
+        return {'form-TOTAL_FORMS': max(1, num),
+                'form-INITIAL_FORMS': 0,
+                'form-MAX_NUM_FORMS': 1000}
+
     def _attachments(self, num):
         """Generate and return data for `num` attachments """
         data = {}

--- a/mkt/comm/tests/test_utils_.py
+++ b/mkt/comm/tests/test_utils_.py
@@ -1,6 +1,7 @@
 import os.path
 
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 import mock
 from nose.tools import eq_
@@ -9,7 +10,9 @@ import amo
 from amo.tests import app_factory, TestCase, user_factory
 from users.models import UserProfile
 
+from mkt.comm.forms import CommAttachmentFormSet
 from mkt.comm.models import CommunicationThread, CommunicationThreadToken
+from mkt.comm.tests.test_api import AttachmentManagementMixin
 from mkt.comm.utils import (CommEmailParser, create_comm_note,
                             save_from_email_reply)
 from mkt.constants import comm
@@ -73,7 +76,7 @@ class TestEmailParser(TestCase):
         eq_(self.parser.get_body(), 'test note 5\n')
 
 
-class TestCreateCommNote(TestCase):
+class TestCreateCommNote(TestCase, AttachmentManagementMixin):
 
     def setUp(self):
         self.create_switch('comm-dashboard')
@@ -147,3 +150,22 @@ class TestCreateCommNote(TestCase):
             'senior_reviewer': True, 'mozilla_contact': True, 'staff': True}
         for perm, has_perm in expected.items():
             eq_(getattr(thread, 'read_permission_%s' % perm), has_perm, perm)
+
+    @mock.patch('mkt.comm.utils.post_create_comm_note', new=mock.Mock)
+    def test_attachments(self):
+        attach_formdata = self._attachment_management_form(num=2)
+        attach_formdata.update(self._attachments(num=2))
+        attach_formset = CommAttachmentFormSet(
+            attach_formdata,
+            {'form-0-attachment':
+                SimpleUploadedFile(
+                    'lol', attach_formdata['form-0-attachment'].read()),
+             'form-1-attachment':
+                SimpleUploadedFile(
+                    'lol2', attach_formdata['form-1-attachment'].read())})
+
+        thread, note = create_comm_note(
+            self.app, self.app.current_version, self.user, 'lol',
+            note_type=comm.APPROVAL, attachments=attach_formset)
+
+        eq_(note.attachments.count(), 2)

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -2056,19 +2056,10 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
     @override_settings(REVIEWER_ATTACHMENTS_PATH=ATTACHMENTS_DIR)
     @mock.patch('amo.utils.LocalFileStorage.save')
     def test_attachment(self, save_mock):
-        """ Test addition of 1 attachment """
+        """ Test addition of an attachment """
         self._attachment_post(1)
-        eq_(save_mock.call_args_list,
-            [mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY)])
-
-    @override_settings(REVIEWER_ATTACHMENTS_PATH=ATTACHMENTS_DIR)
-    @mock.patch('amo.utils.LocalFileStorage.save')
-    def test_multiple_attachments(self, save_mock):
-        """ Test addition of multiple attachments """
-        self._attachment_post(2)
-        eq_(save_mock.call_args_list,
-            [mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY),
-             mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.jpg'), mock.ANY)])
+        eq_(save_mock.call_args_list[0],
+            mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY))
 
     @override_settings(REVIEWER_ATTACHMENTS_PATH=ATTACHMENTS_DIR)
     @mock.patch('amo.utils.LocalFileStorage.save')
@@ -2082,8 +2073,8 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
             'Review attachment not added to email')
         for attachment in mail.outbox[0].attachments:
             self.assertNotEqual(len(attachment), 0, '0-length attachment')
-        eq_(save_mock.call_args_list,
-            [mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY)])
+        eq_(save_mock.call_args_list[0],
+            mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY))
 
     @override_settings(REVIEWER_ATTACHMENTS_PATH=ATTACHMENTS_DIR)
     @mock.patch('amo.utils.LocalFileStorage.save')
@@ -2095,9 +2086,8 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(self._attachment_form_data(num=2, action='reject'))
         eq_(len(mail.outbox[0].attachments), 2,
             'Review attachments not added to email')
-        eq_(save_mock.call_args_list,
-            [mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY),
-             mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.jpg'), mock.ANY)])
+        eq_(save_mock.call_args_list[0],
+            mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY))
 
     @override_settings(REVIEWER_ATTACHMENTS_PATH=ATTACHMENTS_DIR)
     @mock.patch('amo.utils.LocalFileStorage.save')
@@ -2110,8 +2100,8 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(self._attachment_form_data(num=1, action='escalate'))
         eq_(len(mail.outbox[0].attachments), 1,
             'Review attachment not added to email')
-        eq_(save_mock.call_args_list,
-            [mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY)])
+        eq_(save_mock.call_args_list[0],
+            mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY))
 
     @override_settings(REVIEWER_ATTACHMENTS_PATH=ATTACHMENTS_DIR)
     @mock.patch('amo.utils.LocalFileStorage.save')
@@ -2123,8 +2113,8 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         self.post(self._attachment_form_data(num=1, action='info'))
         eq_(len(mail.outbox[0].attachments), 1,
             'Review attachment not added to email')
-        eq_(save_mock.call_args_list,
-            [mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY)])
+        eq_(save_mock.call_args_list[0],
+            mock.call(os.path.join(ATTACHMENTS_DIR, 'bacon.txt'), mock.ANY))
 
     def test_idn_app_domain(self):
         response = self.client.get(self.url)
@@ -2582,6 +2572,16 @@ class TestReviewAppComm(AppReviewerTest, AttachmentManagementMixin):
 
         # Test emails.
         self._check_email_dev_and_contact()
+
+    def test_attachments(self):
+        data = {'action': 'comment', 'comments': 'huh'}
+        data.update(self._attachment_management_form(num=2))
+        data.update(self._attachments(num=2))
+        self._post(data)
+
+        # Test attachments.
+        note = self._get_note()
+        eq_(note.attachments.count(), 2)
 
 
 class TestAbuseReports(amo.tests.TestCase):


### PR DESCRIPTION
Breaking https://github.com/mozilla/zamboni/pull/1607 up. [Screencast](http://screencast.com/t/d4S8e8Bi9FIf)

~~Part 1: In a waffle, use a separate template for reviewers app history that is populated by the Commbadge API rather than passing in ActivityLog objects through the view.~~

~~[Part 2](https://github.com/ngokevin/zamboni/commit/a42d10a156bea1315070bb192fcaef2153d66ce4): Display Commbadge attachments along with the notes.~~

~~[Part 3](https://github.com/ngokevin/zamboni/commit/4482bd15451bb6b122cac6acf42cd9d8784bbd8c): Create Commbadge notes for all review actions.~~

**[Part 4](https://github.com/ngokevin/zamboni/commit/1605848103a934f1a8d1264d23ad32bf1afdbecc): Create Commbadge attachments from reviewer tools.**
- When reviewing an app and adding an attachment, the attachment should be attached the the Commbadge note.

[Part 5](https://github.com/ngokevin/zamboni/commit/1d9acc274afe7a7a29d468b4bf78dee6b527ea89): Paginate Commbadge notes if a lot exist for a version.
