### PR TITLE
Refactor JWT generation to reduce code duplication (bug 979551)

### DIFF
--- a/mkt/purchase/tests/test_webpay.py
+++ b/mkt/purchase/tests/test_webpay.py
@@ -1,7 +1,6 @@
 import calendar
 import json
 import time
-import urlparse
 from decimal import Decimal
 
 from django.conf import settings
@@ -11,27 +10,21 @@ import jwt
 import mock
 from mock import ANY
 from mozpay.exc import RequestExpired
-from mozpay.verify import verify_claims, verify_keys
 from nose.tools import eq_, raises
 
 import amo
-from amo.helpers import absolutify
-from amo.tests import TestCase
 from amo.urlresolvers import reverse
 from market.models import AddonPurchase
 from mkt.api.exceptions import AlreadyPurchased
-from mkt.purchase.webpay import(make_ext_id, make_ext_id_inapp,
-                                _prepare_pay, _prepare_pay_inapp)
-from mkt import regions
 from stats.models import Contribution
 
-from utils import InAppPurchaseTest, PurchaseTest
+from utils import PurchaseTest
 
 
-class BaseTestPurchase(PurchaseTest):
+class TestWebAppPurchase(PurchaseTest):
 
     def setUp(self):
-        super(BaseTestPurchase, self).setUp()
+        super(TestWebAppPurchase, self).setUp()
         self.create_flag(name='solitude-payments')
         self.prepare_pay = reverse('webpay.prepare_pay',
                                    kwargs={'app_slug': self.addon.app_slug})
@@ -108,110 +101,6 @@ class BaseTestPurchase(PurchaseTest):
         self.client.logout()
         resp = self.client.post(self.prepare_pay)
         self.assertLoginRequired(resp)
-
-
-class BaseTestPurchaseJWT(object):
-
-    def pay_jwt(self):
-        return self.get_jwt()['webpayJWT']
-
-    def pay_jwt_dict(self):
-        return jwt.decode(str(self.pay_jwt()), verify=False)
-
-    def test_claims(self):
-        verify_claims(self.pay_jwt_dict())
-
-    def test_keys(self):
-        verify_keys(self.pay_jwt_dict(),
-                    ('iss',
-                     'typ',
-                     'aud',
-                     'iat',
-                     'exp',
-                     'request.name',
-                     'request.description',
-                     'request.pricePoint',
-                     'request.postbackURL',
-                     'request.chargebackURL',
-                     'request.productData'))
-
-    def validate_token_data(self, token_data):
-        eq_(token_data['typ'], settings.APP_PURCHASE_TYP)
-        eq_(token_data['aud'], settings.APP_PURCHASE_AUD)
-
-    def validate_prepare_pay_product_data(self, product_data, contribution):
-        eq_(product_data['contrib_uuid'][0], contribution.uuid)
-        eq_(product_data['seller_uuid'][0], self.seller.uuid)
-        eq_(product_data['addon_id'][0], str(self.addon.pk))
-
-    def validate_prepare_pay_request(self, request):
-        eq_(request['pricePoint'], self.price.name)
-        eq_(request['description'], unicode(self.addon.description))
-        eq_(request['postbackURL'], absolutify(reverse('webpay.postback')))
-        eq_(request['chargebackURL'], absolutify(reverse('webpay.chargeback')))
-
-    def validate_contribution(self, contribution):
-        eq_(contribution.type, amo.CONTRIB_PENDING)
-        eq_(contribution.price_tier, self.price)
-
-    def test_prepare_pay(self):
-        token = self.get_jwt()
-        token_data = jwt.decode(token['webpayJWT'].encode('ascii'),
-                                verify=False)
-
-        contribution = Contribution.objects.get()
-        self.validate_contribution(contribution)
-
-        self.validate_token_data(token_data)
-
-        request = token_data['request']
-        self.validate_prepare_pay_request(request)
-
-        product_token_data = urlparse.parse_qs(request['productData'])
-        self.validate_prepare_pay_product_data(product_token_data,
-                                               contribution)
-
-
-class TestPurchaseWebappJWT(BaseTestPurchaseJWT, PurchaseTest):
-
-    def get_jwt(self):
-        return _prepare_pay(self.addon, user=self.user,
-                            region=regions.US)
-
-    def validate_prepare_pay_product_data(self, product_data, contribution):
-        super(TestPurchaseWebappJWT, self).validate_prepare_pay_product_data(
-            product_data, contribution)
-        eq_(product_data['application_size'][0],
-            str(self.addon.current_version.all_files[0].size))
-
-    def validate_prepare_pay_request(self, request):
-        super(TestPurchaseWebappJWT,
-              self).validate_prepare_pay_request(request)
-        eq_(request['id'], make_ext_id(self.addon.pk))
-        eq_(request['name'], unicode(self.addon.name))
-        eq_(request['icons']['512'], absolutify(self.addon.get_icon_url(512)))
-
-    def validate_contribution(self, contribution):
-        eq_(contribution.user, self.user)
-
-
-class TestPurchaseInappJWT(BaseTestPurchaseJWT, InAppPurchaseTest):
-
-    def get_jwt(self):
-        return _prepare_pay_inapp(self.inapp)
-
-    def validate_prepare_pay_product_data(self, product_data, contribution):
-        super(TestPurchaseInappJWT, self).validate_prepare_pay_product_data(
-            product_data,
-            contribution
-        )
-        eq_(product_data['application_size'][0], u'None')
-
-    def validate_prepare_pay_request(self, request):
-        super(TestPurchaseInappJWT, self).validate_prepare_pay_request(request)
-        eq_(request['id'], make_ext_id_inapp(self.inapp.pk))
-        eq_(request['name'], unicode(self.inapp.name))
-        eq_(request['icons']['64'], absolutify(self.inapp.logo_url))
 
 
 @mock.patch.object(settings, 'SOLITUDE_HOSTS', ['host'])
@@ -338,18 +227,3 @@ class TestPostback(PurchaseTest):
 
         parse_from_webpay.expects_call().returns(example)
         self.post()
-
-
-class TestExtId(TestCase):
-
-    def setUp(self):
-        from mkt.purchase.webpay import make_ext_id
-        self.ext_id = make_ext_id
-
-    def test_no_domain(self):
-        with self.settings(DOMAIN=None):
-            eq_(self.ext_id(123), 'marketplace-dev:123')
-
-    def test_domain(self):
-        with self.settings(DOMAIN='marketplace.allizom.org'):
-            eq_(self.ext_id(123), 'marketplace:123')

--- a/mkt/purchase/tests/test_webpay_jwt.py
+++ b/mkt/purchase/tests/test_webpay_jwt.py
@@ -1,0 +1,166 @@
+import urlparse
+from urllib import urlencode
+
+from django.conf import settings
+
+import jwt
+from mozpay.verify import verify_claims, verify_keys
+from nose.tools import eq_
+
+import amo
+from amo.helpers import absolutify
+from amo.urlresolvers import reverse
+from mkt.purchase.webpay_jwt import (get_product_jwt, WebAppProduct,
+                                     InAppProduct)
+from mkt import regions
+from stats.models import Contribution
+
+from utils import InAppPurchaseTest, PurchaseTest
+
+
+class TestPurchaseJWT(PurchaseTest):
+
+    def setUp(self):
+        super(TestPurchaseJWT, self).setUp()
+        self.product = WebAppProduct(self.addon)
+        self.token = get_product_jwt(
+            self.product,
+            region=regions.US,
+            user=self.user,
+        )
+
+        self.token_data = jwt.decode(
+            str(self.token['webpayJWT']), verify=False)
+
+        self.contribution = Contribution.objects.get()
+
+    def test_claims(self):
+        verify_claims(self.token_data)
+
+    def test_keys(self):
+        verify_keys(self.token_data,
+                    ('iss',
+                     'typ',
+                     'aud',
+                     'iat',
+                     'exp',
+                     'request.name',
+                     'request.description',
+                     'request.pricePoint',
+                     'request.postbackURL',
+                     'request.chargebackURL',
+                     'request.productData'))
+
+    def test_valid_jwt(self):
+        eq_(self.token_data['iss'], settings.APP_PURCHASE_KEY)
+        eq_(self.token_data['typ'], settings.APP_PURCHASE_TYP)
+        eq_(self.token_data['aud'], settings.APP_PURCHASE_AUD)
+
+        contribution = Contribution.objects.get()
+        eq_(contribution.type, amo.CONTRIB_PENDING)
+        eq_(contribution.price_tier, self.addon.premium.price)
+        eq_(contribution.user, self.user)
+
+        request = self.token_data['request']
+        eq_(request['id'], self.product.external_id())
+        eq_(request['name'], self.product.name())
+        eq_(request['icons'], self.product.icons())
+        eq_(request['description'], self.product.description())
+        eq_(request['pricePoint'], self.product.price().name)
+        eq_(request['postbackURL'], absolutify(reverse('webpay.postback')))
+        eq_(request['chargebackURL'], absolutify(reverse('webpay.chargeback')))
+
+        token_product_data = urlparse.parse_qs(request['productData'])
+        expected_product_data = urlparse.parse_qs(
+            urlencode(self.product.product_data(self.contribution)))
+        eq_(token_product_data, expected_product_data)
+
+
+class TestWebAppProduct(PurchaseTest):
+
+    def setUp(self):
+        super(TestWebAppProduct, self).setUp()
+        self.product = WebAppProduct(self.addon)
+        self.token = get_product_jwt(
+            self.product,
+            region=regions.US,
+            user=self.user,
+        )
+
+        self.contribution = Contribution.objects.get()
+
+    def test_external_id_with_no_domain(self):
+        with self.settings(DOMAIN=None):
+            eq_(self.product.external_id(),
+                'marketplace-dev:{0}'.format(self.addon.pk))
+
+    def test_external_id_with_domain(self):
+        with self.settings(DOMAIN='marketplace.allizom.org'):
+            eq_(self.product.external_id(),
+                'marketplace:{0}'.format(self.addon.pk))
+
+    def test_webapp_product(self):
+        eq_(self.product.id(), self.addon.pk)
+        eq_(self.product.name(), unicode(self.addon.name))
+        eq_(self.product.addon(), self.addon)
+        eq_(self.product.amount(regions.US),
+            self.addon.get_price(region=regions.US.id))
+        eq_(self.product.price(), self.addon.premium.price)
+        eq_(self.product.icons()['512'],
+            absolutify(self.addon.get_icon_url(512)))
+        eq_(self.product.description(), self.addon.description)
+        eq_(self.product.application_size(),
+            self.addon.current_version.all_files[0].size)
+        eq_(self.product.seller_uuid(), (self.addon
+                                             .app_payment_account
+                                             .payment_account
+                                             .solitude_seller
+                                             .uuid))
+
+        product_data = self.product.product_data(self.contribution)
+        eq_(product_data['contrib_uuid'], self.contribution.uuid)
+        eq_(product_data['seller_uuid'], self.product.seller_uuid())
+        eq_(product_data['addon_id'], self.product.addon().pk)
+        eq_(product_data['application_size'], self.product.application_size())
+
+
+class TestInAppProduct(InAppPurchaseTest):
+
+    def setUp(self):
+        super(TestInAppProduct, self).setUp()
+        self.product = InAppProduct(self.inapp)
+        self.token = get_product_jwt(self.product)
+        self.contribution = Contribution.objects.get()
+
+    def test_external_id_with_no_domain(self):
+        with self.settings(DOMAIN=None):
+            eq_(self.product.external_id(),
+                'inapp.marketplace-dev:{0}'.format(self.inapp.pk))
+
+    def test_external_id_with_domain(self):
+        with self.settings(DOMAIN='marketplace.allizom.org'):
+            eq_(self.product.external_id(),
+                'inapp.marketplace:{0}'.format(self.inapp.pk))
+
+    def test_inapp_product(self):
+        eq_(self.product.id(), self.inapp.pk)
+        eq_(self.product.name(), unicode(self.inapp.name))
+        eq_(self.product.addon(), self.inapp.webapp)
+        eq_(self.product.amount(regions.US), None)
+        eq_(self.product.price(), self.inapp.price)
+        eq_(self.product.icons()[64], absolutify(self.inapp.logo_url))
+        eq_(self.product.description(), self.inapp.webapp.description)
+        eq_(self.product.application_size(), None)
+        eq_(self.product.seller_uuid(), (self.inapp
+                                             .webapp
+                                             .app_payment_account
+                                             .payment_account
+                                             .solitude_seller
+                                             .uuid))
+
+        product_data = self.product.product_data(self.contribution)
+        eq_(product_data['contrib_uuid'], self.contribution.uuid)
+        eq_(product_data['seller_uuid'], self.product.seller_uuid())
+        eq_(product_data['addon_id'], self.product.addon().pk)
+        eq_(product_data['inapp_id'], self.product.id())
+        eq_(product_data['application_size'], self.product.application_size())

--- a/mkt/purchase/urls.py
+++ b/mkt/purchase/urls.py
@@ -4,14 +4,16 @@ from . import webpay
 
 
 # These URLs are attached to /services
-webpay_services_patterns = patterns('',
+webpay_services_patterns = patterns(
+    '',
     url('^postback$', webpay.postback, name='webpay.postback'),
     url('^chargeback$', webpay.chargeback, name='webpay.chargeback'),
 )
 
 
 # These URLs get attached to the app details URLs.
-app_purchase_patterns = patterns('',
+app_purchase_patterns = patterns(
+    '',
     url('^webpay/prepare_pay$', webpay.prepare_pay,
         name='webpay.prepare_pay'),
     url('^webpay/pay_status/(?P<contrib_uuid>[^/]+)$', webpay.pay_status,
@@ -19,7 +21,8 @@ app_purchase_patterns = patterns('',
 )
 
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     # TODO: Port these views.
     #url('^thanks/$', views.purchase_thanks, name='purchase.thanks'),
     #url('^error/$', views.purchase_error, name='purchase.error'),

--- a/mkt/purchase/webpay.py
+++ b/mkt/purchase/webpay.py
@@ -1,28 +1,20 @@
-import calendar
 import sys
-import time
 import urlparse
-import uuid
 from decimal import Decimal
-from urllib import urlencode
 
 from django import http
-from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 
-import bleach
 import commonware.log
 
 from addons.decorators import addon_view_factory
 import amo
 from amo.decorators import json_view, login_required, post_required, write
-from amo.helpers import absolutify
-from amo.urlresolvers import reverse
 from lib.cef_loggers import app_pay_cef
-from lib.crypto.webpay import (InvalidSender, parse_from_webpay,
-                               sign_webpay_jwt)
+from lib.crypto.webpay import InvalidSender, parse_from_webpay
 from mkt.api.exceptions import AlreadyPurchased
 from mkt.purchase.decorators import can_be_purchased
+from mkt.purchase.webpay_jwt import get_product_jwt, WebAppProduct
 from mkt.webapps.models import Webapp
 from stats.models import ClientData, Contribution
 
@@ -30,29 +22,6 @@ from . import tasks
 
 log = commonware.log.getLogger('z.purchase')
 addon_view = addon_view_factory(qs=Webapp.objects.valid)
-
-
-def make_ext_id(addon_pk):
-    """
-    Generates a webpay/solitude external ID given an addon's primary key.
-    """
-    # This namespace is currently necessary because app products
-    # are mixed into an application's own in-app products.
-    # Maybe we can fix that.
-    # Also, we may use various dev/stage servers with the same
-    # Bango test API.
-    domain = getattr(settings, 'DOMAIN', None)
-    if not domain:
-        domain = 'marketplace-dev'
-    ext_id = domain.split('.')[0]
-    return '%s:%s' % (ext_id, addon_pk)
-
-
-def make_ext_id_inapp(inapp_pk):
-    """
-    Generates a webpay/solitude external ID given an in app item's primary key.
-    """
-    return 'inapp.%s' % make_ext_id(inapp_pk)
 
 
 @login_required
@@ -69,145 +38,14 @@ def prepare_pay(request, addon):
     app_pay_cef.log(request, 'Preparing JWT', 'preparing_jwt',
                     'Preparing JWT for: %s' % (addon.pk), severity=3)
 
-    user = request.amo_user
-    region = request.REGION
-    source = request.REQUEST.get('src', '')
-    lang = request.LANG
-    client_data = ClientData.get_or_create(request)
-
-    return _prepare_pay(addon, user=user, region=region,
-                        source=source, lang=lang,
-                        client_data=client_data)
-
-
-def _prepare_pay(addon, user=None, region=None,
-                 source=None, lang=None, client_data=None):
-    """Prepare a JWT for paid apps to pass into navigator.pay()"""
-    log.debug('Starting purchase of app: %s by user: %s'
-              % (addon.pk, user.pk))
-
-    amount = addon.get_price(region=region.id)
-    uuid_ = str(uuid.uuid4())
-
-    log.debug('Storing contrib for uuid: %s' % uuid_)
-    Contribution.objects.create(addon_id=addon.id, amount=amount,
-                                source=source, source_locale=lang,
-                                uuid=str(uuid_), type=amo.CONTRIB_PENDING,
-                                paykey=None, user=user,
-                                price_tier=addon.premium.price,
-                                client_data=client_data)
-
-    # Until atob() supports encoded HTML we are stripping all tags.
-    # See bug 831524
-    app_description = bleach.clean(unicode(addon.description), strip=True,
-                                   tags=[])
-
-    acct = addon.app_payment_account.payment_account
-    seller_uuid = acct.solitude_seller.uuid
-    application_size = addon.current_version.all_files[0].size
-    issued_at = calendar.timegm(time.gmtime())
-
-    icons = {}
-    for size in amo.ADDON_ICON_SIZES:
-        icons[str(size)] = absolutify(addon.get_icon_url(size))
-
-    token_data = {
-        'iss': settings.APP_PURCHASE_KEY,
-        'typ': settings.APP_PURCHASE_TYP,
-        'aud': settings.APP_PURCHASE_AUD,
-        'iat': issued_at,
-        'exp': issued_at + 3600,  # expires in 1 hour
-        'request': {
-            'name': unicode(addon.name),
-            'description': app_description,
-            'pricePoint': addon.premium.price.name,
-            'id': make_ext_id(addon.pk),
-            'postbackURL': absolutify(reverse('webpay.postback')),
-            'chargebackURL': absolutify(reverse('webpay.chargeback')),
-            'productData': urlencode({
-                'contrib_uuid': uuid_,
-                'seller_uuid': seller_uuid,
-                'addon_id': addon.pk,
-                'application_size': application_size
-            }),
-            'icons': icons,
-        }
-    }
-
-    token = sign_webpay_jwt(token_data)
-    log.debug('Preparing webpay JWT for addon %s: %s' % (addon, token))
-
-    return {
-        'webpayJWT': token,
-        'contribStatusURL': reverse('webpay-status', kwargs={'uuid': uuid_})
-    }
-
-
-def _prepare_pay_inapp(inapp, source=None, lang=None,
-                       client_data=None):
-    """
-    Prepare a JWT to pass into navigator.pay() for in app purchaseable item
-    """
-    log.debug('Starting purchase of inapp: %s' % inapp.pk)
-
-    # Amount is set to none becuase we can't know the user's region
-    # until after the payment is complete.
-    contrib = Contribution.objects.create(addon_id=inapp.webapp.id,
-                                          amount=None,
-                                          client_data=client_data,
-                                          paykey=None,
-                                          price_tier=inapp.price,
-                                          source=source,
-                                          source_locale=lang,
-                                          type=amo.CONTRIB_PENDING,
-                                          uuid=str(uuid.uuid4()))
-    log.debug('Storing contrib for uuid: %s' % contrib.uuid)
-
-    # Until atob() supports encoded HTML we are stripping all tags.
-    # See bug 831524
-    app_description = bleach.clean(unicode(inapp.webapp.description),
-                                   strip=True, tags=[])
-
-    acct = inapp.webapp.app_payment_account.payment_account
-    seller_uuid = acct.solitude_seller.uuid
-    issued_at = calendar.timegm(time.gmtime())
-
-    # TODO: Default to 64x64 icon until addressed in
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=981093
-    icons = {64: absolutify(inapp.logo_url)}
-
-    token_data = {
-        'iss': settings.APP_PURCHASE_KEY,
-        'typ': settings.APP_PURCHASE_TYP,
-        'aud': settings.APP_PURCHASE_AUD,
-        'iat': issued_at,
-        'exp': issued_at + 3600,  # expires in 1 hour
-        'request': {
-            'name': unicode(inapp.name),
-            'description': app_description,
-            'pricePoint': inapp.price.name,
-            'id': make_ext_id_inapp(inapp.pk),
-            'postbackURL': absolutify(reverse('webpay.postback')),
-            'chargebackURL': absolutify(reverse('webpay.chargeback')),
-            'productData': urlencode({
-                'contrib_uuid': contrib.uuid,
-                'seller_uuid': seller_uuid,
-                'addon_id': inapp.webapp.pk,
-                'inapp_id': inapp.pk,
-                'application_size': None
-            }),
-            'icons': icons,
-        }
-    }
-
-    token = sign_webpay_jwt(token_data)
-    log.debug('Preparing webpay JWT for inapp %s: %s' % (inapp, token))
-
-    return {
-        'webpayJWT': token,
-        'contribStatusURL': reverse('webpay-status',
-                                    kwargs={'uuid': contrib.uuid})
-    }
+    return get_product_jwt(
+        WebAppProduct(addon),
+        user=request.amo_user,
+        region=request.REGION,
+        source=request.REQUEST.get('src', ''),
+        lang=request.LANG,
+        client_data=ClientData.get_or_create(request),
+    )
 
 
 @login_required

--- a/mkt/purchase/webpay_jwt.py
+++ b/mkt/purchase/webpay_jwt.py
@@ -1,0 +1,209 @@
+import calendar
+import time
+import uuid
+from urllib import urlencode
+
+from django.conf import settings
+
+import bleach
+import commonware.log
+
+import amo
+from amo.helpers import absolutify
+from amo.urlresolvers import reverse
+from lib.crypto.webpay import sign_webpay_jwt
+from stats.models import Contribution
+
+log = commonware.log.getLogger('z.purchase')
+
+
+def strip_tags(text):
+    # Until atob() supports encoded HTML we are stripping all tags.
+    # See bug 83152422
+    return bleach.clean(unicode(text), strip=True, tags=[])
+
+
+def make_external_id(product):
+    """
+    Generates a webpay/solitude external ID given an addon's primary key.
+    """
+    # This namespace is currently necessary because app products
+    # are mixed into an application's own in-app products.
+    # Maybe we can fix that.
+    # Also, we may use various dev/stage servers with the same
+    # Bango test API.
+    domain = getattr(settings, 'DOMAIN', None)
+    if not domain:
+        domain = 'marketplace-dev'
+    external_id = domain.split('.')[0]
+    return '{0}:{1}'.format(external_id, product.pk)
+
+
+def get_product_jwt(product, user=None, region=None,
+                    source=None, lang=None, client_data=None):
+    """Prepare a JWT for paid products to pass into navigator.pay()"""
+
+    # TODO: Contribution should be created outside of the JWT producer
+    contribution = Contribution.objects.create(
+        addon_id=product.addon().pk,
+        amount=product.amount(region),
+        client_data=client_data,
+        paykey=None,
+        price_tier=product.price(),
+        source=source,
+        source_locale=lang,
+        type=amo.CONTRIB_PENDING,
+        user=user,
+        uuid=str(uuid.uuid4()),
+    )
+
+    log.debug('Storing contrib for uuid: {0}'.format(contribution.uuid))
+
+    user_id = user.pk if user else None
+    log.debug('Starting purchase of app: {0} by user: {1}'.format(
+        product.id(), user_id))
+
+    issued_at = calendar.timegm(time.gmtime())
+
+    token_data = {
+        'iss': settings.APP_PURCHASE_KEY,
+        'typ': settings.APP_PURCHASE_TYP,
+        'aud': settings.APP_PURCHASE_AUD,
+        'iat': issued_at,
+        'exp': issued_at + 3600,  # expires in 1 hour
+        'request': {
+            'id': product.external_id(),
+            'name': unicode(product.name()),
+            'icons': product.icons(),
+            'description': strip_tags(product.description()),
+            'pricePoint': product.price().name,
+            'productData': urlencode(product.product_data(contribution)),
+            'chargebackURL': absolutify(reverse('webpay.chargeback')),
+            'postbackURL': absolutify(reverse('webpay.postback')),
+        }
+    }
+
+    token = sign_webpay_jwt(token_data)
+
+    log.debug('Preparing webpay JWT for self.product {0}: {1}'.format(
+        product.id(), token))
+
+    return {
+        'webpayJWT': token,
+        'contribStatusURL': reverse(
+            'webpay-status',
+            kwargs={
+                'uuid': contribution.uuid
+            }
+        )
+    }
+
+
+class WebAppProduct(object):
+    """Binding layer to pass a web app into a JWT producer"""
+
+    def __init__(self, webapp):
+        self.webapp = webapp
+
+    def id(self):
+        return self.webapp.pk
+
+    def external_id(self):
+        return make_external_id(self.webapp)
+
+    def name(self):
+        return self.webapp.name
+
+    def addon(self):
+        return self.webapp
+
+    def amount(self, region):
+        return self.webapp.get_price(region=region.id)
+
+    def price(self):
+        return self.webapp.premium.price
+
+    def icons(self):
+        icons = {}
+        for size in amo.ADDON_ICON_SIZES:
+            icons[str(size)] = absolutify(self.webapp.get_icon_url(size))
+
+        return icons
+
+    def description(self):
+        return self.webapp.description
+
+    def application_size(self):
+        return self.webapp.current_version.all_files[0].size
+
+    def seller_uuid(self):
+        return (self.webapp
+                    .app_payment_account
+                    .payment_account
+                    .solitude_seller
+                    .uuid)
+
+    def product_data(self, contribution):
+        return {
+            'addon_id': self.webapp.pk,
+            'application_size': self.application_size(),
+            'contrib_uuid': contribution.uuid,
+            'seller_uuid': self.seller_uuid(),
+        }
+
+
+class InAppProduct(object):
+    """Binding layer to pass a in app object into a JWT producer"""
+
+    def __init__(self, inapp):
+        self.inapp = inapp
+
+    def id(self):
+        return self.inapp.pk
+
+    def external_id(self):
+        return 'inapp.{0}'.format(make_external_id(self.inapp))
+
+    def name(self):
+        return self.inapp.name
+
+    def addon(self):
+        return self.inapp.webapp
+
+    def amount(self, region):
+        # In app payments are unauthenticated so we have no user
+        # and therefore can't determine a meaningful region
+        return None
+
+    def price(self):
+        return self.inapp.price
+
+    def icons(self):
+        # TODO: Default to 64x64 icon until addressed in
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=981093
+        return {64: absolutify(self.inapp.logo_url)}
+
+    def description(self):
+        return self.inapp.webapp.description
+
+    def application_size(self):
+        # TODO: Should this be not none, and if so
+        # How do we determine the size of an in app object?
+        return None
+
+    def seller_uuid(self):
+        return (self.inapp
+                    .webapp
+                    .app_payment_account
+                    .payment_account
+                    .solitude_seller
+                    .uuid)
+
+    def product_data(self, contribution):
+        return {
+            'addon_id': self.inapp.webapp.pk,
+            'inapp_id': self.inapp.pk,
+            'application_size': self.application_size(),
+            'contrib_uuid': contribution.uuid,
+            'seller_uuid': self.seller_uuid(),
+        }

--- a/mkt/webpay/resources.py
+++ b/mkt/webpay/resources.py
@@ -28,7 +28,7 @@ from mkt.api.authentication import (RestAnonymousAuthentication,
 from mkt.api.authorization import (AllowOwner, AllowReadOnly, AnyOf,
                                    GroupPermission)
 from mkt.api.base import CORSMixin, MarketplaceView
-from mkt.purchase.webpay import _prepare_pay, sign_webpay_jwt
+from mkt.purchase.webpay_jwt import get_product_jwt, WebAppProduct, sign_webpay_jwt
 from mkt.webpay.forms import FailureForm, PrepareForm
 from mkt.webpay.models import ProductIcon
 from mkt.webpay.serializers import PriceSerializer, ProductIconSerializer
@@ -72,9 +72,9 @@ class PreparePayView(CORSMixin, MarketplaceView, GenericAPIView):
         lang = request._request.LANG
         client_data = ClientData.get_or_create(request._request)
 
-        data = _prepare_pay(app, user=user, region=region,
-                            source=source, lang=lang,
-                            client_data=client_data)
+        data = get_product_jwt(WebAppProduct(app), user=user, region=region,
+                               source=source, lang=lang,
+                               client_data=client_data)
 
         return Response(data, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
- Split JWT creation and testing into their own modules
- Create 'product' abstraction layer
- Single JWT producing code, conencts to webapp and inapp through product interface layer
