### PR TITLE
add in a debug page, really useful for payments

### DIFF
--- a/mkt/developers/templates/developers/debug.html
+++ b/mkt/developers/templates/developers/debug.html
@@ -1,0 +1,18 @@
+{% extends 'developers/base_impala.html' %}
+{% set title = 'Debug: {0}'.format(app.name) %}
+
+{% block title %}{{ hub_page_title(title) }}{% endblock %}
+
+{% block content %}
+  <h1>{{ title }}</h1>
+  <section class="primary">
+    <div class="island">
+      <p>Go to <a href="{{ app.get_dev_url() }}">developer page</a>.</p>
+      <p>See <a href="{{ app.get_api_url() }}">api entry</a>.</p>
+      <p>See <a href="{{ data['urls']['es'] }}">elastic search entry</a>.</p>
+      {% if app.is_premium() %}
+        <p>Buy <a href="/mozpay/?req={{ data['pay_request'] }}">without mozPay</a>.</p>
+      {% endif %}
+    </div>
+  </section>
+{% endblock %}

--- a/mkt/developers/urls.py
+++ b/mkt/developers/urls.py
@@ -64,6 +64,9 @@ app_detail_patterns = patterns('',
     url('^status$', views.status, name='mkt.developers.apps.versions'),
     url('^blocklist$', views.blocklist, name='mkt.developers.apps.blocklist'),
 
+     # Only present if DEBUG=True.
+    url('^debug/', views.debug, name='mkt.developers.debug'),
+
     # IARC content ratings.
     url('^content_ratings$', views.content_ratings,
         name='mkt.developers.apps.ratings'),

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -37,7 +37,7 @@ from amo.utils import escape_all
 from devhub.models import AppLog
 from files.models import File, FileUpload
 from files.utils import parse_addon
-from stats.models import Contribution
+from stats.models import ClientData, Contribution
 from users.models import UserProfile
 from users.views import _login
 from versions.models import Version
@@ -61,6 +61,7 @@ from mkt.developers.utils import check_upload, handle_vip
 from mkt.submit.forms import AppFeaturesForm, NewWebappVersionForm
 from mkt.webapps.models import IARCInfo, Webapp
 from mkt.webapps.tasks import _update_manifest, update_manifests
+from mkt.webpay.webpay_jwt import get_product_jwt, WebAppProduct
 
 from . import forms, tasks
 
@@ -1088,3 +1089,26 @@ def _filter_transactions(qs, data):
 
 def testing(request):
     return render(request, 'developers/testing.html')
+
+
+@addon_view
+def debug(request, addon):
+    if not settings.DEBUG:
+        raise http.Http404
+
+    data = {
+        'urls': {'es': '%s/apps/webapp/%s' % (settings.ES_URLS[0], addon.pk)},
+        'pay_request': ''
+    }
+    if addon.is_premium():
+        data['pay_request'] = get_product_jwt(
+            WebAppProduct(addon),
+            user=request.amo_user,
+            region=request.REGION,
+            source=request.REQUEST.get('src', ''),
+            lang=request.LANG,
+            client_data=ClientData.get_or_create(request),
+        )['webpayJWT']
+
+    return render(request, 'developers/debug.html',
+                  {'app': addon, 'data': data})


### PR DESCRIPTION
- only occurs if debug is on
- means I don't have to remember the ES URL
- means its easy to start a payment on desktop by getting around mozPay not being there
