### PR TITLE
Add API Endpoint to Update App Icons (Bug 883271)

### DIFF
--- a/docs/api/topics/apps.rst
+++ b/docs/api/topics/apps.rst
@@ -339,6 +339,29 @@ App
 
    See :ref:`Creating an app <app-put-label>`
 
+Updating an App Icon
+====================
+
+.. note:: Requires authentication and a successfully created app.
+
+.. http:put:: /api/v1/apps/app/(int:id|string:app_slug)/icon/
+
+    **Request**
+
+    :param file: a dictionary containing the appropriate file data in the upload field.
+    :type file: object
+    :param file.type: the content type.
+    :type file.type: string
+    :param file.name: the file name.
+    :type file.name: string
+    :param file.data: the base 64 encoded data.
+    :type file.data: string
+
+    **Response**
+
+    :status 200: successfully updated the icon.
+    :status 400: error processing the form.
+
 .. _versions-label:
 
 Versions

--- a/mkt/api/forms.py
+++ b/mkt/api/forms.py
@@ -70,14 +70,13 @@ class NewPackagedForm(NewPackagedAppForm):
         return super(NewPackagedForm, self).clean_upload()
 
 
-class PreviewJSONForm(happyforms.Form):
+class FileJSONForm(happyforms.Form):
     file = JSONField(required=True)
-    position = forms.IntegerField(required=True)
 
     def clean_file(self):
         file_ = self.cleaned_data.get('file', {})
         file_obj = parse(file_)
-        errors, hash_ = check_upload(file_obj, 'preview', file_['type'])
+        errors, hash_ = check_upload(file_obj, self.upload_type, file_['type'])
         if errors:
             raise forms.ValidationError(errors)
 
@@ -85,8 +84,24 @@ class PreviewJSONForm(happyforms.Form):
         return file_
 
     def clean(self):
-        self.cleaned_data['upload_hash'] = getattr(self, 'hash_', None)
+        self.cleaned_data[self.hash_name] = getattr(self, 'hash_', None)
         return self.cleaned_data
+
+
+class PreviewJSONForm(FileJSONForm):
+    position = forms.IntegerField(required=True)
+
+    def __init__(self, *args, **kwargs):
+        self.upload_type = 'preview'
+        self.hash_name = 'upload_hash'
+        super(PreviewJSONForm, self).__init__(*args, **kwargs)
+
+
+class IconJSONForm(FileJSONForm):
+    def __init__(self, *args, **kwargs):
+        self.upload_type = 'icon'
+        self.hash_name = 'icon_upload_hash'
+        super(IconJSONForm, self).__init__(*args, **kwargs)
 
 
 class CategoryForm(happyforms.Form):


### PR DESCRIPTION
As suggested in [Bug 883271](https://bugzilla.mozilla.org/show_bug.cgi?id=883271), this will add a new API endpoint in order to update an app's icon.
