### PR TITLE
My Apps should be listed in reverse chronological order (Bug 982854)

### DIFF
--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -66,7 +66,7 @@ class InstalledView(CORSMixin, MarketplaceView, ListAPIView):
         return Webapp.objects.no_cache().filter(
             installed__user=self.request.amo_user,
             installed__install_type=INSTALL_TYPE_USER).order_by(
-                'installed__id')
+                '-installed__created')
 
 
 class CreateAPIViewWithoutModel(CreateAPIView):


### PR DESCRIPTION
As suggested in [Bug 982854](https://bugzilla.mozilla.org/show_bug.cgi?id=982854), this will list the apps in 'My Apps' in reverse chronological order.
