### PR TITLE
remove install from receipts (bug 968474)

### DIFF
--- a/migrations/758-migrate-uuid.sql
+++ b/migrations/758-migrate-uuid.sql
@@ -1,0 +1,8 @@
+ALTER TABLE addon_purchase ADD COLUMN `uuid` varchar(255) NULL UNIQUE;
+
+UPDATE addon_purchase INNER JOIN users_install
+    ON (addon_purchase.user_id = users_install.user_id
+        AND addon_purchase.addon_id = users_install.addon_id)
+    SET addon_purchase.uuid = users_install.uuid;
+
+ALTER TABLE addon_purchase CHANGE `uuid` `uuid` varchar(255) NOT NULL UNIQUE;

--- a/mkt/receipts/api.py
+++ b/mkt/receipts/api.py
@@ -14,7 +14,7 @@ from mkt.api.base import cors_api_view
 from mkt.constants import apps
 from mkt.installs.utils import install_type, record
 from mkt.receipts.forms import ReceiptForm, TestInstall
-from mkt.receipts.utils import create_receipt, create_test_receipt
+from mkt.receipts.utils import create_receipt, create_test_receipt, get_uuid
 
 from mkt.webapps.models import Installed
 
@@ -74,7 +74,8 @@ def install_record(obj, request, install_type):
 
     log.info('Creating receipt: %s' % obj.pk)
     receipt_cef.log(request._request, obj, 'sign', 'Receipt signing')
-    return create_receipt(installed)
+    uuid = get_uuid(installed.addon, installed.user)
+    return create_receipt(installed.addon, installed.user, uuid)
 
 
 @cors_api_view(['POST'])

--- a/mkt/receipts/tests/test_models.py
+++ b/mkt/receipts/tests/test_models.py
@@ -28,7 +28,8 @@ class TestReceipt(amo.tests.TestCase):
     fixtures = ['base/users.json']
 
     def setUp(self):
-        self.webapp = Webapp.objects.create(type=amo.ADDON_WEBAPP)
+        self.app = Webapp.objects.create(type=amo.ADDON_WEBAPP)
+        self.app.update(manifest_url='http://f.c/')
         self.user = UserProfile.objects.get(pk=999)
         self.other_user = UserProfile.objects.exclude(pk=999)[0]
 
@@ -39,124 +40,102 @@ class TestReceipt(amo.tests.TestCase):
                                                      addon=webapp)[0]
 
     def test_get_or_create(self):
-        install = self.create_install(self.user, self.webapp)
-        eq_(install, self.create_install(self.user, self.webapp))
+        install = self.create_install(self.user, self.app)
+        eq_(install, self.create_install(self.user, self.app))
 
     def test_has_installed(self):
-        assert not self.webapp.has_installed(self.user)
-        self.create_install(self.user, self.webapp)
-        assert self.webapp.has_installed(self.user)
+        assert not self.app.has_installed(self.user)
+        self.create_install(self.user, self.app)
+        assert self.app.has_installed(self.user)
 
     def test_receipt(self):
-        ins = self.create_install(self.user, self.webapp)
-        assert create_receipt(ins).startswith('eyJhbGciOiAiUlM1MTIiLCA')
+        assert (create_receipt(self.app, self.user, 'some-uuid')
+                .startswith('eyJhbGciOiAiUlM1MTIiLCA'))
 
     def test_receipt_different(self):
-        ins = self.create_install(self.user, self.webapp)
-        ins_other = self.create_install(self.other_user, self.webapp)
-        assert create_receipt(ins) != create_receipt(ins_other)
+        assert (create_receipt(self.app, self.user, 'some-uuid')
+                != create_receipt(self.app, self.other_user, 'other-uuid'))
 
     def test_addon_premium(self):
         for type_ in amo.ADDON_PREMIUMS:
-            self.webapp.update(premium_type=type_)
-            ins = self.create_install(self.user, self.webapp)
-            assert create_receipt(ins)
-
-    def test_addon_free(self):
-        for type_ in amo.ADDON_FREES:
-            self.webapp.update(premium_type=amo.ADDON_FREE)
-            ins = self.create_install(self.user, self.webapp)
-            assert create_receipt(ins)
+            self.app.update(premium_type=type_)
+            assert create_receipt(self.app, self.user, 'some-uuid')
 
     def test_install_has_uuid(self):
-        install = self.create_install(self.user, self.webapp)
+        install = self.create_install(self.user, self.app)
         assert install.uuid.startswith(str(install.pk))
 
     def test_install_not_premium(self):
         for type_ in amo.ADDON_FREES:
-            self.webapp.update(premium_type=type_)
+            self.app.update(premium_type=type_)
             Installed.objects.all().delete()
             install = self.create_install(self.user,
-                            Webapp.objects.get(pk=self.webapp.pk))
+                                          Webapp.objects.get(pk=self.app.pk))
             eq_(install.premium_type, type_)
 
     def test_install_premium(self):
         for type_ in amo.ADDON_PREMIUMS:
-            self.webapp.update(premium_type=type_)
+            self.app.update(premium_type=type_)
             Installed.objects.all().delete()
-            install = self.create_install(self.user, self.webapp)
+            install = self.create_install(self.user, self.app)
             eq_(install.premium_type, type_)
 
     @mock.patch('jwt.encode')
     def test_receipt_data(self, encode):
         encode.return_value = 'tmp-to-keep-memoize-happy'
-        ins = self.create_install(self.user, self.webapp)
-        create_receipt(ins)
+        create_receipt(self.app, self.user, 'some-uuid')
         receipt = encode.call_args[0][0]
-        eq_(receipt['product']['url'], self.webapp.manifest_url[:-1])
-        eq_(receipt['product']['storedata'], 'id=%s' % int(ins.addon.pk))
+        eq_(receipt['product']['url'], self.app.manifest_url[:-1])
+        eq_(receipt['product']['storedata'], 'id=%s' % int(self.app.pk))
         assert receipt['exp'] > (calendar.timegm(time.gmtime()) +
                                  settings.WEBAPPS_RECEIPT_EXPIRY_SECONDS -
                                  TEST_LEEWAY)
         eq_(receipt['reissue'], absolutify(reverse('receipt.reissue')))
 
     def test_receipt_not_reviewer(self):
-        ins = self.create_install(self.user, self.webapp)
-        self.assertRaises(ValueError,
-                          create_receipt, ins, flavour='reviewer')
+        with self.assertRaises(ValueError):
+            create_receipt(self.app, self.user, 'some-uuid',
+                           flavour='reviewer')
 
     def test_receipt_other(self):
-        ins = self.create_install(self.user, self.webapp)
-        self.assertRaises(AssertionError,
-                          create_receipt, ins, flavour='wat')
+        with self.assertRaises(AssertionError):
+            create_receipt(self.app, self.user, 'some-uuid', flavour='wat')
 
     @mock.patch('jwt.encode')
-    def for_user(self, ins, flavour, encode):
+    def for_user(self, app, user, flavour, encode):
         encode.return_value = 'tmp-to-keep-memoize-happy'
-        create_receipt(ins, flavour=flavour)
+        create_receipt(app, user, 'some-uuid', flavour=flavour)
         receipt = encode.call_args[0][0]
         eq_(receipt['typ'], flavour + '-receipt')
         eq_(receipt['verify'],
-            absolutify(reverse('receipt.verify', args=[ins.addon.guid])))
+            absolutify(reverse('receipt.verify', args=[app.guid])))
         return receipt
 
     def test_receipt_data_developer(self):
         user = UserProfile.objects.get(pk=5497308)
-        ins = self.create_install(user, self.webapp)
-        receipt = self.for_user(ins, 'developer')
+        receipt = self.for_user(self.app, user, 'developer')
         assert receipt['exp'] > (calendar.timegm(time.gmtime()) +
                                  (60 * 60 * 24) - TEST_LEEWAY)
 
     def test_receipt_data_reviewer(self):
         user = UserProfile.objects.get(pk=999)
-        AddonUser.objects.create(addon=self.webapp, user=user)
-        ins = self.create_install(user, self.webapp)
-        receipt = self.for_user(ins, 'reviewer')
+        AddonUser.objects.create(addon=self.app, user=user)
+        receipt = self.for_user(self.app, user, 'reviewer')
         assert receipt['exp'] > (calendar.timegm(time.gmtime()) +
                                  (60 * 60 * 24) - TEST_LEEWAY)
 
     def test_receipt_packaged(self):
-        webapp = addon_factory(type=amo.ADDON_WEBAPP, is_packaged=True,
-                               app_domain='app://foo.com')
+        app = addon_factory(type=amo.ADDON_WEBAPP, is_packaged=True,
+                            app_domain='app://foo.com')
         user = UserProfile.objects.get(pk=5497308)
-        ins = self.create_install(user, webapp)
-        receipt = self.for_user(ins, 'developer')
+        receipt = self.for_user(app, user, 'developer')
         eq_(receipt['product']['url'], 'app://foo.com')
 
     def test_receipt_packaged_no_origin(self):
-        webapp = addon_factory(type=amo.ADDON_WEBAPP, is_packaged=True)
+        app = addon_factory(type=amo.ADDON_WEBAPP, is_packaged=True)
         user = UserProfile.objects.get(pk=5497308)
-        ins = self.create_install(user, webapp)
-        receipt = self.for_user(ins, 'developer')
+        receipt = self.for_user(app, user, 'developer')
         eq_(receipt['product']['url'], settings.SITE_URL)
-
-    @mock.patch.object(settings, 'SIGNING_SERVER_ACTIVE', True)
-    @mock.patch('mkt.receipts.utils.sign')
-    def test_receipt_signer(self, sign):
-        sign.return_value = 'something-cunning'
-        ins = self.create_install(self.user, self.webapp)
-        eq_(create_receipt(ins), 'something-cunning')
-        #TODO: more goes here.
 
 
 @mock.patch.object(settings, 'WEBAPPS_RECEIPT_KEY',


### PR DESCRIPTION
- removes use of installed from receipt verification
- moves uuid from installed onto addon-purchase
- what to do for receipts that don't have addon-purchase (eg developer or reviewer installs, just empty?)

tests pass, but want to think about this one a little bit

r? @robhudson, @kumar303
