### PR TITLE
Fix wrongly caught UnicodeDecodeError in reviewers notification (bug 982031)

### DIFF
--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -1437,6 +1437,23 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         eq_(update_cached_manifests.delay.call_count, 0)
         eq_(storefront_mock.call_count, 1)
 
+    @mock.patch('mkt.webapps.models.Webapp.set_iarc_storefront_data')
+    @mock.patch('mkt.reviewers.views.messages.success')
+    @mock.patch('mkt.webapps.tasks.index_webapps')
+    @mock.patch('mkt.webapps.tasks.update_cached_manifests')
+    @mock.patch('mkt.webapps.models.Webapp.update_supported_locales')
+    @mock.patch('mkt.webapps.models.Webapp.update_name_from_package_manifest')
+    def test_pending_to_public_notification_translation(self, update_name,
+            update_locales, update_cached_manifests, index_webapps, messages,
+            storefront_mock):
+        data = {'action': 'public', 'device_types': '', 'browsers': '',
+                'comments': 'something'}
+        data.update(self._attachment_management_form(num=0))
+        self.client.post(self.url, data, HTTP_ACCEPT_LANGUAGE='es')
+        eq_(messages.call_args_list[0][0][1],
+            u'"Valoración de la aplicación web" successfully processed '
+            u'(+60 points, 60 total).')
+
     @mock.patch('mkt.reviewers.views.messages.success', new=mock.Mock)
     def test_incomplete_cant_approve(self):
         self.app.update(status=amo.STATUS_NULL)

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -341,17 +341,12 @@ def _review(request, addon, version):
         # Success message.
         if score:
             score = ReviewerScore.objects.filter(user=request.amo_user)[0]
-            rev_str = amo.REVIEWED_CHOICES[score.note_key]
-            try:
-                rev_str = str(unicode(rev_str))
-            except UnicodeEncodeError:
-                pass
             # L10N: {0} is the type of review. {1} is the points they earned.
             #       {2} is the points they now have total.
             success = _(
-                '"{0}" successfully processed (+{1} points, {2} total).'
-                .format(rev_str, score.score,
-                        ReviewerScore.get_total(request.amo_user)))
+               u'"{0}" successfully processed (+{1} points, {2} total).'
+                .format(unicode(amo.REVIEWED_CHOICES[score.note_key]),
+                        score.score, ReviewerScore.get_total(request.amo_user)))
         else:
             success = _('Review successfully processed.')
         messages.success(request, success)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=982031

Converting to `str` and catching `UnicodeDecodeError` is the wrong way to go, it will leave the string unproxified every time it cannot be converted to ascii. Instead, use unicode all the way.
