### PR TITLE
Add task to run uploaded icons through Pngcrush (Bug 983426)

### DIFF
--- a/docs/topics/install-zamboni/installation.rst
+++ b/docs/topics/install-zamboni/installation.rst
@@ -39,9 +39,9 @@ On Ubuntu
 ~~~~~~~~~
 The following command will install the required development files on Ubuntu or,
 if you're running a recent version, you can `install them automatically
-<apt:python-dev,python-virtualenv,libxml2-dev,libxslt1-dev,libmysqlclient-dev,libmemcached-dev,libssl-dev,swig openssl,curl>`_::
+<apt:python-dev,python-virtualenv,libxml2-dev,libxslt1-dev,libmysqlclient-dev,libmemcached-dev,libssl-dev,swig openssl,curl,pngcrush>`_::
 
-    sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev libmemcached-dev libssl-dev swig openssl curl
+    sudo aptitude install python-dev python-virtualenv libxml2-dev libxslt1-dev libmysqlclient-dev libmemcached-dev libssl-dev swig openssl curl pngcrush
 
 On versions 12.04 and later, you will need to install a patched version of
 M2Crypto instead of the version from PyPI. Please check the `Finish the
@@ -56,7 +56,7 @@ The best solution for installing UNIX tools on OS X is Homebrew_.
 
 The following packages will get you set for zamboni::
 
-    brew install python libxml2 mysql libmemcached openssl swig jpeg
+    brew install python libxml2 mysql libmemcached openssl swig jpeg pngcrush
 
 MySQL
 ~~~~~

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -66,6 +66,9 @@ CLEANCSS_BIN = 'cleancss'
 # Path to uglifyjs (our JS minifier).
 UGLIFY_BIN = 'uglifyjs'  # Set as None to use YUI instead (at your risk).
 
+# Path to pngcrush (for image optimization).
+PNGCRUSH_BIN = 'pngcrush'
+
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
 )


### PR DESCRIPTION
From [Bug 983426](https://bugzilla.mozilla.org/show_bug.cgi?id=983426), this adds a separate task to run uploaded icons through the Pngcrush lossless optimizer. It will overwrite the icon in src with the new optimized icon.
