### PR TITLE
allow multiple payment providers, ensure API doesn't break

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1645,6 +1645,8 @@ IARC_ALLOW_CERT_REUSE = False
 
 # The payment providers supported.
 PAYMENT_PROVIDERS = []
+# If you need to get a payment provider, which one will be the default?
+DEFAULT_PAYMENT_PROVIDER = 'bango'
 
 # The currently-recommended version of the API. Any requests to versions older
 # than this will include the `API-Status: Deprecated` header.

--- a/mkt/developers/providers.py
+++ b/mkt/developers/providers.py
@@ -282,8 +282,9 @@ for p in (Bango, Reference):
 
 
 def get_provider():
-    if len(settings.PAYMENT_PROVIDERS) != 1:
-        raise ImproperlyConfigured(
-            'You must have only one payment provider in zamboni. Having '
-            'multiple providers at one time will be added at a later date.')
-    return ALL_PROVIDERS[settings.PAYMENT_PROVIDERS[0]]()
+    """
+    This returns the default provider so we can provide backwards capability
+    for API's that expect get_provider to return 'bango'. This is something
+    we'll have to clean out.
+    """
+    return ALL_PROVIDERS[settings.DEFAULT_PAYMENT_PROVIDER]()

--- a/mkt/developers/tests/test_providers.py
+++ b/mkt/developers/tests/test_providers.py
@@ -62,10 +62,10 @@ class Patcher(object):
 
 class TestSetup(TestCase):
 
-    @raises(ImproperlyConfigured)
     def test_multiple(self):
-        with self.settings(PAYMENT_PROVIDERS=['foo', 'bar']):
-            get_provider()
+        with self.settings(PAYMENT_PROVIDERS=['bango', 'reference'],
+                           DEFAULT_PAYMENT_PROVIDER='bango'):
+            eq_(get_provider().name, 'bango')
 
 
 class TestBango(Patcher, TestCase):


### PR DESCRIPTION
Don't blow up by allowing multiple payment providers but keep Bango the default.

r? @mstriemer 
