### PR TITLE
Make /fireplace/search/featured/ use fireplace-specific serializers for apps in collections (bug 989331)

### DIFF
--- a/mkt/fireplace/api.py
+++ b/mkt/fireplace/api.py
@@ -9,6 +9,8 @@ from mkt.api.base import CORSMixin
 from mkt.api.authentication import (RestAnonymousAuthentication,
                                     RestOAuthAuthentication,
                                     RestSharedSecretAuthentication)
+from mkt.collections.serializers import (CollectionMembershipField,
+                                         CollectionSerializer)
 from mkt.search.api import (FeaturedSearchView as BaseFeaturedSearchView,
                             SearchView as BaseSearchView)
 from mkt.search.serializers import SimpleESAppSerializer
@@ -37,12 +39,24 @@ class FireplaceESAppSerializer(SimpleESAppSerializer):
         return None
 
 
+class FireplaceCollectionMembershipField(CollectionMembershipField):
+    app_serializer_classes = {
+        'es': FireplaceESAppSerializer,
+        'normal': FireplaceAppSerializer,
+    }
+
+
+class FireplaceCollectionSerializer(CollectionSerializer):
+    apps = FireplaceCollectionMembershipField(many=True, source='apps')
+
+
 class AppViewSet(BaseAppViewset):
     serializer_class = FireplaceAppSerializer
 
 
 class FeaturedSearchView(BaseFeaturedSearchView):
     serializer_class = FireplaceESAppSerializer
+    collections_serializer_class = FireplaceCollectionSerializer
     authentication_classes = []
 
 

--- a/mkt/fireplace/tests/test_api.py
+++ b/mkt/fireplace/tests/test_api.py
@@ -12,6 +12,8 @@ from users.models import UserProfile
 import mkt
 from mkt.api.tests import BaseAPI
 from mkt.api.tests.test_oauth import RestOAuth
+from mkt.collections.constants import COLLECTIONS_TYPE_BASIC
+from mkt.collections.models import Collection
 from mkt.fireplace.api import FireplaceAppSerializer
 from mkt.webapps.models import Webapp
 from mkt.site.fixtures import fixture
@@ -60,6 +62,9 @@ class TestFeaturedSearchView(RestOAuth, ESTestCase):
     def setUp(self):
         super(TestFeaturedSearchView, self).setUp()
         self.webapp = Webapp.objects.get(pk=337141)
+        collection = Collection.objects.create(name='Hi', description='Mom',
+            collection_type=COLLECTIONS_TYPE_BASIC, is_public=True)
+        collection.add_app(self.webapp)
         self.reindex(Webapp, 'webapp')
         self.url = reverse('fireplace-featured-search-api')
 
@@ -74,8 +79,15 @@ class TestFeaturedSearchView(RestOAuth, ESTestCase):
             ok_(not field in data, field)
         for field in FireplaceAppSerializer.Meta.fields:
             ok_(field in data, field)
-        ok_('featured' in res.json)
+
         ok_('collections' in res.json)
+        eq_(res.json['collections'][0]['name'], {u'en-US': u'Hi'})
+        data = res.json['collections'][0]['apps'][0]
+        for field in FIREPLACE_EXCLUDED_FIELDS:
+            ok_(not field in data, field)
+        for field in FireplaceAppSerializer.Meta.fields:
+            ok_(field in data, field)
+        ok_('featured' in res.json)
         ok_('operator' in res.json)
 
 

--- a/mkt/search/api.py
+++ b/mkt/search/api.py
@@ -86,6 +86,7 @@ class SearchView(CORSMixin, MarketplaceView, GenericAPIView):
 
 
 class FeaturedSearchView(SearchView):
+    collections_serializer_class = CollectionSerializer
 
     def collections(self, request, collection_type=None, limit=1):
         filters = request.GET.dict()
@@ -98,10 +99,11 @@ class FeaturedSearchView(SearchView):
             qs = Collection.public.all()
         qs = CollectionFilterSetWithFallback(filters, queryset=qs).qs
         preview_mode = filters.get('preview', False)
-        serializer = CollectionSerializer(qs[:limit], many=True, context={
-            'request': request,
-            'view': self,
-            'use-es-for-apps': not preview_mode
+        serializer = self.collections_serializer_class(qs[:limit], many=True,
+            context={
+                'request': request,
+                'view': self,
+                'use-es-for-apps': not preview_mode
         })
         return serializer.data, getattr(qs, 'filter_fallback', None)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=989331

Collections are already using a simpler representation for apps, but using the fireplace ones makes us gain a few bytes for each app that appears in a collection/featured app/operator shelf in /search/featured/.
