### PR TITLE
Removed ADDON_ANY choice for changing add-on types (Bug 970312)

### DIFF
--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -731,7 +731,9 @@ PreviewFormSet = modelformset_factory(Preview, formset=BasePreviewFormSet,
 
 
 class AdminForm(happyforms.ModelForm):
-    type = forms.ChoiceField(choices=amo.ADDON_TYPE.items())
+    _choices = [(k, v) for k, v in amo.ADDON_TYPE.items()
+                if k != amo.ADDON_ANY]
+    type = forms.ChoiceField(choices=_choices)
 
     # Request is needed in other ajax forms so we're stuck here.
     def __init__(self, request=None, *args, **kw):


### PR DESCRIPTION
From [Bug 970312](https://bugzilla.mozilla.org/show_bug.cgi?id=970312), selecting an add-on type of 'Any' when modifying the add-on would result in a 500 error. This simply removes that option from the drop-down list since it does not make much sense in that context.
