### PR TITLE
Allows the email to be selected and pasted in webmails (bug 919160)

### DIFF
--- a/media/js/impala/global.js
+++ b/media/js/impala/global.js
@@ -110,6 +110,8 @@ $(function() {
         $this.find('.i').remove();
         var em = $this.text().split('').reverse().join('');
         $this.prev('a').attr('href', 'mailto:' + em);
+        // Allows the email to be selected and pasted in webmails, see #919160.
+        $this.text(em).css('direction', 'ltr');
     });
 
     $('#page').delegate('.expando .toggle', 'click', _pd(function() {


### PR DESCRIPTION
I only modified the one related to the original bug, I wonder if it should be added to zamboni/devreg `init.js` too and maybe `mobile/general.js` (but I doubt about that last one given the name and the use-case).
