### PR TITLE
Remove dependency on request object in JWT producers (bug #983824)

### DIFF
--- a/mkt/purchase/tests/test_webpay.py
+++ b/mkt/purchase/tests/test_webpay.py
@@ -20,19 +20,21 @@ from amo.tests import TestCase
 from amo.urlresolvers import reverse
 from market.models import AddonPurchase
 from mkt.api.exceptions import AlreadyPurchased
+from mkt.purchase.webpay import(make_ext_id, make_ext_id_inapp,
+                                _prepare_pay, _prepare_pay_inapp)
+from mkt import regions
 from stats.models import Contribution
 
-from utils import PurchaseTest
+from utils import InAppPurchaseTest, PurchaseTest
 
 
-@mock.patch.object(settings, 'SOLITUDE_HOSTS', ['host'])
-class TestPurchase(PurchaseTest):
+class BaseTestPurchase(PurchaseTest):
 
     def setUp(self):
-        super(TestPurchase, self).setUp()
+        super(BaseTestPurchase, self).setUp()
+        self.create_flag(name='solitude-payments')
         self.prepare_pay = reverse('webpay.prepare_pay',
                                    kwargs={'app_slug': self.addon.app_slug})
-        self.setup_package()
 
     def _req(self, method, url):
         req = getattr(self.client, method)
@@ -47,73 +49,39 @@ class TestPurchase(PurchaseTest):
     def post(self, url, **kw):
         return self._req('post', url, **kw)
 
-    def test_prepare_pay(self):
-        from mkt.purchase.webpay import make_ext_id
-        data = self.post(self.prepare_pay)
-        cn = Contribution.objects.get()
-        eq_(cn.type, amo.CONTRIB_PENDING)
-        eq_(cn.user, self.user)
-        eq_(cn.price_tier, self.price)
-
-        data = jwt.decode(data['webpayJWT'].encode('ascii'), verify=False)
-        eq_(data['typ'], settings.APP_PURCHASE_TYP)
-        eq_(data['aud'], settings.APP_PURCHASE_AUD)
-        req = data['request']
-        eq_(req['pricePoint'], self.price.name)
-        eq_(req['id'], make_ext_id(self.addon.pk))
-        eq_(req['name'], unicode(self.addon.name))
-        eq_(req['description'], unicode(self.addon.description))
-        eq_(req['postbackURL'], absolutify(reverse('webpay.postback')))
-        eq_(req['chargebackURL'], absolutify(reverse('webpay.chargeback')))
-        eq_(req['icons']['512'], absolutify(self.addon.get_icon_url(512)))
-        pd = urlparse.parse_qs(req['productData'])
-        eq_(pd['contrib_uuid'][0], cn.uuid)
-        eq_(pd['seller_uuid'][0], self.seller.uuid)
-        eq_(pd['addon_id'][0], str(self.addon.pk))
-        eq_(pd['application_size'][0], '388096')
-
-    def test_require_login(self):
-        self.client.logout()
-        resp = self.client.post(self.prepare_pay)
-        self.assertLoginRequired(resp)
-
     def test_pay_status(self):
-        uuid_ = '<returned from prepare-pay>'
-        cn = Contribution.objects.create(addon_id=self.addon.id,
-                                         amount=self.price.price,
-                                         uuid=uuid_,
-                                         type=amo.CONTRIB_PENDING,
-                                         user=self.user)
+        uuid = '<returned from prepare-pay>'
+        contribution = Contribution.objects.create(addon_id=self.addon.id,
+                                                   amount=self.price.price,
+                                                   uuid=uuid,
+                                                   type=amo.CONTRIB_PENDING,
+                                                   user=self.user)
+
         data = self.get(reverse('webpay.pay_status',
-                                args=[self.addon.app_slug, uuid_]))
+                                args=[self.addon.app_slug, uuid]))
+
         eq_(data['status'], 'incomplete')
 
-        cn.update(type=amo.CONTRIB_PURCHASE)
+        contribution.update(type=amo.CONTRIB_PURCHASE)
+
         data = self.get(reverse('webpay.pay_status',
-                                args=[self.addon.app_slug, uuid_]))
+                                args=[self.addon.app_slug, uuid]))
+
         eq_(data['status'], 'complete')
 
     def test_status_for_purchases_only(self):
-        uuid_ = '<returned from prepare-pay>'
+        uuid = '<returned from prepare-pay>'
         Contribution.objects.create(addon_id=self.addon.id,
                                     amount=self.price.price,
-                                    uuid=uuid_,
+                                    uuid=uuid,
                                     type=amo.CONTRIB_PURCHASE,
                                     user=self.user)
         self.client.logout()
         assert self.client.login(username='admin@mozilla.com',
                                  password='password')
         data = self.get(reverse('webpay.pay_status',
-                                args=[self.addon.app_slug, uuid_]))
+                                args=[self.addon.app_slug, uuid]))
         eq_(data['status'], 'incomplete')
-
-    def test_status_for_already_purchased(self):
-        AddonPurchase.objects.create(addon=self.addon,
-                                     user=self.user,
-                                     type=amo.CONTRIB_PURCHASE)
-
-        with self.assertRaises(AlreadyPurchased):
-            self.client.post(self.prepare_pay)
 
     def test_pay_status_for_unknown_contrib(self):
         data = self.get(reverse('webpay.pay_status',
@@ -128,30 +96,32 @@ class TestPurchase(PurchaseTest):
         req = data['request']
         eq_(req['description'], 'Some site')
 
+    def test_status_for_already_purchased(self):
+        AddonPurchase.objects.create(addon=self.addon,
+                                     user=self.user,
+                                     type=amo.CONTRIB_PURCHASE)
 
-class TestPurchaseJWT(PurchaseTest):
+        with self.assertRaises(AlreadyPurchased):
+            self.client.post(self.prepare_pay)
 
-    def setUp(self):
-        super(TestPurchaseJWT, self).setUp()
-        self.prepare_pay = reverse('webpay.prepare_pay',
-                                   kwargs={'app_slug': self.addon.app_slug})
+    def test_require_login(self):
+        self.client.logout()
+        resp = self.client.post(self.prepare_pay)
+        self.assertLoginRequired(resp)
 
-    def pay_jwt(self, lang=None):
-        if not lang:
-            lang = 'en-US'
-        resp = self.client.post(self.prepare_pay,
-                                HTTP_ACCEPT_LANGUAGE=lang)
-        return json.loads(resp.content)['webpayJWT']
 
-    def pay_jwt_dict(self, lang=None):
-        return jwt.decode(str(self.pay_jwt(lang=lang)), verify=False)
+class BaseTestPurchaseJWT(object):
+
+    def pay_jwt(self):
+        return self.get_jwt()['webpayJWT']
+
+    def pay_jwt_dict(self):
+        return jwt.decode(str(self.pay_jwt()), verify=False)
 
     def test_claims(self):
-        self.setup_package()
         verify_claims(self.pay_jwt_dict())
 
     def test_keys(self):
-        self.setup_package()
         verify_keys(self.pay_jwt_dict(),
                     ('iss',
                      'typ',
@@ -165,6 +135,84 @@ class TestPurchaseJWT(PurchaseTest):
                      'request.chargebackURL',
                      'request.productData'))
 
+    def validate_token_data(self, token_data):
+        eq_(token_data['typ'], settings.APP_PURCHASE_TYP)
+        eq_(token_data['aud'], settings.APP_PURCHASE_AUD)
+
+    def validate_prepare_pay_product_data(self, product_data, contribution):
+        eq_(product_data['contrib_uuid'][0], contribution.uuid)
+        eq_(product_data['seller_uuid'][0], self.seller.uuid)
+        eq_(product_data['addon_id'][0], str(self.addon.pk))
+
+    def validate_prepare_pay_request(self, request):
+        eq_(request['pricePoint'], self.price.name)
+        eq_(request['description'], unicode(self.addon.description))
+        eq_(request['postbackURL'], absolutify(reverse('webpay.postback')))
+        eq_(request['chargebackURL'], absolutify(reverse('webpay.chargeback')))
+
+    def validate_contribution(self, contribution):
+        eq_(contribution.type, amo.CONTRIB_PENDING)
+        eq_(contribution.price_tier, self.price)
+
+    def test_prepare_pay(self):
+        token = self.get_jwt()
+        token_data = jwt.decode(token['webpayJWT'].encode('ascii'),
+                                verify=False)
+
+        contribution = Contribution.objects.get()
+        self.validate_contribution(contribution)
+
+        self.validate_token_data(token_data)
+
+        request = token_data['request']
+        self.validate_prepare_pay_request(request)
+
+        product_token_data = urlparse.parse_qs(request['productData'])
+        self.validate_prepare_pay_product_data(product_token_data,
+                                               contribution)
+
+
+class TestPurchaseWebappJWT(BaseTestPurchaseJWT, PurchaseTest):
+
+    def get_jwt(self):
+        return _prepare_pay(self.addon, user=self.user,
+                            region=regions.US)
+
+    def validate_prepare_pay_product_data(self, product_data, contribution):
+        super(TestPurchaseWebappJWT, self).validate_prepare_pay_product_data(
+            product_data, contribution)
+        eq_(product_data['application_size'][0],
+            str(self.addon.current_version.all_files[0].size))
+
+    def validate_prepare_pay_request(self, request):
+        super(TestPurchaseWebappJWT,
+              self).validate_prepare_pay_request(request)
+        eq_(request['id'], make_ext_id(self.addon.pk))
+        eq_(request['name'], unicode(self.addon.name))
+        eq_(request['icons']['512'], absolutify(self.addon.get_icon_url(512)))
+
+    def validate_contribution(self, contribution):
+        eq_(contribution.user, self.user)
+
+
+class TestPurchaseInappJWT(BaseTestPurchaseJWT, InAppPurchaseTest):
+
+    def get_jwt(self):
+        return _prepare_pay_inapp(self.inapp)
+
+    def validate_prepare_pay_product_data(self, product_data, contribution):
+        super(TestPurchaseInappJWT, self).validate_prepare_pay_product_data(
+            product_data,
+            contribution
+        )
+        eq_(product_data['application_size'][0], u'None')
+
+    def validate_prepare_pay_request(self, request):
+        super(TestPurchaseInappJWT, self).validate_prepare_pay_request(request)
+        eq_(request['id'], make_ext_id_inapp(self.inapp.pk))
+        eq_(request['name'], unicode(self.inapp.name))
+        eq_(request['icons']['64'], absolutify(self.inapp.logo_url))
+
 
 @mock.patch.object(settings, 'SOLITUDE_HOSTS', ['host'])
 @mock.patch('mkt.purchase.webpay.tasks')
@@ -174,11 +222,12 @@ class TestPostback(PurchaseTest):
         super(TestPostback, self).setUp()
         self.client.logout()
         self.contrib = Contribution.objects.create(
-                                        addon_id=self.addon.id,
-                                        amount=self.price.price,
-                                        uuid='<some uuid>',
-                                        type=amo.CONTRIB_PENDING,
-                                        user=self.user)
+            addon_id=self.addon.id,
+            amount=self.price.price,
+            uuid='<some uuid>',
+            type=amo.CONTRIB_PENDING,
+            user=self.user
+        )
         self.webpay_dev_id = '<stored in solitude>'
         self.webpay_dev_secret = '<stored in solitude>'
 
@@ -193,25 +242,26 @@ class TestPostback(PurchaseTest):
             issued_at = calendar.timegm(time.gmtime())
         if not contrib_uuid:
             contrib_uuid = self.contrib.uuid
-        return {'iss': 'mozilla',
-                'aud': self.webpay_dev_id,
-                'typ': 'mozilla/payments/inapp/v1',
-                'iat': issued_at,
-                'exp': issued_at + expiry,
-                'request': {
-                    'name': 'Some App',
-                    'description': 'fantastic app',
-                    'pricePoint': '1',
-                    'currencyCode': 'USD',
-                    'postbackURL': '/postback',
-                    'chargebackURL': '/chargeback',
-                    'productData': 'contrib_uuid=%s' % contrib_uuid
-                },
-                'response': {
-                    'transactionID': '<webpay-trans-id>',
-                    'price': {'amount': '10.99', 'currency': 'BRL'}
-                },
-            }
+        return {
+            'iss': 'mozilla',
+            'aud': self.webpay_dev_id,
+            'typ': 'mozilla/payments/inapp/v1',
+            'iat': issued_at,
+            'exp': issued_at + expiry,
+            'request': {
+                'name': 'Some App',
+                'description': 'fantastic app',
+                'pricePoint': '1',
+                'currencyCode': 'USD',
+                'postbackURL': '/postback',
+                'chargebackURL': '/chargeback',
+                'productData': 'contrib_uuid=%s' % contrib_uuid
+            },
+            'response': {
+                'transactionID': '<webpay-trans-id>',
+                'price': {'amount': '10.99', 'currency': 'BRL'}
+            },
+        }
 
     def jwt(self, req=None, **kw):
         if not req:

--- a/mkt/purchase/tests/utils.py
+++ b/mkt/purchase/tests/utils.py
@@ -3,11 +3,11 @@ from decimal import Decimal
 import amo.tests
 from addons.models import Addon
 from market.models import AddonPremium, Price, PriceCurrency
-from users.models import UserProfile
-
+from mkt.inapp.models import InAppProduct
 from mkt.developers.models import (AddonPaymentAccount, PaymentAccount,
                                    SolitudeSeller)
 from mkt.site.fixtures import fixture
+from users.models import UserProfile
 
 
 class PurchaseTest(amo.tests.TestCase):
@@ -21,12 +21,16 @@ class PurchaseTest(amo.tests.TestCase):
         self.brl = PriceCurrency.objects.create(currency='BRL',
                                                 price=Decimal('0.5'),
                                                 tier_id=1)
+        self.setup_package()
 
     def setup_base(self):
         self.addon = Addon.objects.get(pk=337141)
         self.addon.update(premium_type=amo.ADDON_PREMIUM)
         self.price = Price.objects.get(pk=1)
         AddonPremium.objects.create(addon=self.addon, price=self.price)
+
+        # Refetch addon from the database to populate addon.premium field.
+        self.addon = Addon.objects.get(pk=self.addon.pk)
 
     def setup_package(self):
         self.seller = SolitudeSeller.objects.create(
@@ -37,3 +41,12 @@ class PurchaseTest(amo.tests.TestCase):
         AddonPaymentAccount.objects.create(
             addon=self.addon, account_uri='foo',
             payment_account=self.account, product_uri='bpruri')
+
+
+class InAppPurchaseTest(PurchaseTest):
+
+    def setUp(self):
+        super(InAppPurchaseTest, self).setUp()
+        self.inapp = InAppProduct.objects.create(
+            logo_url='logo.png', name='Inapp Object', price=self.price,
+            webapp=self.addon)

--- a/mkt/webpay/tests/test_resources.py
+++ b/mkt/webpay/tests/test_resources.py
@@ -134,7 +134,8 @@ class TestStatus(RestOAuth):
 class TestPrices(RestOAuth):
 
     def make_currency(self, amount, tier, currency, region):
-        return PriceCurrency.objects.create(price=Decimal(amount), tier=tier,
+        return PriceCurrency.objects.create(
+            price=Decimal(amount), tier=tier,
             currency=currency, provider=PROVIDER_BANGO, region=region.id)
 
     def setUp(self):
@@ -345,7 +346,8 @@ class TestProductIconResource(RestOAuth):
         data = json.loads(res.content)
         eq_(len(data['objects']), 2)
 
-        res = self.anon.get(self.list_url,
+        res = self.anon.get(
+            self.list_url,
             data={'ext_url': 'http://someappnoreally.com/icons/icon_256.png'})
         eq_(res.status_code, 200)
         data = json.loads(res.content)


### PR DESCRIPTION
- Remove request as argument to _prepare_pay and _prepare_pay_inapp
- Modify tests to talk directly to JWT producers
- Remove request dependent logic from JWT producer and move into view
- Update views to unpack request object and pass data directly into JWT producers
