### PR TITLE
Crop the jetpack_version (sdkVersion) received from harness-options.json (bug 986221)

### DIFF
--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -155,7 +155,7 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
         # Size in bytes.
         f.size = storage.size(upload.path)
         data = cls.get_jetpack_metadata(upload.path)
-        f.jetpack_version = data['sdkVersion']
+        f.jetpack_version = data['sdkVersion'][:10]
         if f.jetpack_version:
             Tag(tag_text='jetpack').save_tag(version.addon)
         f.builder_version = data['builderVersion']


### PR DESCRIPTION
fix [bug 986221](https://bugzilla.mozilla.org/show_bug.cgi?id=986221)

Allow the upload of new versions of addons developped with the development
version of the SDK (for the upcoming australis).

It was prevented because the `sdkVersion` from the
`harness-options.json` file is too long to fit in the
`Files.jetpack_version` (max_length=10) field.
