### PR TITLE
paginate commbadge notes on in reviewer tools review history (bug 977325)

### DIFF
--- a/media/css/devreg/reviewers.styl
+++ b/media/css/devreg/reviewers.styl
@@ -772,13 +772,48 @@ button.search, .log-filter-outside button {
     top: -20px;
     width: auto;
 }
+#review-files .activity .comm-notes-paginator {
+    border-bottom: none;
+    display: none;
+
+    a {
+        display: none;
+        float: right;
+        margin-right: 5px;
+
+    }
+    .next.active + .prev:after {
+        background-color: $medium-gray;
+        border-radius: 3px;
+        bottom: 2px;
+        content: "";
+        display: inline-block;
+        height: 3px;
+        left: 2px;
+        margin: 0 2px;
+        position: relative;
+        width: 3px;
+    }
+}
+
+.comm-note {
+
+    pre {
+        padding-left: 0;
+    }
+    strong {
+        color: lighten($medium-gray, 15%);
+    }
+}
+
 #review-files table.activity {
     th {
       width: 25%;
       padding-right: 1em;
     }
     tr {
-        border-top: 1px dotted #ccc;
+        border-bottom: 1px dotted #ccc;
+        border-top: none;
 
         td {
             padding: 15px 0;
@@ -790,8 +825,8 @@ button.search, .log-filter-outside button {
             padding-bottom: 0;
         }
     }
-    tr:first-child {
-        border-top: 0 none;
+    tr:last-child {
+        border-bottom: 0;
     }
 }
 #review-files .listing-header span.light {

--- a/mkt/reviewers/templates/reviewers/includes/commbadge_note_template.html
+++ b/mkt/reviewers/templates/reviewers/includes/commbadge_note_template.html
@@ -1,8 +1,8 @@
 <script type="text/template" id="commbadge-note">
-  <tr>
+  <tr class="comm-note">
     <th><%= noteType %></th>
     <td>
-      <div><%= metadata %></div>
+      <strong><%= metadata %></strong>
       <pre class="light history-comment"><%= body %></pre>
       <% if (attachments.length) { %>
         <div class="log-group log-attachments">

--- a/mkt/reviewers/templates/reviewers/includes/review_history_commbadge.html
+++ b/mkt/reviewers/templates/reviewers/includes/review_history_commbadge.html
@@ -56,28 +56,38 @@
         <td>
           {# By version. #}
           <table class="activity" data-version="{{ version.id }}">
-            {% if version.releasenotes %}
-              <tr>
-                <th>{{ _('Version Notes') }}</th>
-                <td class="activity_version">
-                  <div class="history-notes">
-                    {{ version.releasenotes|nl2br }}
-                  </div>
+            <thead>
+              {% if version.releasenotes %}
+                <tr>
+                  <th>{{ _('Version Notes') }}</th>
+                  <td class="activity_version">
+                    <div class="history-notes">
+                      {{ version.releasenotes|nl2br }}
+                    </div>
+                  </td>
+                </tr>
+              {% endif %}
+              {% if version.approvalnotes %}
+                <tr>
+                  <th>{{ _('Notes for Reviewers') }}</th>
+                  <td class="activity_approval">
+                    <div class="history-notes">
+                      {{ version.approvalnotes|urlize(100)|nl2br }}
+                    </div>
+                  </td>
+                </tr>
+              {% endif %}
+            </thead>
+            <tbody>
+              {# Results populated here by reviewers_commbadge.js (Commbadge API) #}
+              <tr class="comm-notes-paginator">
+                <th>&nbsp;</th>
+                <td>
+                  <a class="next" href="#">{{ _('Next Page') }}</a>
+                  <a class="prev" href="#">{{ _('Previous Page') }}</a>
                 </td>
               </tr>
-            {% endif %}
-            {% if version.approvalnotes %}
-              <tr>
-                <th>{{ _('Notes for Reviewers') }}</th>
-                <td class="activity_approval">
-                  <div class="history-notes">
-                    {{ version.approvalnotes|urlize(100)|nl2br }}
-                  </div>
-                </td>
-              </tr>
-            {% endif %}
-
-            {# Results populated here by reviewers_commbadge.js (Commbadge API) #}
+            </tbody>
           </table>
         </td>
 


### PR DESCRIPTION
Breaking https://github.com/mozilla/zamboni/pull/1607 up. [Screencast](http://screencast.com/t/d4S8e8Bi9FIf)

~~Part 1: In a waffle, use a separate template for reviewers app history that is populated by the Commbadge API rather than passing in ActivityLog objects through the view.~~

~~[Part 2](https://github.com/ngokevin/zamboni/commit/a42d10a156bea1315070bb192fcaef2153d66ce4): Display Commbadge attachments along with the notes.~~

~~[Part 3](https://github.com/ngokevin/zamboni/commit/4482bd15451bb6b122cac6acf42cd9d8784bbd8c): Create Commbadge notes for all review actions.~~

[Part 4](https://github.com/ngokevin/zamboni/commit/1605848103a934f1a8d1264d23ad32bf1afdbecc): Create Commbadge attachments from reviewer tools.

**[Part 5](https://github.com/ngokevin/zamboni/commit/1d9acc274afe7a7a29d468b4bf78dee6b527ea89): Paginate Commbadge notes if a lot exist for a version.**
- JS pagination of notes pulling in from the Commbadge API on reviewer tools.
