### PR TITLE
Remove merchant_id from developer signup (bug 994943)

### DIFF
--- a/mkt/developers/forms_payments.py
+++ b/mkt/developers/forms_payments.py
@@ -636,7 +636,6 @@ class BokuAccountForm(happyforms.Form):
     account_name = forms.CharField(max_length=50, label=_lazy(u'Account name'))
     # The lengths of these are not specified in the Boku documentation, so
     # making a guess here about max lengths.
-    merchant_id = forms.CharField(max_length=50, label=_lazy(u'Merchant ID'))
     service_id = forms.CharField(max_length=50, label=_lazy(u'Service ID'))
 
 

--- a/mkt/developers/templates/developers/payments/includes/add_payment_account_boku.html
+++ b/mkt/developers/templates/developers/payments/includes/add_payment_account_boku.html
@@ -9,7 +9,7 @@
       <input type="hidden" name="provider" value="boku">
       <p>
         {% trans boku_url=account_form.signup_url %}
-        You will need a Boku merchant and service id to sign up for
+        You will need a Boku service id to sign up for
         a Boku account. Boku accounts must be created through the
         <a href="{{ boku_url }}">Mozilla sign up process</a>.
         {% endtrans %}
@@ -19,10 +19,6 @@
         <div class="field">
           {{ account_form.account_name.label_tag() }}
           {{ account_form.account_name }}
-        </div>
-        <div class="field">
-          {{ account_form.merchant_id.label_tag() }}
-          {{ account_form.merchant_id }}
         </div>
         <div class="field no-border">
           {{ account_form.service_id.label_tag() }}

--- a/mkt/developers/tests/test_providers.py
+++ b/mkt/developers/tests/test_providers.py
@@ -281,7 +281,7 @@ class TestBoku(Patcher, TestCase):
                                              provider=PROVIDER_BOKU)
 
     def test_account_create(self):
-        data = {'account_name': 'account', 'merchant_id': 'f',
+        data = {'account_name': 'account',
                 'service_id': 'b'}
         res = self.boku.account_create(self.user, data)
         acct = PaymentAccount.objects.get(user=self.user)
@@ -290,7 +290,6 @@ class TestBoku(Patcher, TestCase):
         eq_(res.pk, acct.pk)
         self.boku_patcher.seller.post.assert_called_with(data={
             'seller': ANY,
-            'merchant_id': 'f',
             'service_id': 'b',
         })
 


### PR DESCRIPTION
- Remove merchant_id from sign up form, templates, tests
