### PR TITLE
Handle special tarako categories in search (bug 998814)

### DIFF
--- a/locale/generate_categories_translations.py
+++ b/locale/generate_categories_translations.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+import os
+import requests
+
+api_url = 'https://marketplace.firefox.com/api/v1/apps/category/?lang=%s'
+
+english_categories = {  # Stolen from fireplace's categories.js
+    'games': 'Games',
+    #'books': 'Books',  # Commented because already present in .po files.
+    'business': 'Business',
+    'education': 'Education',
+    'entertainment': 'Entertainment',
+    'health-fitness': 'Health & Fitness',
+    'lifestyle': 'Lifestyle',
+    'maps-navigation': 'Maps & Navigation',
+    'music': 'Music',
+    'news-weather': 'News & Weather',
+    'photo-video': 'Photo & Video',
+    'productivity': 'Productivity',
+    'reference': 'Reference',
+    'shopping': 'Shopping',
+    'social': 'Social',
+    'sports': 'Sports',
+    'travel': 'Travel',
+    'utilities': 'Utilities'
+}
+
+
+def build_locale_dict(data):
+    if not 'objects' in data:
+        return None
+    return dict(((d['slug'], d['name']) for d in data['objects']
+                 if d['slug'] in english_categories))
+
+
+def write_po(filename, locale_categories):
+    with open(filename, 'a') as f:
+        for slug, translation in locale_categories.items():
+            f.write('\n')
+            f.write('#: /mkt/search/forms.py\n')
+            f.write('msgid "%s"\n' % english_categories[slug])
+            f.write('msgstr "%s"\n' % locale_categories[slug].encode('utf-8'))
+
+
+
+def main():
+    if not os.getcwd().endswith('locale'):
+        print 'Run me from the locale/ directory please.'
+        return
+
+    for locale in os.listdir('.'):
+        if not os.path.isdir(locale) or locale == 'templates':
+            # print "Skipping %s since it's not a locale directory" % locale
+            continue
+
+        fname = os.path.join(locale, 'LC_MESSAGES', 'messages.po')
+        if not os.path.exists(fname):
+            # print "Skipping %s since it doesn't contain a messages.po file"
+            continue
+
+        print "Requesting categories for locale %s from the API" % locale
+        response = requests.get(api_url % locale)
+        if not response.status_code == 200:
+            print "Error while requesting API, aborting script."
+            return
+
+        locale_categories = build_locale_dict(response.json())
+        if locale_categories is None:
+            print "Error in API response, aborting script."
+            return
+
+        if locale_categories == english_categories:
+            print "Skipping '%s' since API response is not translated" % locale
+            continue
+
+        print "Writing %d translations to %s" % (len(locale_categories), fname)
+        write_po(fname, locale_categories)
+
+
+if __name__ == '__main__':
+    main()

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -2762,6 +2762,9 @@ class TestGetSigned(BasePackagedAppTest, amo.tests.TestCase):
         eq_(res.status_code, 404)
 
     def test_token_good(self):
+        if not settings.XSENDFILE:
+            raise SkipTest()
+
         token = Token(data={'app_id': self.app.id})
         token.save()
         self.setup_files()

--- a/mkt/search/api.py
+++ b/mkt/search/api.py
@@ -8,7 +8,6 @@ from rest_framework.generics import GenericAPIView
 
 from translations.helpers import truncate
 
-import mkt
 from mkt.api.authentication import (RestSharedSecretAuthentication,
                                     RestOAuthAuthentication)
 from mkt.api.base import CORSMixin, form_errors, MarketplaceView
@@ -21,7 +20,7 @@ from mkt.collections.models import Collection
 from mkt.collections.serializers import CollectionSerializer
 from mkt.features.utils import get_feature_profile
 from mkt.search.views import _filter_search
-from mkt.search.forms import ApiSearchForm
+from mkt.search.forms import ApiSearchForm, TARAKO_CATEGORIES_MAPPING
 from mkt.search.serializers import (ESAppSerializer, RocketbarESAppSerializer,
                                     SuggestionsESAppSerializer)
 from mkt.search.utils import S
@@ -104,6 +103,9 @@ class FeaturedSearchView(SearchView):
         return response
 
     def add_featured_etc(self, request, data):
+        # Tarako categories don't have collections.
+        if request.GET.get('cat') in TARAKO_CATEGORIES_MAPPING:
+            return data, {}
         types = (
             ('collections', COLLECTIONS_TYPE_BASIC),
             ('featured', COLLECTIONS_TYPE_FEATURED),

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -12,7 +12,8 @@ from mkt import regions
 from mkt.api.tests.test_oauth import BaseOAuth
 from mkt.regions import set_region
 from mkt.reviewers.forms import ApiReviewersSearchForm
-from mkt.search.forms import ApiSearchForm, DEVICE_CHOICES_IDS
+from mkt.search.forms import (ApiSearchForm, DEVICE_CHOICES_IDS,
+                              TARAKO_CATEGORIES_MAPPING)
 from mkt.search.views import _filter_search
 from mkt.site.fixtures import fixture
 from mkt.webapps.models import Webapp
@@ -97,7 +98,20 @@ class TestSearchFilters(BaseOAuth):
 
     def test_category(self):
         qs = self._filter(self.req, {'cat': self.category.slug})
-        ok_({'term': {'category': self.category.slug}} in qs['filter']['and'])
+        ok_({'in': {'category': [self.category.slug]}} in qs['filter']['and'])
+
+    def test_tarako_categories(self):
+        qs = self._filter(self.req, {'cat': 'tarako-lifestyle'})
+        ok_({'in': {'category': TARAKO_CATEGORIES_MAPPING['tarako-lifestyle']}}
+            in qs['filter']['and'])
+
+        qs = self._filter(self.req, {'cat': 'tarako-games'})
+        ok_({'in': {'category': TARAKO_CATEGORIES_MAPPING['tarako-games']}}
+            in qs['filter']['and'])
+
+        qs = self._filter(self.req, {'cat': 'tarako-tools'})
+        ok_({'in': {'category': TARAKO_CATEGORIES_MAPPING['tarako-tools']}}
+            in qs['filter']['and'])
 
     def test_device(self):
         qs = self._filter(self.req, {'device': 'desktop'})

--- a/mkt/search/views.py
+++ b/mkt/search/views.py
@@ -105,7 +105,9 @@ def _filter_search(request, qs, query, filters=None, sorting=None,
     if query.get('q'):
         qs = qs.query(should=True, **name_query(query['q'].lower()))
     if 'cat' in show:
-        qs = qs.filter(category=query['cat'])
+        # query['cat'] should be a list, the form clean_cat method takes care
+        # of that.
+        qs = qs.filter(category__in=query['cat'])
     if 'price' in show:
         if query['price'] == 'paid':
             qs = qs.filter(premium_type__in=amo.ADDON_PREMIUMS)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=998814

Ground work for bug 987880 (only the parts relevant to search) is also included to make things easier. A script to generate translations (almost an exact copy of what was added to fireplace one month ago) to be run before extracting new strings for translators.

For client-side API users: just continue using `/api/v1/fireplace/search/featured/` endpoint, pass `cat=tarako-lifestyle`, `cat=tarako-tools` or `cat=tarako-games` and everything should be handled for you in a transparent way. Note that no Featured Apps, Basic Collections or Operator Shelves will appear.
