### PR TITLE
Trim whitespace from search queries (Bug 967754)

### DIFF
--- a/apps/search/forms.py
+++ b/apps/search/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.conf import settings
 from django.forms.util import ErrorDict
 
+import happyforms
 from tower import ugettext_lazy as _lazy
 
 import amo
@@ -107,7 +108,7 @@ APP_SORT_CHOICES = (
 )
 
 
-class ESSearchForm(forms.Form):
+class ESSearchForm(happyforms.Form):
     q = forms.CharField(required=False)
     tag = forms.CharField(required=False)
     platform = forms.CharField(required=False)

--- a/apps/search/tests/test_views.py
+++ b/apps/search/tests/test_views.py
@@ -154,6 +154,10 @@ class TestESSearch(SearchBase):
         assert 'X-PJAX' in r['vary'].split(','), 'Expected "Vary: X-PJAX"'
         self.assertTemplateUsed(r, 'search/results.html')
 
+    def test_search_space(self):
+        r = self.client.get(urlparams(self.url, q='+'))
+        eq_(r.status_code, 200)
+
     @amo.tests.mobile_test
     def test_get_mobile(self):
         r = self.client.get(self.url)


### PR DESCRIPTION
From [Bug 967754](https://bugzilla.mozilla.org/show_bug.cgi?id=967754), it was found that searching for only whitespace would cause elasticsearch to throw an error indicating that search is temporary unavailable. This pull request will simply trim any whitespace so that searching for a space will be treated the same as searching with no query.
