### PR TITLE
Modify previews thumbnails regenerate command to also crush icons (bug 993497)

### DIFF
--- a/apps/addons/management/commands/process_addons.py
+++ b/apps/addons/management/commands/process_addons.py
@@ -13,8 +13,9 @@ from market.tasks import check_paypal, check_paypal_multiple
 
 from mkt.webapps.tasks import (add_uuids, clean_apps, dump_apps,
                                fix_missing_icons, import_manifests,
-                               regenerate_thumbnails, update_manifests,
-                               update_supported_locales, zip_apps)
+                               regenerate_icons_and_thumbnails,
+                               update_manifests, update_supported_locales,
+                               zip_apps)
 
 
 tasks = {
@@ -60,7 +61,8 @@ tasks = {
                                                amo.STATUS_PUBLIC,
                                                amo.STATUS_PUBLIC_WAITING],
                                    disabled_by_user=False)]},
-    'regenerate_thumbnails': {'method': regenerate_thumbnails,
+    'regenerate_icons_and_thumbnails':
+                             {'method': regenerate_icons_and_thumbnails,
                               'qs': [Q(type=amo.ADDON_WEBAPP,
                                        status__in=[amo.STATUS_PENDING,
                                                    amo.STATUS_PUBLIC,

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -36,8 +36,8 @@ from users.utils import get_task_user
 
 import mkt
 from mkt.constants.regions import RESTOFWORLD
-from mkt.developers.tasks import (_fetch_manifest, fetch_icon, resize_preview,
-                                  validator)
+from mkt.developers.tasks import (_fetch_manifest, fetch_icon, pngcrush_image,
+                                  resize_preview, validator)
 from mkt.webapps.models import AppManifest, Webapp, WebappIndexer
 from mkt.webapps.utils import get_locale_properties
 
@@ -503,13 +503,14 @@ def fix_missing_icons(ids, **kw):
         _fix_missing_icons(id)
 
 
-def _regenerate_thumbnails(pk):
+def _regenerate_icons_and_thumbnails(pk):
     try:
         webapp = Webapp.objects.get(pk=pk)
     except Webapp.DoesNotExist:
         _log(id, u'Webapp does not exist')
         return
 
+    # Previews.
     for preview in webapp.all_previews:
         # Re-resize each preview by calling the task with the image that we
         # have and asking the task to only deal with the thumbnail. We no
@@ -517,12 +518,16 @@ def _regenerate_thumbnails(pk):
         # enough for us to generate a thumbnail.
         resize_preview.delay(preview.image_path, preview, generate_image=False)
 
+    # Icons. The only thing we need to do is crush the 64x64 icon.
+    icon_path = os.path.join(webapp.get_icon_dir(), '%s-64.png' % webapp.id)
+    pngcrush_image.delay(icon_path)
+
 
 @task
 @write
-def regenerate_thumbnails(ids, **kw):
+def regenerate_icons_and_thumbnails(ids, **kw):
     for pk in ids:
-        _regenerate_thumbnails(pk);
+        _regenerate_icons_and_thumbnails(pk);
 
 
 @task

--- a/mkt/webapps/tests/test_tasks.py
+++ b/mkt/webapps/tests/test_tasks.py
@@ -634,13 +634,13 @@ class TestFixMissingIcons(amo.tests.TestCase):
         assert fetch_icon.called
 
 
-class TestRegenerateThumbnails(amo.tests.TestCase):
+class TestRegenerateIconsAndThumbnails(amo.tests.TestCase):
     fixtures = fixture('webapp_337141')
 
     @mock.patch('mkt.webapps.tasks.resize_preview.delay')
     def test_command(self, resize_preview):
         preview = Preview.objects.create(filetype='image/png', addon_id=337141)
-        call_command('process_addons', task='regenerate_thumbnails')
+        call_command('process_addons', task='regenerate_icons_and_thumbnails')
 
         resize_preview.assert_called_once_with(preview.image_path, preview,
                                                generate_image=False)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=993497
