### PR TITLE
Don't hide content just to remove file inputs (bug 974191)

### DIFF
--- a/media/css/devreg/invisible-upload.styl
+++ b/media/css/devreg/invisible-upload.styl
@@ -52,3 +52,12 @@
         }
     }
 }
+
+/* Hide upload form on devices with no filesystem (Unagi, some other mobile) */
+.filesystem-only {
+  display: none;
+}
+/* Show upload form if there is a filesystem, depends on JS feature detection */
+.filesystem .filesystem-only {
+  display: block;
+}

--- a/media/js/devreg/capabilities.js
+++ b/media/js/devreg/capabilities.js
@@ -4,6 +4,7 @@ function safeMatchMedia(query) {
 }
 
 define('capabilities', [], function() {
+    var div = document.createElement('div');
     var capabilities = {
         'JSON': window.JSON && typeof JSON.parse == 'function',
         'debug': (('' + document.location).indexOf('dbg') >= 0),
@@ -19,6 +20,8 @@ define('capabilities', [], function() {
             typeof navigator.mozApps.html5Implementation === 'undefined'
         ),
         'fileAPI': !!window.FileReader,
+        'dragAndDrop': ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div),
+        'filesystem': false,
         'userAgent': navigator.userAgent,
         'desktop': false,
         'tablet': false,
@@ -76,6 +79,8 @@ define('capabilities', [], function() {
         }
     } catch (e) {
     }
+
+    capabilities.filesystem = capabilities.fileAPI && capabilities.dragAndDrop; 
 
     return capabilities;
 

--- a/media/js/devreg/reviewers/reviewers_init.js
+++ b/media/js/devreg/reviewers/reviewers_init.js
@@ -15,6 +15,10 @@
         }
     });
 
+    if (z.capabilities.filesystem) {
+        document.body.classList.add('filesystem');
+    }
+
     require('reviewers');
 
 })();

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -137,8 +137,7 @@
         {{ form.device_types.errors }}
         {{ form.browsers.errors }}
       </div>
-      <div class="review-actions-section review-actions-attachments hidden">
-      <div class="review-actions-section review-actions-attachments">
+      <div class="review-actions-section review-actions-attachments filesystem-only">
         {% set max_attachment_size = attachment_formset[0].max_upload_size|filesizeformat %}
         <strong>{{ _('Attach a screenshot or log file (max {0})'|f(max_attachment_size)) }}</strong>
         {% for attachment_form_errors in attachment_formset.errors %}


### PR DESCRIPTION
In order to hide the file inputs on the reviewer page there was an extra &lt;div> which had the side effect of hiding the entire end of the page, including the file inputs, checkboxes, and the submit button. I removed the extraneous div and added a class and a feature test so the file inputs (and _only_ the file inputs) should be hidden if there is not filesystem support on the device. Unfortunately, I don't have a device without filesystem support to test on (Unagi, for instance), but have tested that the hidden content is now shown.
