### PR TITLE
add missing fields to FeedApp

### DIFF
--- a/docs/api/topics/feed.rst
+++ b/docs/api/topics/feed.rst
@@ -10,7 +10,7 @@ the Marketplace home page. The feed is comprised of a number of :ref:`feed items
 <feed-items>`, each containing a singular of piece of content. Currently, the
 feed may include:
 
-- :ref:`Apps <feed-apps>`
+- :ref:`Feed Apps <feed-apps>`
 - :ref:`Collections <feed-collections>`
 
 .. note::
@@ -26,7 +26,9 @@ feed may include:
 Feed Items
 ----------
 
-Feed items are represented thusly:
+A feed item wraps a :ref:`FeedApp  <feed-apps>` or
+:ref:`Collection <feed-collections>` with additional metadata regarding
+when and where to feature the content. Feed items are represented thusly:
 
 .. code-block:: json
 
@@ -61,7 +63,7 @@ Feed items are represented thusly:
     always be usable as a key on the feed item instance to fetch that object's
     data (i.e. ``feeditem[feeditem['item_type']]`` will always be non-null).
 ``resource_url``
-    *string* - the permanent URL for this feed item. 
+    *string* - the permanent URL for this feed item.
 ``region``
     *string|null* - the slug of a :ref:`region <regions>`. If defined, this feed
     item will only be available in that region.
@@ -210,7 +212,8 @@ Feed Apps
 ---------
 
 A feed app is a thin wrapper around an :ref:`app <app>`, object containing
-additional metadata related to its feature in the feed.
+additional metadata related to its feature in the feed. A feed app represents
+a featured app, a single app that is highlighted on its own in the feed.
 
 Feed apps are represented thusly:
 
@@ -220,25 +223,36 @@ Feed apps are represented thusly:
         "app": {
             "data": "..."
         },
+        "background_color": "#A90000",
         "description": {
             "en-US": "A featured app",
             "fr": "Une application sélectionnée"
         },
+        "feedapp_type": "icon",
+        "image": "http://somecdn.com/someimage.png"
         "id": 1
         "preview": null,
         "pullquote_attribute": null,
         "pullquote_rating": null,
         "pullquote_text": null,
+        "slug": "app-of-the-month",
         "url": "/api/v2/feed/apps/1/"
     }
 
 ``app``
     *object* - the full representation of an :ref:`app <app>`.
+``background_color``
+    *string* - background color in 6-digit hex format prepending by a hash
 ``description``
     *string|null* - a :ref:`translated <overview-translations>` description of
     the app being featured.
+``feedapp_type``
+    *string* - describes how the feed app will be displayed or featured. Can be
+    ``icon``, ``image``, ``description``, ``quote``, ``preview``.
 ``id``
     *int* - the ID of this feed app.
+``image``
+    *string* - header graphic or background image
 ``preview``
     *object|null* - a featured :ref:`preview <screenshot-response-label>`
     (screenshot or video) of the app.
@@ -251,6 +265,8 @@ Feed apps are represented thusly:
 ``pullquote_text``
     *object|null* - the :ref:`translated <overview-translations>` text of a pull
     quote to feature with the app
+``slug``
+    *string* - a slug to use in URLs for the featured app
 ``url``
     *string|null* - the permanent URL for this feed app.
 
@@ -299,9 +315,14 @@ Create
 
     :param app: the ID of a :ref:`feed app <feed-apps>`.
     :type app: int|null
+    :param background_color: color in six-digit hex (with hash prefix)
+    :type background_color: string
     :param description: a :ref:`translated <overview-translations>` description
         of the app being featured.
     :type description: object|null
+    :param feedapp_type: can be ``icon``, ``image``, ``description``,
+        ``quote``, or ``preview.
+    :type feedapp_type: string
     :param preview: the ID of a :ref:`preview <screenshot-response-label>` to
         feature with the app.
     :type preview: int|null
@@ -315,20 +336,25 @@ Create
         a pull quote to feature with the app. Required if
         ``pullquote_attribute`` or ``pullquote_rating`` are defined.
     :type pullquote_text: object|null
+    :param slug: unique slug to use in URLs for the featured app
+    :type slug: string
 
     .. code-block:: json
 
         {
             "app": 710,
+            "background_color": "#A90000",
             "description": {
                 "en-US": "A featured app",
                 "fr": "Une application sélectionnée"
             },
+            "feedapp_type": "icon",
             "pullquote_rating": 4,
             "pullquote_text": {
                 "en-US": "This featured app is excellent.",
                 "fr": "Pommes frites"
-            }
+            },
+            "slug": "app-of-the-month"
         }
 
     **Response**
@@ -351,9 +377,14 @@ Update
 
     :param app: the ID of a :ref:`feed app <feed-apps>`.
     :type app: int|null
+    :param background_color: color in six-digit hex (with hash prefix)
+    :type background_color: string
     :param description: a :ref:`translated <overview-translations>` description
         of the app being featured.
     :type description: object|null
+    :param feedapp_type: can be ``icon``, ``image``, ``description``,
+       ``quote``, or ``preview.
+    :type feedapp_type: string
     :param preview: the ID of a :ref:`preview <screenshot-response-label>` to
         feature with the app.
     :type preview: int|null
@@ -367,6 +398,8 @@ Update
         a pull quote to feature with the app. Required if
         ``pullquote_attribute`` or ``pullquote_rating`` are defined.
     :type pullquote_text: object|null
+    :param slug: unique slug to use in URLs for the featured app
+    :type slug: string
 
     **Response**
 
@@ -396,13 +429,43 @@ Delete
     :status 403: not authorized.
 
 
+Feed App Image
+==============
+
+One-to-one background image or header graphic used to display with the
+feed app.
+
+.. http:get:: /api/v2/feed/apps/(int:id|string:slug)/image/
+
+    Get the image for a feed app.
+
+    .. note:: Authentication is optional.
+
+
+.. http:put:: /api/v2/feed/apps/(int:id|string:slug)/image/
+
+    Set the image for a feed app. Accepts a data URI as the request
+    body containing the image, rather than a JSON object.
+
+    .. note:: Authentication and one of the 'Collections:Curate' permission or
+        curator-level access to the feed app are required.
+
+
+.. http:delete:: /api/v2/feed/apps/(int:id|string:slug)/image/
+
+    Delete the image for a feed app.
+
+    .. note:: Authentication and one of the 'Collections:Curate' permission or
+        curator-level access to the feed app are required.
+
+
 .. _feed-collections:
 
 -----------
 Collections
 -----------
 
-A collection is a group of applications
+A collection is a group of apps (not to be confused with :ref:`Feed Apps <feed-app>`)
 
 .. note::
 
@@ -704,8 +767,11 @@ Reorder Apps
         For convenience, a list of all apps in the collection will be included
         in the response.
 
-Image
-=====
+Collection Image
+================
+
+One-to-one background image or header graphic used to display with the
+collection.
 
 .. http:get:: /api/v2/feed/collections/(int:id|string:slug)/image/
 

--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -975,6 +975,7 @@ PRIVATE_MIRROR_URL = '/_privatefiles'
 # File paths
 ADDON_ICONS_PATH = UPLOADS_PATH + '/addon_icons'
 COLLECTIONS_ICON_PATH = UPLOADS_PATH + '/collection_icons'
+FEATURED_APP_BG_PATH = UPLOADS_PATH + '/featured_app_background'
 PREVIEWS_PATH = UPLOADS_PATH + '/previews'
 IMAGEASSETS_PATH = UPLOADS_PATH + '/imageassets'
 REVIEWER_ATTACHMENTS_PATH = UPLOADS_PATH + '/reviewer_attachment'

--- a/migrations/772-feedapp-fields.sql
+++ b/migrations/772-feedapp-fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `mkt_feed_app`
+    ADD COLUMN `background_color` varchar(7) NULL,
+    ADD COLUMN `feedapp_type` varchar(30) NOT NULL DEFAULT '',
+    ADD COLUMN `has_image` bool NULL DEFAULT false,
+    ADD COLUMN `slug` varchar(30) NOT NULL DEFAULT '';

--- a/mkt/api/v2/urls.py
+++ b/mkt/api/v2/urls.py
@@ -6,13 +6,17 @@ from mkt.api.base import SubRouterWithFormat
 from mkt.api.v1.urls import urlpatterns as v1_urls
 from mkt.api.views import endpoint_removed
 from mkt.collections.views import CollectionImageViewSet, CollectionViewSet
-from mkt.feed.views import FeedAppViewSet, FeedItemViewSet
+from mkt.feed.views import FeedAppImageViewSet, FeedAppViewSet, FeedItemViewSet
 
 
 feed = SimpleRouter()
 feed.register(r'apps', FeedAppViewSet, base_name='feedapps')
 feed.register(r'collections', CollectionViewSet, base_name='collections')
 feed.register(r'items', FeedItemViewSet, base_name='feeditems')
+
+subfeedapp = SubRouterWithFormat()
+subfeedapp.register('image', FeedAppImageViewSet,
+                    base_name='feed-app-image')
 
 subcollections = SubRouterWithFormat()
 subcollections.register('image', CollectionImageViewSet,
@@ -21,5 +25,6 @@ subcollections.register('image', CollectionImageViewSet,
 urlpatterns = patterns('',
     url(r'^rocketfuel/collections/.*', endpoint_removed),
     url(r'^feed/', include(feed.urls)),
+    url(r'^feed/apps/', include(subfeedapp.urls)),
     url(r'^feed/collections/', include(subcollections.urls)),
 ) + v1_urls

--- a/mkt/collections/models.py
+++ b/mkt/collections/models.py
@@ -20,6 +20,7 @@ from .managers import PublicCollectionsManager
 
 
 class Collection(amo.models.ModelBase):
+    # `collection_type` for rocketfuel, not transonic.
     collection_type = models.IntegerField(choices=COLLECTION_TYPES)
     description = PurifiedField()
     name = PurifiedField()

--- a/mkt/constants/feed.py
+++ b/mkt/constants/feed.py
@@ -1,0 +1,16 @@
+from tower import ugettext_lazy as _lazy
+
+
+FEEDAPP_TYPE_ICON = 'icon'
+FEEDAPP_TYPE_IMAGE = 'image'
+FEEDAPP_TYPE_DESC = 'description'
+FEEDAPP_TYPE_QUOTE = 'quote'
+FEEDAPP_TYPE_PREVIEW = 'preview'
+
+FEEDAPP_TYPES = (
+    (FEEDAPP_TYPE_ICON, _lazy(u'Icon')),
+    (FEEDAPP_TYPE_IMAGE, _lazy(u'Header Graphic')),
+    (FEEDAPP_TYPE_DESC, _lazy(u'Description')),
+    (FEEDAPP_TYPE_QUOTE, _lazy(u'Quote')),
+    (FEEDAPP_TYPE_PREVIEW, _lazy(u'Screenshot')),
+)

--- a/mkt/feed/serializers.py
+++ b/mkt/feed/serializers.py
@@ -6,7 +6,8 @@ import mkt.regions
 from addons.models import Category
 from mkt.api.fields import SplitField, TranslationSerializerField
 from mkt.api.serializers import URLSerializerMixin
-from mkt.collections.serializers import (CollectionSerializer, SlugChoiceField,
+from mkt.collections.serializers import (CollectionImageField,
+                                         CollectionSerializer, SlugChoiceField,
                                          SlugModelChoiceField)
 from mkt.submit.serializers import PreviewSerializer
 from mkt.webapps.api import AppSerializer
@@ -15,9 +16,14 @@ from .models import FeedApp, FeedItem
 
 
 class FeedAppSerializer(URLSerializerMixin, serializers.ModelSerializer):
+    """Thin wrappers around apps w/ metadata related to its feature in feed."""
     app = SplitField(relations.PrimaryKeyRelatedField(required=True),
                      AppSerializer())
     description = TranslationSerializerField(required=False)
+    image = CollectionImageField(
+        source='*',
+        view_name='feed-app-image-detail',
+        format='png')
     preview = SplitField(relations.PrimaryKeyRelatedField(required=False),
                          PreviewSerializer())
     pullquote_attribution = TranslationSerializerField(required=False)
@@ -25,14 +31,15 @@ class FeedAppSerializer(URLSerializerMixin, serializers.ModelSerializer):
     pullquote_text = TranslationSerializerField(required=False)
 
     class Meta:
-        fields = ('app', 'description', 'id', 'preview',
-                  'pullquote_attribution', 'pullquote_rating', 'pullquote_text',
-                  'url')
+        fields = ('app', 'background_color', 'description', 'feedapp_type',
+                  'id', 'image', 'preview', 'pullquote_attribution',
+                  'pullquote_rating', 'pullquote_text', 'slug', 'url')
         model = FeedApp
         url_basename = 'feedapps'
 
 
 class FeedItemSerializer(URLSerializerMixin, serializers.ModelSerializer):
+    """Thin wrappers around apps w/ metadata related to its feature in feed."""
     carrier = SlugChoiceField(required=False,
         choices_dict=mkt.carriers.CARRIER_MAP)
     region = SlugChoiceField(required=False,

--- a/mkt/feed/tests/test_serializers.py
+++ b/mkt/feed/tests/test_serializers.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-
 from rest_framework import serializers
 
 import amo
 import amo.tests
+
 from mkt.collections.constants import COLLECTIONS_TYPE_BASIC
 from mkt.collections.models import Collection
 from mkt.feed.serializers import FeedItemSerializer

--- a/mkt/feed/tests/test_views.py
+++ b/mkt/feed/tests/test_views.py
@@ -36,9 +36,13 @@ class FeedAppMixin(object):
     def setUp(self):
         self.feedapp_data = {
             'app': 337141,
+            'background_color': '#B90000',
+            'feedapp_type': 'icon',
             'description': {
                 'en-US': u'pan-fried potatoes'
             },
+            'has_image': False,
+            'slug': 'my-feed-app',
         }
         self.pullquote_data = {
             'pullquote_text': {'en-US': u'The bést!'},
@@ -318,9 +322,16 @@ class TestFeedAppViewSetCreate(BaseTestFeedAppViewSet):
         eq_(res.status_code, 201)
         eq_(data['app']['id'], self.feedapp_data['app'])
         eq_(data['description'], self.feedapp_data['description'])
+        eq_(data['slug'], self.feedapp_data['slug'])
+        eq_(data['feedapp_type'], self.feedapp_data['feedapp_type'])
 
         self.assertCORS(res, 'get', 'post')
         return res, data
+
+    def test_create_with_background_color(self):
+        self.feedapp_data.update(background_color='#00AACC')
+        res, data = self.test_create_with_permission()
+        eq_(data['background_color'], '#00AACC')
 
     def test_create_with_preview(self):
         preview = Preview.objects.create(addon=self.app, position=0)

--- a/mkt/feed/views.py
+++ b/mkt/feed/views.py
@@ -5,6 +5,7 @@ from mkt.api.authentication import (RestAnonymousAuthentication,
                                     RestSharedSecretAuthentication)
 from mkt.api.authorization import AllowReadOnly, AnyOf, GroupPermission
 from mkt.api.base import CORSMixin
+from mkt.collections.views import CollectionImageViewSet
 
 from .models import FeedApp, FeedItem
 from .serializers import FeedAppSerializer, FeedItemSerializer
@@ -30,3 +31,7 @@ class FeedAppViewSet(CORSMixin, viewsets.ModelViewSet):
     queryset = FeedApp.objects.all()
     cors_allowed_methods = ('get', 'post')
     serializer_class = FeedAppSerializer
+
+
+class FeedAppImageViewSet(CollectionImageViewSet):
+    queryset = FeedApp.objects.all()


### PR DESCRIPTION
Revelation! Collections are Collections, featured apps are FeedApps. Add missing fields:
- background_color
- background_image (copy and pasted collection's CollectionImageViewSet code)
- slug
- feedapp_type (make the display type explicit, icon vs. bg-image vs. quote vs. screenshot vs. desc)

@chuckharmston 
