### PR TITLE
add collections to our API dumps (bug 996665)

### DIFF
--- a/mkt/collections/tasks.py
+++ b/mkt/collections/tasks.py
@@ -1,0 +1,59 @@
+import json
+import logging
+import os
+
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+
+from celeryutils import task
+from test_utils import RequestFactory
+
+from amo.utils import chunked, JSONEncoder
+from mkt.collections.models import Collection
+from mkt.collections.serializers import CollectionSerializer
+from mkt.constants.regions import RESTOFWORLD
+
+task_log = logging.getLogger('collections.tasks')
+
+
+def collection_filepath(collection):
+    return os.path.join(settings.DUMPED_APPS_PATH,
+                        'collections',
+                        str(collection.pk / 1000),
+                        '{pk}.json'.format(pk=collection.pk))
+
+
+def collection_data(collection):
+    request = RequestFactory().get('/')
+    request.user = AnonymousUser()
+    request.REGION = RESTOFWORLD
+    return CollectionSerializer(collection, context={'request': request}).data
+
+
+def write_file(filepath, output):
+    target_path = os.path.dirname(filepath)
+    if not os.path.exists(target_path):
+        os.makedirs(target_path)
+    with open(filepath, 'w') as f:
+        f.write(output)
+    return filepath
+
+
+def dump_collection(collection):
+    target_file = collection_filepath(collection)
+    task_log.info('Dumping collection {0} to {1}'.format(collection.pk,
+                                                         target_file))
+    json_collection = json.dumps(collection_data(collection),
+                                 cls=JSONEncoder)
+    return write_file(target_file, json_collection)
+
+
+@task(ignore_result=False)
+def dump_collections(pks):
+    return [dump_collection(collection)
+            for collection in Collection.public.filter(pk__in=pks).iterator()]
+
+
+def dump_all_collections_tasks():
+    all_pks = Collection.public.values_list('pk', flat=True).order_by('pk')
+    return [dump_collections.si(pks) for pks in chunked(all_pks, 100)]

--- a/mkt/collections/tests/test_tasks.py
+++ b/mkt/collections/tests/test_tasks.py
@@ -1,0 +1,51 @@
+import json
+import mock
+from tempfile import mkdtemp
+
+from django.test.utils import override_settings
+from nose.tools import eq_
+
+import amo
+import amo.tests
+from mkt.collections.models import Collection
+from mkt.collections.tasks import dump_collection, dump_collections
+from mkt.webapps.tasks import rm_directory
+from mkt.site.fixtures import fixture
+
+temp_directory = mkdtemp()
+
+
+@override_settings(DUMPED_APPS_PATH=temp_directory)
+class TestDumpCollections(amo.tests.TestCase):
+    fixtures = fixture('webapp_337141', 'collection_81721')
+
+    def get_collection(self):
+        return Collection.objects.get(pk=81721)
+
+    def tearDown(self):
+        rm_directory(temp_directory)
+
+    def test_dump_collections(self):
+        filename = dump_collections([81721])[0]
+        collection_json = json.load(open(filename, 'r'))
+        eq_(collection_json['id'], 81721)
+        eq_(collection_json['slug'], 'public-apps')
+
+    def test_dump_collection(self):
+        collection = self.get_collection()
+        filename = dump_collection(collection)
+        collection_json = json.load(open(filename, 'r'))
+        eq_(collection_json['id'], 81721)
+        eq_(collection_json['slug'], 'public-apps')
+
+    @mock.patch('mkt.collections.tasks.dump_collection')
+    def test_dumps_public_collection(self, dump_collection):
+        dump_collections([81721])
+        assert dump_collection.called
+
+    @mock.patch('mkt.collections.tasks.dump_collection')
+    def test_doesnt_dump_public_collection(self, dump_collection):
+        collection = self.get_collection()
+        collection.update(is_public=False)
+        dump_collections([81721])
+        assert not dump_collection.called

--- a/mkt/site/fixtures/data/collection_81721.json
+++ b/mkt/site/fixtures/data/collection_81721.json
@@ -1,0 +1,60 @@
+[
+{
+    "pk": 580, 
+    "model": "translations.translation", 
+    "fields": {
+        "localized_string_clean": "Public apps", 
+        "created": "2014-04-17T10:20:36", 
+        "locale": "en-us", 
+        "modified": "2014-04-17T10:20:36", 
+        "id": 1363, 
+        "localized_string": "Public apps"
+    }
+},
+{
+    "pk": 579, 
+    "model": "translations.translation", 
+    "fields": {
+        "localized_string_clean": "Public apps", 
+        "created": "2014-04-17T10:20:36", 
+        "locale": "en-us", 
+        "modified": "2014-04-17T10:20:36", 
+        "id": 1362, 
+        "localized_string": "Public apps"
+    }
+},
+{
+    "pk": 81721, 
+    "model": "collections.collection", 
+    "fields": {
+        "category": null, 
+        "curators": [], 
+        "image_hash": null, 
+        "description": 1362, 
+        "created": "2014-04-17T10:20:36", 
+        "region": null, 
+        "author": "Mark", 
+        "default_language": "en-US", 
+        "modified": "2014-04-17T10:20:49", 
+        "can_be_hero": false, 
+        "text_color": "#000000", 
+        "carrier": null, 
+        "collection_type": 0, 
+        "is_public": true, 
+        "background_color": "#ffffff", 
+        "slug": "public-apps", 
+        "name": 1363
+    }
+},
+{
+    "pk": 8, 
+    "model": "collections.collectionmembership", 
+    "fields": {
+        "app": 337141, 
+        "order": 0, 
+        "modified": "2014-04-17T10:20:44", 
+        "collection": 81721, 
+        "created": "2014-04-17T10:20:44"
+    }
+}
+]

--- a/mkt/webapps/management/commands/export_data.py
+++ b/mkt/webapps/management/commands/export_data.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from mkt.webapps.tasks import export_data
+
+
+class Command(BaseCommand):
+    help = 'Export our data as a tgz for third-parties'
+
+    def handle(self, *args, **kwargs):
+        export_data()

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -47,7 +47,7 @@ HOME=/tmp
 45 9 * * * %(z_cron)s mkt_gc --settings=settings_local_mkt
 45 9 * * * %(z_cron)s clean_old_signed --settings=settings_local_mkt
 45 10 * * * %(django)s process_addons --task=update_manifests --settings=settings_local_mkt
-45 11 * * * %(django)s process_addons --task=dump_apps --settings=settings_local_mkt
+45 11 * * * %(django)s export_data --settings=settings_local_mkt
 # 30 12 * * * %(z_cron)s cleanup_synced_collections
 # 30 13 * * * %(z_cron)s expired_resetcode
 # 30 14 * * * %(z_cron)s category_totals


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=996665

This adds a new management command `export_data` which can be used to dump apps and collections together in the same format that apps were dumped before.
