### PR TITLE
add a django form validation for the boku service id (bug 999075)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -13,7 +13,7 @@ certifi==0.0.8
 chardet==2.1.1
 commonware==0.4.2
 cssutils==0.9.7b3
-curling==0.2.6
+curling==0.3.9.4
 defusedxml==0.4.1
 dennis==0.3.10
 Django==1.6.2


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=999075

Waiting on @andymckay's curling update for the parse error.

![screenshot 2014-04-23 09 40 36](https://cloud.githubusercontent.com/assets/211578/2778751/46136c80-caf5-11e3-87c1-f62632a2c662.png)
