### PR TITLE
Fix errors in Makefile for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # You can set these variables from the command line.
 DJANGO = python manage.py
 SETTINGS = settings_local
+SHELL := /usr/bin/env bash
 
 .PHONY: help docs test test_force_db tdd test_failed update update_landfill reindex reindex_mkt
 
@@ -36,7 +37,7 @@ test_failed:
 
 update:
 	git checkout master && git pull && git submodule update --init --recursive
-	pushd vendor && git pull && git submodule update --init && popd
+	pushd vendor && git pull . && git submodule update --init && popd
 	pip install --no-deps --exists-action=w --download-cache=/tmp/pip-cache -r requirements/dev.txt --find-links https://pyrepo.addons.mozilla.org/ --allow-external PIL --allow-unverified PIL
 	schematic migrations
 	npm install


### PR DESCRIPTION
This fixes some errors I was seeing when running `make update` under ubuntu.
- `pushd` is a bash builtin so specifying bash was required.
- the second issue was the git pull was complaining about not a branch e.g:
  
  ```
  You are not currently on a branch, so I cannot use any
  'branch.<branchname>.merge' in your configuration file.
  Please specify which branch you want to merge with on the command
  line and try again (e.g. 'git pull <repository> <refspec>').
  See git-pull(1) for details.
  ```

Would be useful if someone on a mac could check this doesn't break anything for them.
