### PR TITLE
force apps to get content ratings before resubmit, geodata flag for iarc purge (bug 971049)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -380,6 +380,10 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
 
     enable_new_regions = models.BooleanField(default=False, db_index=True)
 
+    # Annotates disabled apps from the Great IARC purge for auto-reapprove.
+    # Note: for currently PUBLIC apps only.
+    iarc_purged = models.BooleanField(default=False)
+
     objects = AddonManager()
     with_deleted = AddonManager(include_deleted=True)
 

--- a/migrations/765-iarc-purge-flag.sql
+++ b/migrations/765-iarc-purge-flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE addons
+    ADD COLUMN `iarc_purged` bool NOT NULL DEFAULT false;

--- a/mkt/developers/templates/developers/apps/status.html
+++ b/mkt/developers/templates/developers/apps/status.html
@@ -50,10 +50,18 @@
             </p>
           {% elif addon.status == amo.STATUS_DISABLED %}
             {{ status(_('This app has been <b>disabled by Mozilla</b>.')) }}
-            {% trans email=emaillink(settings.MKT_REVIEWERS_EMAIL) %}
-              Your app was disabled by a site administrator. If you have any
-              questions, please email {{ email }}.
-            {% endtrans %}
+            {% if addon.iarc_purged %}
+              {% trans ratings_url=addon.get_dev_url('ratings') %}
+                Your app was disabled because it is missing content ratings. It will
+                automatically be re-enabled after
+                <a href="{{ ratings_url }}">obtaining content ratings</a>.
+              {% endtrans %}
+            {% else %}
+              {% trans email=emaillink(settings.MKT_REVIEWERS_EMAIL) %}
+                Your app was disabled by a site administrator. If you have any
+                questions, please email {{ email }}.
+              {% endtrans %}
+            {% endif %}
           {% elif addon.status == amo.STATUS_BLOCKED %}
             {{ status(_('Your app has been <b>blocked by Mozilla</b>.')) }}
             {% trans email=emaillink(settings.MKT_REVIEWERS_EMAIL) %}
@@ -99,12 +107,17 @@
                   {% endif %}
                 </p>
               {% endif %}
-              {% if not addon.is_packaged %}
+              {% if not addon.is_packaged and addon.is_rated() or not waffle.switch('iarc') %}
                 <form method="post">
                   {{ csrf() }}
                   {{ form_field(form.notes, opt=True) }}
                   <p><button type="submit" name="resubmit-app">{{ _('Resubmit App') }}</button></p>
                 </form>
+              {% elif waffle.switch('iarc') and not addon.is_rated() %}
+                {% trans ratings_url=addon.get_dev_url('ratings') %}
+                  You must <a href="{{ ratings_url }}">obtain content ratings</a>
+                  before resubmitting your app.
+                {% endtrans %}
               {% endif %}
           {% endif %}
         </div>

--- a/mkt/developers/tests/test_views_versions.py
+++ b/mkt/developers/tests/test_views_versions.py
@@ -113,6 +113,18 @@ class TestVersion(amo.tests.TestCase):
             addon=webapp, activity_log__action=action.id).exists(), (
                 "Didn't find `%s` action in logs." % action.short)
 
+    def test_no_ratings_no_resubmit(self):
+        self.create_switch('iarc')
+        self.webapp.update(status=amo.STATUS_REJECTED)
+        r = self.client.post(self.url, {'notes': 'lol',
+                                        'resubmit-app': ''})
+        eq_(r.status_code, 403)
+
+        self.webapp.content_ratings.create(ratings_body=0, rating=0)
+        r = self.client.post(self.url, {'notes': 'lol',
+                                        'resubmit-app': ''})
+        self.assert3xx(r, self.webapp.get_dev_url('versions'))
+
     def test_comm_thread_after_resubmission(self):
         self.create_switch('comm-dashboard')
         self.webapp.update(status=amo.STATUS_REJECTED)

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -214,6 +214,12 @@ def status(request, addon_id, addon, webapp=False):
 
     if request.method == 'POST':
         if 'resubmit-app' in request.POST and form.is_valid():
+            if waffle.switch_is_active('iarc') and not addon.is_rated():
+                # Cannot resubmit without content ratings.
+                return http.HttpResponseForbidden(
+                    'This app must obtain content ratings before being '
+                    'resubmitted.')
+
             form.save()
             create_comm_note(addon, addon.latest_version,
                              request.amo_user, form.data['notes'],

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1210,10 +1210,15 @@ class Webapp(Addon):
         geodata.region_de_usk_exclude = has_usk_refused
 
         # Un-exclude games in Brazil/Germany once they get a content rating.
-        save = (save or geodata.region_br_iarc_exclude or
+        save = (save or
+                geodata.region_br_iarc_exclude or
                 geodata.region_de_iarc_exclude)
         geodata.region_br_iarc_exclude = False
         geodata.region_de_iarc_exclude = False
+
+        # Un-disable apps that were disabled by the great IARC purge.
+        if (self.status == amo.STATUS_DISABLED and self.iarc_purged):
+            self.update(status=amo.STATUS_PUBLIC, iarc_purged=False)
 
         if save:
             geodata.save()

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -715,7 +715,7 @@ class TestWebappContentRatings(amo.tests.TestCase):
         })
         ok_(not Geodata.objects.get(addon=app).region_de_usk_exclude)
 
-    def test_set_content_ratings_iarc_unexclude(self):
+    def test_set_content_ratings_iarc_games_unexclude(self):
         app = app_factory()
         app._geodata.update(region_br_iarc_exclude=True,
                             region_de_iarc_exclude=True)
@@ -727,6 +727,17 @@ class TestWebappContentRatings(amo.tests.TestCase):
         geodata = Geodata.objects.get(addon=app)
         ok_(not geodata.region_br_iarc_exclude)
         ok_(not geodata.region_de_iarc_exclude)
+
+    def test_set_content_ratings_purge_unexclude(self):
+        app = app_factory()
+        app.update(status=amo.STATUS_DISABLED, iarc_purged=True)
+
+        app.set_content_ratings({
+            mkt.ratingsbodies.USK: mkt.ratingsbodies.USK_12
+        })
+
+        ok_(not app.reload().iarc_purged)
+        eq_(app.status, amo.STATUS_PUBLIC)
 
     def test_set_descriptors(self):
         app = app_factory()
@@ -751,7 +762,6 @@ class TestWebappContentRatings(amo.tests.TestCase):
         app.set_descriptors([
             'has_esrb_blood', 'has_classind_drugs'
         ])
-        eq_(RatingDescriptors.objects.count(), 1)
         descriptors = RatingDescriptors.objects.get(addon=app)
         assert descriptors.has_esrb_blood
         assert descriptors.has_classind_drugs


### PR DESCRIPTION
IARC Purge - on April 15th, we disable public apps without content ratings
1. When an app is rejected, don't allow to resubmit without content rating.
2. When an app is "purged" but then gets a content rating, automatically re-enable.

![screen shot 2014-03-10 at 6 07 14 pm](https://f.cloud.github.com/assets/674727/2381080/f192d1f8-a8b9-11e3-968b-000fa4512525.png)
![screen shot 2014-03-10 at 6 09 27 pm](https://f.cloud.github.com/assets/674727/2381082/f7d4b5cc-a8b9-11e3-8188-902674cf3ec3.png)
