### PR TITLE
slim down content ratings api responses(bug 982991)

### DIFF
--- a/docs/api/topics/apps.rst
+++ b/docs/api/topics/apps.rst
@@ -57,29 +57,10 @@ App
                 "games"
             ],
             "content_ratings": {
-                "ratings": {
-                    "esrb": {"body": "ESRB", "body_label": "esrb", "rating": "Teen", "rating_label": "13", "description": "Not recommended for users younger than 13."},
-                    "classind": {"body": "CLASSIND", "body_label": "classind", "rating": "For ages 14+", "rating_label": "14", "description": "Not recommended for users younger than 14."},
-                    "pegi": {"body": "PEGI", "body_label": "pegi", "rating": "For ages 12+", "rating_label": "12", "description": "Not recommended for users younger than 12."},
-                    "usk": {"body": "USK", "body_label": "usk", "rating": "For ages 16+", "rating_label": "16", "description": "Not recommended for users younger than 16."},
-                    "generic": {"body": "Generic", "body_label": "generic", "rating": "For ages 13+", "rating_label": "13", "description": "Not recommended for users younger than 13."}
-                },
-                "descriptors": {
-                    "esrb": [{"label": "esrb-scary", "name": "Scary Themes"}],
-                    "generic": [{"label": "generic-scary", "name": "Fear"}]
-                },
-                "interactive_elements": [
-                    {"label": "users-interact", "name": "Users Interact"},
-                    {"label": "shares-location", "name": "Shares Location"},
-                ]
-                "regions": {
-                    "us": "esrb",
-                    "mx": "esrb",
-                    "br": "classind",
-                    "es": "pegi",
-                    "it": "pegi",
-                    "de": "usk"
-                }
+                "body": "esrb",
+                "rating": "13",
+                "descriptors": ["scary"],
+                "interactives": ["users-interact', "shares-location"]
             },
             "created": "2013-09-17T13:19:16",
             "current_version": "1.1",
@@ -183,19 +164,18 @@ App
         ``interactive_elements``. If a region is detected, only a subset
         of data will be returned.
     :type content_ratings: object
-    :param content_ratings.ratings: Content ratings associated with the app.
-    :type content_ratings.ratings: object
+    :param content_ratings.body: The rating body that assigned the content
+        rating. It is based off of the region of the request. It can be
+        'classind', 'esrb', 'generic', 'pegi', or 'usk.
+    :type content_ratings.body: string
+    :param content_ratings.rating: The content rating (usually an age).
+    :type content_ratings.ratings: string
     :param content_ratings.descriptors: IARC content descriptors, flags about
         the app that might affect its suitability for younger-aged users.
-    :type content_ratings.descriptors: object
-    :param content_ratings.interactive_elements: IARC interactive elements,
+    :type content_ratings.descriptors: array
+    :param content_ratings.interactives: IARC interactive elements,
         aspects about the app relating to whether the app shares info or
         interacts with external elements.
-    :type content_ratings.interactive_elements: array
-    :param content_ratings.regions: The mapping of region slugs to their
-        respective and assigned IARC ratings bodies. Regions that do not fall
-        under any of the listed regions uses the "generic" content rating in
-        content_ratings.ratings.
     :type content_ratings.interactive_elements: array
     :param created: The date the app was added to the Marketplace, in ISO 8601
         format.

--- a/docs/api/topics/content_ratings.rst
+++ b/docs/api/topics/content_ratings.rst
@@ -35,24 +35,16 @@ Content Rating
         {
             "objects": [
                 {
-                    "id": 34,
                     "created": "2013-06-14T11:54:24",
                     "modified": "2013-06-24T22:01:37",
-                    "body_name": "ESRB",
-                    "body_slug": "esrb",
-                    "name": "Everyone 10+",
-                    "slug": "10",
-                    "description": "Not recommended for users younger than 10 years of age"
+                    "body": "esrb",
+                    "rating": "10",
                 },
                 {
-                    "id": 35,
                     "created": "2013-06-14T11:54:24",
                     "modified": "2013-06-24T22:01:37",
-                    "body_name": "PEGI",
-                    "body_slug": "pegi",
-                    "name": "3+",
-                    "slug": "3",
-                    "description": "Not recommended for users younger than 3 years of age"
+                    "body": "pegi",
+                    "rating": "3",
                 },
                 ...
             ]

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -695,53 +695,6 @@ class TestAppDetail(RestOAuth):
         eq_(data['banner_message'], unicode(geodata.banner_message))
         eq_(data['banner_regions'], [mkt.regions.AR.slug, mkt.regions.BR.slug])
 
-    def test_get_content_ratings(self):
-        rating = ratingsbodies.CLASSIND_12
-        self.app.content_ratings.create(ratings_body=ratingsbodies.CLASSIND.id,
-                                        rating=rating.id)
-        self.app.save()
-
-        res = self.client.get(self.get_url)
-        eq_(res.status_code, 200)
-        data = json.loads(res.content)
-        cr = data.get('content_ratings')['ratings']
-
-        eq_(cr['classind']['body'], 'CLASSIND')
-        ok_(cr['classind']['rating'])
-        ok_(cr['classind']['description'])
-
-    def test_get_content_descriptors(self):
-        self.app.set_descriptors(['has_esrb_blood', 'has_pegi_scary'])
-
-        res = self.client.get(self.get_url)
-        eq_(res.status_code, 200)
-        data = json.loads(res.content)
-
-        eq_(data['content_ratings']['descriptors'],
-            {'esrb': [{'label': 'blood', 'name': 'Blood'}],
-             'pegi': [{'label': 'scary', 'name': 'Fear'}]})
-
-    def test_get_interactive_elements(self):
-        self.app.set_interactives(['has_digital_purchases', 'has_shares_info'])
-
-        res = self.client.get(self.get_url)
-        eq_(res.status_code, 200)
-        data = json.loads(res.content)
-
-        eq_(data['content_ratings']['interactive_elements'],
-            [{'label': 'shares-info', 'name': 'Shares Info'},
-             {'label': 'digital-purchases', 'name': 'Digital Purchases'}])
-
-    def test_get_content_descriptors_region(self):
-        self.app.set_descriptors(['has_usk_violence', 'has_esrb_violence'])
-
-        res = self.client.get(self.get_url, data={'region': 'de'})
-        eq_(res.status_code, 200)
-        data = json.loads(res.content)
-
-        eq_(data['content_ratings']['descriptors'],
-            {'usk': [{'label': 'violence', 'name': 'Violence'}]})
-
 
 class TestCategoryHandler(RestOAuth):
 

--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -2,12 +2,6 @@
 from tower import ugettext_lazy as _lazy
 
 
-DESC_GENERAL = _lazy(u'General Audiences')
-# L10n: %d is the age in years.
-DESC_LAZY = _lazy(u'Not recommended for users younger than %d years of age')
-DESC_REJECTED = _lazy(u'Rejected for All Audiences')
-DESC_PENDING = _lazy(u'Rating Pending')
-
 NAME_GENERAL = _lazy('For all ages')
 # L10n: %d is the age in years. For ages %d and higher.
 NAME_LAZY = _lazy('For ages %d+')  # Fill this in after accessing.
@@ -23,12 +17,10 @@ class RATING(object):
     age -- minimum age of the rating's age recommendation.
     name -- how we name the rating, for translated display on all pages.
     label -- for CSS classes, to create icons.
-    description -- for general translated display on consumer pages.
     """
     age = None
     name = None
     label = None
-    description = None
     adult = False
 
 
@@ -138,7 +130,6 @@ class GENERIC_RP(RATING):
     iarc_name = 'RP'
     label = 'pending'
     name = NAME_PENDING
-    description = DESC_PENDING
 
 
 class GENERIC(RATING_BODY):
@@ -191,7 +182,6 @@ class USK_REJECTED(RATING):
     iarc_name = 'Rating Refused'
     label = 'rating-refused'
     name = NAME_REJECTED
-    description = DESC_REJECTED
 
 
 class USK(RATING_BODY):
@@ -215,7 +205,6 @@ class ESRB_E(RATING):
     age = 0
     iarc_name = 'Everyone'
     name = _lazy('Everyone')
-    description = DESC_GENERAL
 
 
 class ESRB_10(RATING):
@@ -379,14 +368,8 @@ def dehydrate_rating(rating_class):
             rating.name = unicode(NAME_GENERAL)
         else:
             rating.name = unicode(NAME_LAZY) % rating.age
-    if rating.description is None:
-        if rating.age == 0:
-            rating.description = unicode(DESC_GENERAL)
-        else:
-            rating.description = unicode(DESC_LAZY) % rating.age
 
     rating.name = unicode(rating.name)
-    rating.description = unicode(rating.description)
     return rating
 
 

--- a/mkt/developers/api.py
+++ b/mkt/developers/api.py
@@ -19,32 +19,18 @@ log = commonware.log.getLogger('z.devhub')
 
 
 class ContentRatingSerializer(ModelSerializer):
-    body_name = SerializerMethodField('get_body_name')
-    body_slug = SerializerMethodField('get_body_slug')
+    body = SerializerMethodField('get_body')
+    rating = SerializerMethodField('get_rating')
 
-    name = SerializerMethodField('get_rating_name')
-    slug = SerializerMethodField('get_rating_slug')
-    description = SerializerMethodField('get_rating_description')
-
-    def get_body_name(self, obj):
-        return obj.get_body().name
-
-    def get_body_slug(self, obj):
+    def get_body(self, obj):
         return obj.get_body().label
 
-    def get_rating_name(self, obj):
-        return obj.get_rating().name
-
-    def get_rating_slug(self, obj):
+    def get_rating(self, obj):
         return obj.get_rating().label
-
-    def get_rating_description(self, obj):
-        return obj.get_rating().description
 
     class Meta:
         model = ContentRating
-        fields = ('id', 'created', 'modified', 'body_name', 'body_slug',
-                  'name', 'slug', 'description')
+        fields = ('created', 'modified', 'body', 'rating')
 
 
 class ContentRatingList(CORSMixin, SlugOrIdMixin, ListAPIView):

--- a/mkt/developers/tests/test_api.py
+++ b/mkt/developers/tests/test_api.py
@@ -33,11 +33,8 @@ class TestContentRating(amo.tests.TestCase):
         res = json.loads(res.content)
         eq_(len(res['objects']), 2)
         rating = res['objects'][0]
-        eq_(rating['body_slug'], 'classind')
-        eq_(rating['body_name'], 'CLASSIND')
-        assert rating['name']
-        eq_(rating['slug'], '0')
-        assert 'description' in rating
+        eq_(rating['body'], 'classind')
+        eq_(rating['rating'], '0')
 
     def test_get_content_ratings_since(self):
         cr = ContentRating.objects.create(addon=self.app, ratings_body=0,

--- a/mkt/search/tests/test_api.py
+++ b/mkt/search/tests/test_api.py
@@ -195,9 +195,10 @@ class TestApi(RestOAuth, ESTestCase):
             eq_(obj['absolute_url'],
                 absolutify(self.webapp.get_absolute_url()))
             eq_(obj['app_type'], self.webapp.app_type)
-            eq_(content_ratings['descriptors'], {})
-            eq_(content_ratings['interactive_elements'], [])
-            eq_(content_ratings['ratings'], None)
+            eq_(content_ratings['body'], 'generic')
+            eq_(content_ratings['rating'], None)
+            eq_(content_ratings['descriptors'], [])
+            eq_(content_ratings['interactives'], [])
             eq_(obj['current_version'], u'1.0')
             eq_(obj['description'],
                 {'en-US': self.webapp.description.localized_string})
@@ -657,12 +658,12 @@ class TestApi(RestOAuth, ESTestCase):
 
     def test_content_ratings_reindex(self):
         self.webapp.set_content_ratings({
-            mkt.ratingsbodies.ESRB: mkt.ratingsbodies.ESRB_T
+            mkt.ratingsbodies.GENERIC: mkt.ratingsbodies.GENERIC_18
         })
         self.refresh('webapp')
         res = self.client.get(self.url)
         obj = res.json['objects'][0]
-        ok_(obj['content_ratings']['ratings'])
+        ok_(obj['content_ratings']['rating'])
 
     def test_usk_refused_exclude(self):
         geodata = self.webapp._geodata

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -677,7 +677,6 @@ class TestWebappContentRatings(amo.tests.TestCase):
             rb.PEGI: rb.PEGI_3,
             rb.GENERIC: rb.GENERIC_18,
         })
-        eq_(ContentRating.objects.count(), 3)
         for expected in [(rb.CLASSIND.id, rb.CLASSIND_10.id),
                          (rb.PEGI.id, rb.PEGI_3.id),
                          (rb.GENERIC.id, rb.GENERIC_18.id)]:
@@ -733,7 +732,6 @@ class TestWebappContentRatings(amo.tests.TestCase):
         app = app_factory()
         eq_(RatingDescriptors.objects.count(), 0)
         app.set_descriptors([])
-        eq_(RatingDescriptors.objects.count(), 1)
 
         descriptors = RatingDescriptors.objects.get(addon=app)
         assert not descriptors.has_classind_drugs
@@ -743,7 +741,6 @@ class TestWebappContentRatings(amo.tests.TestCase):
         app.set_descriptors([
             'has_classind_drugs', 'has_pegi_scary', 'has_generic_drugs'
         ])
-        eq_(RatingDescriptors.objects.count(), 1)
         descriptors = RatingDescriptors.objects.get(addon=app)
         assert descriptors.has_classind_drugs
         assert descriptors.has_pegi_scary
@@ -904,8 +901,7 @@ class TestWebappContentRatings(amo.tests.TestCase):
 
         app.set_descriptors(['has_esrb_blood', 'has_pegi_scary'])
         eq_(dict(app.get_descriptors()),
-            {'esrb': [{'label': 'blood', 'name': 'Blood'}],
-             'pegi': [{'label': 'scary', 'name': 'Fear'}]})
+            {'esrb': ['blood'], 'pegi': ['scary']})
 
     def test_get_interactives_es(self):
         app = app_factory()
@@ -920,9 +916,7 @@ class TestWebappContentRatings(amo.tests.TestCase):
         eq_(app.get_interactives(), [])
 
         app.set_interactives(['has_digital_purchases', 'has_shares_info'])
-        eq_(app.get_interactives(),
-            [{'label': 'shares-info', 'name': 'Shares Info'},
-             {'label': 'digital-purchases', 'name': 'Digital Purchases'}])
+        eq_(app.get_interactives(), ['shares-info', 'digital-purchases'])
 
     @override_settings(SECRET_KEY='test')
     def test_iarc_token(self):


### PR DESCRIPTION
Now looks like `"content_ratings":{"body":"generic","rating":"3","interactives":["users-interact","shares-info","shares-location"],"descriptors":[]}`
- Infer which rating body to use in Zamboni, not client side, which simplifies things
- Remove description
- Shorten key name
- Pass in slugs only, not translated strings
- Remove some dupe coverage tests
