### PR TITLE
Use CDN when returning rocketfuel collections images URLs (bug 990295)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -472,6 +472,8 @@ class TestCase(MockEsMixin, RedisTest, test_utils.TestCase):
         This is done by prepending '/api/vx' (where x is equal to the `version`
         keyword argument or API_CURRENT_VERSION) to each string passed as a
         positional argument if that URL doesn't already start with that string.
+        Also accepts 'netloc' and 'scheme' optional keyword arguments to
+        compare absolute URLs.
 
         Example usage:
 
@@ -482,14 +484,25 @@ class TestCase(MockEsMixin, RedisTest, test_utils.TestCase):
         url = '/api/v1/apps/app/bastacorp/'
         self.assertApiUrlEqual(url, '/apps/app/bastacorp/', version=1)
         """
+        # Constants for the positions of the URL components in the tuple
+        # returned by urlsplit. Only here for readability purposes.
+        SCHEME = 0
+        NETLOC = 1
         PATH = 2
+
         version = kwargs.get('version', settings.API_CURRENT_VERSION)
+        scheme = kwargs.get('scheme', None)
+        netloc = kwargs.get('netloc', None)
         urls = list(args)
         prefix = '/api/v%d' % version
         for idx, url in enumerate(urls):
             urls[idx] = list(urlsplit(url))
             if not urls[idx][PATH].startswith(prefix):
                 urls[idx][PATH] = prefix + urls[idx][PATH]
+            if scheme and not urls[idx][SCHEME]:
+                urls[idx][SCHEME] = scheme
+            if netloc and not urls[idx][NETLOC]:
+                urls[idx][NETLOC] = netloc
             urls[idx] = SplitResult(*urls[idx])
         eq_(*urls)
 

--- a/mkt/collections/tests/test_serializers.py
+++ b/mkt/collections/tests/test_serializers.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 import json
+
+from django.test.utils import override_settings
+
 from mock import patch
 from nose.tools import eq_, ok_
 from rest_framework import serializers
@@ -255,6 +258,7 @@ class TestCollectionSerializer(CollectionDataMixin, amo.tests.TestCase):
         data = self.serializer.to_native(self.collection)
         ok_('can_be_hero' in data.keys())
 
+    @override_settings(STATIC_URL='https://testserver-cdn/')
     @patch('mkt.collections.serializers.build_id', 'bbbbbb')
     def test_image(self):
         data = self.serializer.to_native(self.collection)
@@ -262,7 +266,8 @@ class TestCollectionSerializer(CollectionDataMixin, amo.tests.TestCase):
         self.collection.update(has_image=True)
         data = self.serializer.to_native(self.collection)
         self.assertApiUrlEqual(data['image'],
-            '/rocketfuel/collections/%s/image.png?bbbbbb' % self.collection.pk)
+            '/rocketfuel/collections/%s/image.png?bbbbbb' % self.collection.pk,
+            scheme='https', netloc='testserver-cdn')
 
     def test_wrong_default_language_serialization(self):
         # The following is wrong because we only accept the 'en-us' form.

--- a/mkt/collections/views.py
+++ b/mkt/collections/views.py
@@ -8,7 +8,7 @@ from django.utils.datastructures import MultiValueDictKeyError
 
 from PIL import Image
 
-from rest_framework import generics, status, viewsets
+from rest_framework import generics, serializers, status, viewsets
 from rest_framework.decorators import action, link
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
@@ -249,6 +249,9 @@ class CollectionImageViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
                               RestSharedSecretAuthentication,
                               RestAnonymousAuthentication]
     cors_allowed_methods = ('get', 'put', 'delete')
+
+    # Dummy serializer to keep DRF happy when it's answering to OPTIONS.
+    serializer_class = serializers.Serializer
 
     def perform_content_negotiation(self, request, force=False):
         """


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=990295

Also authorize anonymous to make OPTIONS/HEAD requests (which makes manual testing much easier)
