### PR TITLE
command to remove old AERs (bug 980336)

### DIFF
--- a/mkt/developers/management/commands/remove_old_aers.py
+++ b/mkt/developers/management/commands/remove_old_aers.py
@@ -1,0 +1,31 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+import amo
+
+from mkt import regions
+
+
+log = logging.getLogger('z.task')
+
+
+class Command(BaseCommand):
+    help = ('Remove game-related AERs for Brazil + Germany.')
+
+    def handle(self, *args, **options):
+        # Avoid import error.
+        from mkt.webapps.models import Webapp
+
+        games = Webapp.objects.filter(
+            category__type=amo.ADDON_WEBAPP, category__slug='games')
+
+        for app in games:
+            aers = app.addonexcludedregion
+
+            if (aers.count() == 2 and
+                aers.filter(region=regions.BR.id).exists() and
+                aers.filter(region=regions.DE.id).exists()):
+
+                log.info('Removing BR/DE AERs for %s' % app.id)
+                aers.all().delete()

--- a/mkt/developers/tests/test_commands.py
+++ b/mkt/developers/tests/test_commands.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 import amo
 import amo.tests
-from addons.models import AddonPremium
+from addons.models import AddonPremium, Category
 
 import mkt
 from mkt.developers.management.commands import (cleanup_addon_premium,
-                                                exclude_games, migrate_geodata)
+                                                exclude_games, migrate_geodata,
+                                                remove_old_aers)
 from mkt.site.fixtures import fixture
 from mkt.webapps.models import Webapp
 
@@ -132,3 +133,29 @@ class TestExcludeUnratedGames(amo.tests.TestCase):
         exclude_games.Command().handle()
         assert self._brazil_listed()
         assert not self._germany_listed()
+
+
+class TestRemoveOldAERs(amo.tests.TestCase):
+    fixtures = fixture('webapp_337141')
+
+    def setUp(self):
+        self.webapp = Webapp.objects.get(pk=337141)
+        self.geo = self.webapp.geodata
+        self.webapp.addoncategory_set.create(
+            category=Category.objects.create(slug='games',
+                                             type=amo.ADDON_WEBAPP))
+
+    def test_delete(self):
+        self.webapp.addonexcludedregion.create(region=mkt.regions.BR.id)
+        self.webapp.addonexcludedregion.create(region=mkt.regions.DE.id)
+
+        remove_old_aers.Command().handle()
+        eq_(self.webapp.addonexcludedregion.count(), 0)
+
+    def test_user_excluded_no_delete(self):
+        self.webapp.addonexcludedregion.create(region=mkt.regions.BR.id)
+        self.webapp.addonexcludedregion.create(region=mkt.regions.DE.id)
+        self.webapp.addonexcludedregion.create(region=mkt.regions.MX.id)
+
+        remove_old_aers.Command().handle()
+        eq_(self.webapp.addonexcludedregion.count(), 3)


### PR DESCRIPTION
Some apps still had IARC-related game region exclusions via AddonExcludedRegion objects. This command removes old AERs on the heuristic that AERs are old if the app is a game that only has Germany+Brazil excluded.

It doesn't cover 100% of the cases. Only apps that have untouched regions where the system only disabled Brazil+Germany because they were unrated games. Apps that have been manually excluded from other regions will have to manually re-include Brazil+Germany.

@robhudson
