### PR TITLE
Don't dump out html for unhandled errors (bug 1000992)

### DIFF
--- a/media/css/devreg/payments.styl
+++ b/media/css/devreg/payments.styl
@@ -303,6 +303,10 @@
             display: inline-block;
             vertical-align: top;
         }
+
+        p.error {
+            margin-top: 1em;
+        }
     }
 
 }

--- a/media/js/devreg/payments.js
+++ b/media/js/devreg/payments.js
@@ -84,7 +84,7 @@ define('payments', [], function() {
                     // There was a JSON parse error, just stick the error
                     // message on the form.
                     $old_overlay.find('#payment-account-errors')
-                                .html(error_data.responseText);
+                                .append($('<p class="error"></p>').text(apiErrorMsg));
                 }
 
                 // Re-initialize the form submit binding.


### PR DESCRIPTION
This doesn't address the root cause of bug 1000992 but it does mean our unhandled error message is not just outputting as html anything we get as a response. Instead this defaults to a generic error message.
