### PR TITLE
allow user to localize her bio (bug 933038)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1472,10 +1472,7 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
     def remove_locale(self, locale):
         """NULLify strings in this locale for the add-on and versions."""
         for o in itertools.chain([self], self.versions.all()):
-            ids = [getattr(o, f.attname) for f in o._meta.translated_fields]
-            qs = Translation.objects.filter(id__in=filter(None, ids),
-                                            locale=locale)
-            qs.update(localized_string=None, localized_string_clean=None)
+            Translation.objects.remove_for(o, locale)
 
     def app_perf_results(self):
         """Generator of (AppVersion, [list of perf results contexts]).

--- a/apps/translations/helpers.py
+++ b/apps/translations/helpers.py
@@ -50,12 +50,15 @@ def truncate(s, length=255, killwords=True, end='...'):
 
 @jingo.register.inclusion_tag('translations/trans-menu.html')
 @jinja2.contextfunction
-def l10n_menu(context, default_locale='en-us'):
+def l10n_menu(context, default_locale='en-us', remove_locale_url=''):
     """Generates the locale menu for zamboni l10n."""
     default_locale = default_locale.lower()
     languages = dict((i.lower(), j) for i, j in settings.LANGUAGES.items())
     c = dict(context.items())
-    c.update({'languages': languages, 'default_locale': default_locale})
+    if 'addon' in c:
+        remove_locale_url = c['addon'].get_dev_url('remove-locale')
+    c.update({'languages': languages, 'default_locale': default_locale,
+              'remove_locale_url': remove_locale_url})
     return c
 
 

--- a/apps/translations/templates/translations/trans-menu.html
+++ b/apps/translations/templates/translations/trans-menu.html
@@ -1,5 +1,5 @@
 <div class="transbox-new"
-     data-rm-locale="{{ addon.get_dev_url('remove-locale') }}"
+     data-rm-locale="{{ remove_locale_url }}"
      data-default="{{ default_locale }}" id="l10n-menu">
   {% set dl = languages[default_locale] %}
   <p>

--- a/apps/translations/tests/test_helpers.py
+++ b/apps/translations/tests/test_helpers.py
@@ -7,6 +7,7 @@ from nose.tools import eq_
 
 import amo
 import amo.tests
+from addons.models import Addon
 from translations import helpers
 from translations.fields import save_signal
 from translations.models import PurifiedTranslation
@@ -98,6 +99,21 @@ def test_no_links():
     s = 'some text <http://bad.markup.com'
     eq_(jingo.env.from_string('{{ s|no_links }}').render({'s': s}),
         'some text')
+
+
+def test_l10n_menu():
+    # No remove_locale_url provided.
+    menu = helpers.l10n_menu({})
+    assert 'data-rm-locale=""' in menu, menu
+
+    # Specific remove_locale_url provided (eg for user).
+    menu = helpers.l10n_menu({}, remove_locale_url='/some/url/')
+    assert 'data-rm-locale="/some/url/"' in menu, menu
+
+    # Use the remove_locale_url taken from the addon in the context.
+    menu = helpers.l10n_menu({'addon': Addon()},
+                             remove_locale_url='some/url/')
+    assert 'data-rm-locale="/developers/addon/None/rmlocale"' in menu, menu
 
 
 @patch.object(settings, 'AMO_LANGUAGES', ('de', 'en-US', 'es', 'fr', 'pt-BR'))

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -17,7 +17,6 @@ import amo
 from amo.utils import clean_nl, log_cef, remove_links, slug_validator
 from .models import (UserProfile, UserNotification, BlacklistedUsername,
                      BlacklistedEmailDomain, BlacklistedPassword, DjangoUser)
-from translations.widgets import TranslationTextarea
 from .widgets import NotificationsSelectMultiple
 import users.notifications as email
 from . import tasks
@@ -251,9 +250,6 @@ class UserEditForm(UserRegisterForm, PasswordMixin):
     password2 = forms.CharField(max_length=255, required=False,
                                 widget=forms.PasswordInput(render_value=False))
 
-    bio = forms.CharField(widget=TranslationTextarea(),
-                          max_length=200,
-                          required=False)
     photo = forms.FileField(label=_lazy(u'Profile Photo'), required=False)
 
     notifications = forms.MultipleChoiceField(

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -33,6 +33,7 @@ import amo.models
 from access.models import Group, GroupUser
 from amo.urlresolvers import reverse
 from translations.fields import NoLinksField, save_signal
+from translations.models import Translation
 from translations.query import order_by_translation
 
 log = commonware.log.getLogger('z.users')
@@ -519,6 +520,10 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase):
         tower.activate(lang)
         yield
         tower.activate(old)
+
+    def remove_locale(self, locale):
+        """Remove the given locale for the user."""
+        Translation.objects.remove_for(self, locale)
 
 
 models.signals.pre_save.connect(save_signal, sender=UserProfile,

--- a/apps/users/templates/users/edit.html
+++ b/apps/users/templates/users/edit.html
@@ -8,6 +8,10 @@
 <link rel="stylesheet" href="{{ media('css/zamboni/translations/trans.css') }}">
 {% endblock %}
 
+{% block bodyattrs %}
+data-default-locale="{{ request.LANG|lower }}"
+{% endblock %}
+
 {% block content %}
 {% include 'users/includes/navigation.html' %}
 <div id="user_edit" class="primary prettyform grid" role="main">
@@ -130,6 +134,7 @@
               This text will appear publicly on your user info page.
             {%- endtrans %}
           </p>
+          {{ l10n_menu(remove_locale_url=amouser.get_user_url('remove-locale')) }}
           <div class="formfields">
           {{ form.bio }}
           {{ some_html_tip(title=

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -22,6 +22,7 @@ from addons.models import Addon, AddonUser
 from amo.signals import _connect, _disconnect
 from bandwagon.models import Collection
 from reviews.models import Review
+from translations.models import Translation
 from users.models import (BlacklistedEmailDomain, BlacklistedPassword,
                           BlacklistedUsername, get_hexdigest, UserEmailField,
                           UserProfile)
@@ -241,6 +242,15 @@ class TestUserProfile(amo.tests.TestCase):
 
         with UserProfile(username='yolo', lang='fr').activate_lang():
             eq_(translation.get_language(), 'fr')
+
+    def test_remove_locale(self):
+        u = UserProfile.objects.create()
+        u.bio = {'en-US': 'my bio', 'fr': 'ma bio'}
+        u.save()
+        u.remove_locale('fr')
+        qs = (Translation.objects.filter(localized_string__isnull=False)
+              .values_list('locale', flat=True))
+        eq_(sorted(qs.filter(id=u.bio_id)), ['en-US'])
 
 
 class TestPasswords(amo.tests.TestCase):

--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -294,6 +294,22 @@ class TestEdit(UserViewBase):
         eq_(doc('#profile-misc').length, 1,
             'Collections options should be visible.')
 
+    def test_remove_locale_bad_request(self):
+        r = self.client.post(self.user.get_user_url('remove-locale'))
+        eq_(r.status_code, 400)
+
+    @patch.object(UserProfile, 'remove_locale')
+    def test_remove_locale(self, remove_locale_mock):
+        r = self.client.post(self.user.get_user_url('remove-locale'),
+                             {'locale': 'el'})
+        eq_(r.status_code, 200)
+        remove_locale_mock.assert_called_with('el')
+
+    def test_remove_locale_default_locale(self):
+        r = self.client.post(self.user.get_user_url('remove-locale'),
+                             {'locale': settings.LANGUAGE_CODE})
+        eq_(r.status_code, 400)
+
 
 class TestEditAdmin(UserViewBase):
     fixtures = ['base/users']

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -23,6 +23,7 @@ detail_patterns = patterns('',
     url(r'^emailchange/(?P<token>[-\w]+={0,3})/(?P<hash>[\w]+)$',
                         views.emailchange, name="users.emailchange"),
     url('^abuse', views.report_abuse, name='users.abuse'),
+    url('^rmlocale$', views.remove_locale, name='users.remove-locale'),
 )
 
 

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -737,6 +737,17 @@ def report_abuse(request, user):
     return redirect(user.get_url_path())
 
 
+@post_required
+@user_view
+def remove_locale(request, user):
+    """Remove a locale from the user's translations."""
+    POST = request.POST
+    if 'locale' in POST and POST['locale'] != settings.LANGUAGE_CODE:
+        user.remove_locale(POST['locale'])
+        return http.HttpResponse()
+    return http.HttpResponseBadRequest()
+
+
 @never_cache
 def password_reset_confirm(request, uidb36=None, token=None):
     """

--- a/media/css/impala/forms.less
+++ b/media/css/impala/forms.less
@@ -363,6 +363,13 @@ textarea {
     a.delete {
         color: @error-red;
     }
+    #l10n-menu {
+        color: #777;
+        float: none;
+        #change-locale:after {
+            border-top-color: #777;
+        }
+    }
 }
 
 .prettyform form:only-child fieldset {

--- a/media/css/impala/l10n.less
+++ b/media/css/impala/l10n.less
@@ -69,9 +69,20 @@
     }
 }
 #existing_locales a.remove {
+    background-color: #ddd;
+    border-radius: 20px;
+    color: #fff;
+    cursor: pointer;
     display: block;
     float: right;
+    font-size: 14px;
+    font-weight: bold;
+    height: 18px;
+    line-height: 16px;
     margin: 4px;
+    text-align: center;
+    text-decoration: none;
+    width: 18px;
 
     &:hover {
         background-color: #2a4364;


### PR DESCRIPTION
This PR adds a "localize for" menu, like the one in devhub, to allow a user to
localize her bio.

![localize_for](https://f.cloud.github.com/assets/167767/2349014/d24ec756-a55e-11e3-9fd5-c6e5c7d51cee.png)

The current language is used to select the bio translation to display. If it
doesn't exist, a fallback language is used (by default, the en-US, set in the
settings).

As the user couldn't localize her bio previously, and if she entered her bio
while browsing the site using the "fr" locale, her bio would only be displayed
for users also browsing using the same locale. For anybody else, no bio would
be displayed.

The user can now localize her bio for various locales, including the default
(fallback) one: en-US.

I've also taken the opportunity to revert a change added in
https://github.com/mozilla/zamboni/pull/1708/files#diff-dff2aa5261ee9882eb4ef3405c2e934fR254
(for no particular reason), reverting the limitation to 200 chars max on the bio.
