### PR TITLE
fix for bug 997416 return query not list

### DIFF
--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -226,8 +226,10 @@ class Webapp(Addon):
     @staticmethod
     def version_and_file_transformer(apps):
         """Attach all the versions and files to the apps."""
-        if not apps:
-            return []
+        # Don't just return an empty list, it will break code that expects
+        # a query object
+        if not len(apps):
+            return apps
 
         ids = set(app.id for app in apps)
         versions = (Version.objects.no_cache().filter(addon__in=ids)

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -655,6 +655,13 @@ class TestWebapp(amo.tests.TestCase):
         pay_mock.return_value = True
         assert app.payments_complete()
 
+    def test_version_and_file_transformer_with_empty_query(self):
+        # When we process a query, don't return a list just because
+        # the query is empty
+        empty_query = Webapp.objects.filter(app_slug='mahna__mahna')
+        empty_result = Webapp.version_and_file_transformer(empty_query)
+        self.assertEqual(empty_result.count(), 0)
+
 
 class TestWebappContentRatings(amo.tests.TestCase):
 


### PR DESCRIPTION
Just a small fix, plus a test. We were returning an empty list from `mkt.webapps.models.Webapp.version_and_file_transformer(apps)` if `apps` was an empty `addons.query.IndexQuerySet` and when code expected a query back, but got a list instead, it called query methods, which broke things.
