### PR TITLE
don't validate accounts formset on the free page (bug 995218)

### DIFF
--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -325,10 +325,10 @@ class TestPayments(Patcher, amo.tests.TestCase):
                                    self.webapp.device_types],
                 'paid_platforms': ['paid-%s' % dt.class_name for dt in
                                    self.webapp.device_types]}
-        extension['form-TOTAL_FORMS'] = 1
-        extension['form-INITIAL_FORMS'] = 1
-        extension['form-MAX_NUM_FORMS'] = 1
         if 'accounts' in extension:
+            extension['form-TOTAL_FORMS'] = 1
+            extension['form-INITIAL_FORMS'] = 1
+            extension['form-MAX_NUM_FORMS'] = 1
             extension['form-0-accounts'] = extension['accounts']
             del extension['accounts']
         base.update(extension)
@@ -342,8 +342,9 @@ class TestPayments(Patcher, amo.tests.TestCase):
 
     def test_premium_passes(self):
         self.webapp.update(premium_type=amo.ADDON_FREE)
-        res = self.client.post(
-            self.url, self.get_postdata({'toggle-paid': 'paid'}), follow=True)
+        res = self.client.post(self.url,
+                               self.get_postdata({'toggle-paid': 'paid'}),
+                               follow=True)
         eq_(self.get_webapp().premium_type, amo.ADDON_PREMIUM)
         eq_(res.context['is_paid'], True)
 

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -70,9 +70,11 @@ def payments(request, addon_id, addon, webapp=False):
 
     if request.method == 'POST':
 
-        success = all(form.is_valid() for form in
-                      [premium_form, region_form, upsell_form,
-                       account_list_formset])
+        active_forms = [premium_form, region_form, upsell_form]
+        if formset_data is not None:
+            active_forms.append(account_list_formset)
+
+        success = all(form.is_valid() for form in active_forms)
 
         if success:
             region_form.save()
@@ -96,7 +98,8 @@ def payments(request, addon_id, addon, webapp=False):
                 try:
                     if not is_free_inapp:
                         upsell_form.save()
-                    account_list_formset.save()
+                    if formset_data is not None:
+                        account_list_formset.save()
                 except client.Error as err:
                     log.error('Error saving payment information (%s)' % err)
                     messages.error(


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=995218

The formset isn't valid if the management form wasn't submitted so it shouldn't be validated or saved if the management form isn't present.
