### PR TITLE
Stop requiring permission to set region=None in search (bug 975413)

### DIFF
--- a/docs/api/topics/search.rst
+++ b/docs/api/topics/search.rst
@@ -55,9 +55,7 @@ Search
     :param optional region: Filters apps by a supported region. A region
         code should be provided in ISO 3166 format (e.g., `pl`). If not
         provided, the region is automatically detected via requesting IP
-        address. To disable automatic region detection, `None` may be passed;
-        authentication and one of the 'Regions:BypassFilters' permission or
-        curator-level access to a collection are required to do so.
+        address. To disable automatic region detection, `None` may be passed.
     :type region: string
     :param optional sort: The fields to sort by. One or more of 'created',
         'downloads', 'name', 'rating', or 'reviewed'. Sorts by


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=975413

Per comment 1 on this bug, we no longer need the `Regions:BypassFilters` to test payments in fireplace (I'm tempted to also remove the option in fireplace, but waiting to hear comments on this pull request first).

Since we ultimately want fireplace to be able to call search API completely anonymously, I felt the simplest thing to do was to remove the extra checks here. I don't think it hurts us much to let people who know about this hack to do that kind of searches, but r- if you disagree :)
