### PR TITLE
Implement fireplace-specific collection API endpoint (bug 989331)

### DIFF
--- a/mkt/api/base.py
+++ b/mkt/api/base.py
@@ -11,6 +11,7 @@ from rest_framework.routers import Route, SimpleRouter
 from rest_framework.response import Response
 from rest_framework.urlpatterns import format_suffix_patterns
 
+import mkt
 
 log = commonware.log.getLogger('z.api')
 
@@ -144,6 +145,19 @@ class MarketplaceView(object):
             self.kwargs[self.page_kwarg] = page_number
         return super(MarketplaceView, self).paginate_queryset(queryset,
             page_size=page_size)
+
+    def get_region_from_request(self, request):
+        """
+        Returns the REGION object for the passed request. If the GET param
+        `region` is `'None'`, return `None`. Otherwise, return `request.REGION`
+        which will have been set by the RegionMiddleware. If somehow we didn't
+        go through the middleware and request.REGION is absent, we fall back to
+        RESTOFWORLD.
+        """
+        region = request.GET.get('region')
+        if region and region == 'None':
+            return None
+        return getattr(request, 'REGION', mkt.regions.RESTOFWORLD)
 
 
 class CORSMixin(object):

--- a/mkt/collections/serializers.py
+++ b/mkt/collections/serializers.py
@@ -102,7 +102,7 @@ class CollectionMembershipField(serializers.RelatedField):
         to properly rehydrate results returned by ES.
         """
         profile = get_feature_profile(request)
-        region = self.context['view'].get_region(request)
+        region = self.context['view'].get_region_from_request(request)
         device = self._get_device(request)
 
         _rget = lambda d: getattr(request, d, False)

--- a/mkt/fireplace/api.py
+++ b/mkt/fireplace/api.py
@@ -11,6 +11,7 @@ from mkt.api.authentication import (RestAnonymousAuthentication,
                                     RestSharedSecretAuthentication)
 from mkt.collections.serializers import (CollectionMembershipField,
                                          CollectionSerializer)
+from mkt.collections.views import CollectionViewSet as BaseCollectionViewSet
 from mkt.search.api import (FeaturedSearchView as BaseFeaturedSearchView,
                             SearchView as BaseSearchView)
 from mkt.search.serializers import SimpleESAppSerializer
@@ -55,6 +56,17 @@ class FireplaceCollectionMembershipField(CollectionMembershipField):
 
 class FireplaceCollectionSerializer(CollectionSerializer):
     apps = FireplaceCollectionMembershipField(many=True, source='apps')
+
+
+class CollectionViewSet(BaseCollectionViewSet):
+    serializer_class = FireplaceCollectionSerializer
+
+    def get_serializer_context(self):
+        """Context passed to the serializer. Since we are in Fireplace, we
+        always want to use ES to fetch apps."""
+        context = super(CollectionViewSet, self).get_serializer_context()
+        context['use-es-for-apps'] = not self.request.GET.get('preview')
+        return context
 
 
 class AppViewSet(BaseAppViewset):

--- a/mkt/fireplace/urls.py
+++ b/mkt/fireplace/urls.py
@@ -2,14 +2,21 @@ from django.conf.urls import include, patterns, url
 
 from rest_framework.routers import SimpleRouter
 
-from mkt.fireplace.api import (AppViewSet, ConsumerInfoView, FeaturedSearchView,
-                               SearchView)
+from mkt.fireplace.api import (AppViewSet, CollectionViewSet, ConsumerInfoView,
+                               FeaturedSearchView, SearchView)
 
 apps = SimpleRouter()
 apps.register(r'app', AppViewSet, base_name='fireplace-app')
 
+
+collections = SimpleRouter()
+collections.register(r'collection', CollectionViewSet,
+                     base_name='fireplace-collection')
+
+
 urlpatterns = patterns('',
     url(r'^fireplace/', include(apps.urls)),
+    url(r'^fireplace/', include(collections.urls)),
     url(r'^fireplace/consumer-info/',
         ConsumerInfoView.as_view(),
         name='fireplace-consumer-info'),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=989331

This introduces a `/api/v1/fireplace/collection/[...]` endpoint that Fireplace can use to display a collection without fetching ton of info about apps it doesn't need. 

(We'll need to update fireplace to use it once it's merged)
