### PR TITLE
use safer_get_or_create when creating comm_threads (bug 992369)

### DIFF
--- a/migrations/768-comm-unique.sql
+++ b/migrations/768-comm-unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `comm_threads` ADD UNIQUE (`addon_id`, `version_id`);

--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -141,6 +141,7 @@ class CommunicationThread(CommunicationPermissionModel):
 
     class Meta:
         db_table = 'comm_threads'
+        unique_together = ('addon', 'version')
 
     def join_thread(self, user):
         return self.thread_cc.get_or_create(user=user)

--- a/mkt/comm/utils.py
+++ b/mkt/comm/utils.py
@@ -231,7 +231,7 @@ def create_comm_note(app, version, author, body, note_type=comm.NO_ACTION,
                         for key, has_perm in perms.iteritems())
 
     # Create thread + note.
-    thread, created_thread = app.threads.get_or_create(
+    thread, created_thread = app.threads.safer_get_or_create(
         version=version, defaults=create_perms)
     note = thread.notes.create(
         note_type=note_type, body=body, author=author, **create_perms)


### PR DESCRIPTION
There are 7 duplicate comm_threads in the DB, which are created on a get_or_create. Maybe a safer_get_or_create will prevent that from happening in the future.

@robhudson
