### PR TITLE
command to refresh iarc ratings for apps (bug 981100)

### DIFF
--- a/mkt/developers/management/commands/refresh_iarc_ratings.py
+++ b/mkt/developers/management/commands/refresh_iarc_ratings.py
@@ -1,0 +1,36 @@
+import logging
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+
+from amo.utils import chunked
+
+from mkt.developers.tasks import refresh_iarc_ratings
+
+
+log = logging.getLogger('z.task')
+
+
+class Command(BaseCommand):
+    """
+    Refresh old or corrupt IARC ratings by re-fetching the certificate.
+    """
+    option_list = BaseCommand.option_list + (
+        make_option('--apps',
+                    help='Webapp ids to process. Use commas to separate '
+                         'multiple ids.'),
+    )
+    help = __doc__
+
+    def handle(self, *args, **kw):
+        from mkt.webapps.models import Webapp
+
+        # Get apps.
+        apps = Webapp.objects.filter(iarc_info__isnull=False)
+        ids = kw.get('apps')
+        if ids:
+            apps = apps.filter(
+                id__in=(int(id.strip()) for id in ids.split(',')))
+
+        for chunk in chunked(apps.values_list('id', flat=True), 100):
+            refresh_iarc_ratings.delay(chunk)

--- a/mkt/developers/tests/test_commands.py
+++ b/mkt/developers/tests/test_commands.py
@@ -8,9 +8,10 @@ from addons.models import AddonPremium, Category
 import mkt
 from mkt.developers.management.commands import (cleanup_addon_premium,
                                                 exclude_games, migrate_geodata,
+                                                refresh_iarc_ratings,
                                                 remove_old_aers)
 from mkt.site.fixtures import fixture
-from mkt.webapps.models import Webapp
+from mkt.webapps.models import IARCInfo, RatingDescriptors, Webapp
 
 
 class TestCommandViews(amo.tests.TestCase):
@@ -140,7 +141,6 @@ class TestRemoveOldAERs(amo.tests.TestCase):
 
     def setUp(self):
         self.webapp = Webapp.objects.get(pk=337141)
-        self.geo = self.webapp.geodata
         self.webapp.addoncategory_set.create(
             category=Category.objects.create(slug='games',
                                              type=amo.ADDON_WEBAPP))
@@ -159,3 +159,39 @@ class TestRemoveOldAERs(amo.tests.TestCase):
 
         remove_old_aers.Command().handle()
         eq_(self.webapp.addonexcludedregion.count(), 3)
+
+
+class TestRefreshIARCRatings(amo.tests.TestCase):
+    fixtures = fixture('webapp_337141')
+
+    def setUp(self):
+        self.webapp = Webapp.objects.get(pk=337141)
+
+    def test_refresh_create(self):
+        IARCInfo.objects.create(
+            addon=self.webapp, submission_id=52, security_code='FZ32CU8')
+        refresh_iarc_ratings.Command().handle()
+
+        ok_(self.webapp.rating_descriptors)
+        ok_(self.webapp.rating_interactives)
+        ok_(self.webapp.content_ratings.count())
+
+    def test_refresh_update(self):
+        IARCInfo.objects.create(
+            addon=self.webapp, submission_id=52, security_code='FZ32CU8')
+        RatingDescriptors.objects.create(
+            addon=self.webapp, has_usk_violence=True)
+        refresh_iarc_ratings.Command().handle()
+
+        ok_(self.webapp.rating_descriptors.has_generic_lang)
+        ok_(not self.webapp.rating_descriptors.has_usk_violence)
+
+    def test_no_cert_no_refresh(self):
+        refresh_iarc_ratings.Command().handle()
+        ok_(not self.webapp.content_ratings.count())
+
+    def test_single_app(self):
+        IARCInfo.objects.create(
+            addon=self.webapp, submission_id=52, security_code='FZ32CU8')
+        refresh_iarc_ratings.Command().handle(apps=unicode(self.webapp.id))
+        ok_(self.webapp.content_ratings.count())


### PR DESCRIPTION
[cage-fighter](http://marketplace.firefox.com/app/cage-fighter) has some missing descriptors, interactive elements, and some incorrect ratings. Somehow our db got out of sync with their certs, possibly due to a bug that has since been fixed (cage-fighter attained ratings in late January).

This adds a command to resync with IARC certs. @robhudson
