### PR TITLE
De-dupe regions in payments page (bug 996553)

### DIFF
--- a/apps/market/fixtures/market/prices.json
+++ b/apps/market/fixtures/market/prices.json
@@ -122,5 +122,18 @@
       "modified": "2011-08-15 16:15:23",
       "created": "2011-08-15 16:15:23"
     }
+  },
+  {
+    "pk": 7,
+    "model": "market.pricecurrency",
+    "fields": {
+      "currency": "EUR",
+      "tier": 2,
+      "provider": 1,
+      "region": 8,
+      "price": "0.50",
+      "modified": "2011-08-15 16:14:26",
+      "created": "2011-08-15 16:14:26"
+    }
   }
 ]

--- a/apps/market/models.py
+++ b/apps/market/models.py
@@ -171,8 +171,9 @@ class Price(amo.models.ModelBase):
 
     def region_ids_by_slug(self):
         """A tuple of price region ids sorted by slug."""
-        price_regions_ids = [(p['region'], RID.get(p['region']).slug)
-                             for p in self.prices() if p['paid'] is True]
+        price_regions_ids = set([(p['region'], RID.get(p['region']).slug)
+                                 for p in self.prices() if p['paid'] is True])
+
         if price_regions_ids:
             return zip(*sorted(price_regions_ids, key=itemgetter(1)))[0]
         return tuple()


### PR DESCRIPTION
There are some price_currencies that exist for the same region. 

We need to check this in case this data is erroneous but in any case we're going to need to de-dupe the `region_ids_by_slug` list when adding more providers.

This adds duplicate data to the fixture which causes the test to fail without the change.
