### PR TITLE
Don't make the same ES query twice if there are no results (bug 975102)

### DIFF
--- a/mkt/api/paginator.py
+++ b/mkt/api/paginator.py
@@ -43,9 +43,15 @@ class ESPaginator(Paginator):
         top = bottom + self.per_page
         page = Page(self.object_list[bottom:top], number, self)
 
-        # Force the search to evaluate and then attach the count.
+        # Force the search to evaluate and then attach the count. We want to
+        # avoid an extra useless query even if there are no results, so we
+        # directly fetch the count from _results_cache instead of calling
+        # page.object_list.count().
+        # FIXME: replace by simply calling page.object_list.count() when
+        # https://github.com/mozilla/elasticutils/pull/212 is merged and
+        # released.
         page.object_list.execute()
-        self._count = page.object_list.count()
+        self._count = page.object_list._results_cache.count
 
         return page
 

--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -353,8 +353,31 @@ class TestApi(RestOAuth, ESTestCase):
 
         res = self.client.get(self.url, data={'q': 'something'})
         eq_(res.status_code, 200)
+        eq_(res.json['meta']['total_count'], 1)
+        eq_(len(res.json['objects']), 1)
         obj = res.json['objects'][0]
         eq_(obj['slug'], self.webapp.app_slug)
+
+        # Verify only one search call was made.
+        eq_(es.counter, 1)
+
+        es.search = orig_search
+
+    def test_q_num_requests_no_results(self):
+        es = WebappIndexer.get_es()
+        orig_search = es.search
+        es.counter = 0
+
+        def monkey_search(*args, **kwargs):
+            es.counter += 1
+            return orig_search(*args, **kwargs)
+
+        es.search = monkey_search
+
+        res = self.client.get(self.url, data={'q': 'noresults'})
+        eq_(res.status_code, 200)
+        eq_(res.json['meta']['total_count'], 0)
+        eq_(len(res.json['objects']), 0)
 
         # Verify only one search call was made.
         eq_(es.counter, 1)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=975102

This is a workaround while we wait for mozilla/elasticutils#212
