### PR TITLE
Don't allow nameless collections in the API (Bug 984934)

### DIFF
--- a/mkt/collections/serializers.py
+++ b/mkt/collections/serializers.py
@@ -159,7 +159,7 @@ class HyperlinkedRelatedOrNullField(serializers.HyperlinkedRelatedField):
 
 
 class CollectionSerializer(serializers.ModelSerializer):
-    name = TranslationSerializerField()
+    name = TranslationSerializerField(min_length=1)
     description = TranslationSerializerField()
     slug = serializers.CharField(required=False)
     collection_type = serializers.IntegerField()

--- a/mkt/collections/tests/test_serializers.py
+++ b/mkt/collections/tests/test_serializers.py
@@ -272,6 +272,49 @@ class TestCollectionSerializer(CollectionDataMixin, amo.tests.TestCase):
         eq_(serializer.is_valid(), False)
         ok_('default_language' in serializer.errors)
 
+    def test_name_required(self):
+        data = {
+            'description': u'some description',
+            'collection_type': u'1'
+        }
+        serializer = CollectionSerializer(instance=self.collection, data=data)
+        eq_(serializer.is_valid(), False)
+        ok_('name' in serializer.errors)
+
+    def test_name_cannot_be_empty(self):
+        data = {
+            'name': u''
+        }
+        serializer = CollectionSerializer(instance=self.collection, data=data,
+                                          partial=True)
+        eq_(serializer.is_valid(), False)
+        ok_('name' in serializer.errors)
+        eq_(serializer.errors['name'],
+            [u'The field must have a length of at least 1 characters.'])
+
+    def test_name_all_locales_cannot_be_empty(self):
+        data = {
+            'name': {
+                'fr': u'',
+                'en-US': u''
+            }
+        }
+        serializer = CollectionSerializer(instance=self.collection, data=data,
+                                          partial=True)
+        eq_(serializer.is_valid(), False)
+        ok_('name' in serializer.errors)
+
+    def test_name_one_locale_must_be_non_empty(self):
+        data = {
+            'name': {
+                'fr': u'',
+                'en-US': u'Non-Empty Name'
+            }
+        }
+        serializer = CollectionSerializer(instance=self.collection, data=data,
+                                          partial=True)
+        eq_(serializer.is_valid(), True)
+
     def test_translation_deserialization(self):
         data = {
             'name': u'¿Dónde está la biblioteca?'


### PR DESCRIPTION
From [Bug 984934](https://bugzilla.mozilla.org/show_bug.cgi?id=984934), this should prevent the saving of empty collection names in the API by raising a validation error in the serializer.
