### PR TITLE
update InAppProduct API logo_url validations

### DIFF
--- a/mkt/inapp/models.py
+++ b/mkt/inapp/models.py
@@ -11,7 +11,7 @@ class InAppProduct(ModelBase):
     webapp = models.ForeignKey('webapps.WebApp')
     price = models.ForeignKey('market.Price')
     name = TranslatedField(require_locale=False)
-    logo_url = models.URLField(max_length=1024)
+    logo_url = models.URLField(max_length=1024, null=True, blank=True)
 
     class Meta:
         db_table = 'inapp_products'

--- a/mkt/inapp/serializers.py
+++ b/mkt/inapp/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from mkt.api.forms import SchemeURLValidator as URLValidator
 from mkt.inapp.models import InAppProduct
 
 
@@ -9,6 +10,9 @@ class InAppProductSerializer(serializers.ModelSerializer):
                                        source='webapp')
     price_id = serializers.PrimaryKeyRelatedField(source='price')
     name = serializers.CharField()
+    logo_url = serializers.CharField(
+            validators=[URLValidator(schemes=['http', 'https'])],
+            required=False)
 
     class Meta:
         model = InAppProduct

--- a/mkt/inapp/tests/test_serializers.py
+++ b/mkt/inapp/tests/test_serializers.py
@@ -1,0 +1,38 @@
+from nose.tools import eq_, ok_
+
+import amo.tests
+from market.models import Price
+from mkt.inapp.serializers import InAppProductSerializer
+from mkt.site.fixtures import fixture
+from mkt.webapps.models import Webapp
+
+
+class TestInAppProductSerializer(amo.tests.TestCase):
+    fixtures = fixture('webapp_337141', 'prices')
+
+    def setUp(self):
+        self.webapp = Webapp.objects.get(pk=337141)
+        price = Price.objects.all()[0]
+        self.valid_product_data = {
+            'name': 'Purple Gems',
+            'logo_url': 'https://marketplace.firefox.com/rocket.png',
+            'price_id': price.id,
+        }
+
+    def test_valid(self):
+        serializer = InAppProductSerializer(data=self.valid_product_data)
+        ok_(serializer.is_valid())
+
+    def test_no_logo_url(self):
+        product_data = dict(self.valid_product_data)
+        del product_data['logo_url']
+        serializer = InAppProductSerializer(data=product_data)
+        ok_(serializer.is_valid())
+
+    def test_create_ftp_scheme(self):
+        product_data = dict(self.valid_product_data)
+        product_data['logo_url'] = 'ftp://example.com/awesome.png'
+        serializer = InAppProductSerializer(data=product_data)
+        ok_(not serializer.is_valid())
+        eq_(serializer.errors['logo_url'],
+            ['Scheme should be one of http, https.'])


### PR DESCRIPTION
Allow blank `logo_url` and verify the scheme is http or https if it is present.
