### PR TITLE
paginate by the max number of regions

### DIFF
--- a/mkt/api/resources.py
+++ b/mkt/api/resources.py
@@ -34,6 +34,7 @@ from mkt.api.base import (cors_api_view, CORSMixin, MarketplaceView,
 from mkt.api.fields import SlugChoiceField
 from mkt.api.serializers import CarrierSerializer, RegionSerializer
 from mkt.carriers import CARRIER_MAP, CARRIERS
+from mkt.regions import REGIONS_DICT
 from mkt.regions.utils import parse_region
 from mkt.constants.regions import REGIONS_CHOICES_SLUG, REGIONS_DICT
 from mkt.webapps.tasks import _update_manifest
@@ -127,6 +128,7 @@ class RegionViewSet(CORSMixin, MarketplaceView, ReadOnlyModelViewSet):
     authentication_classes = []
     permission_classes = [AllowAny]
     serializer_class = RegionSerializer
+    paginate_by = len(REGIONS_DICT)
 
     def get_queryset(self, *args, **kwargs):
         return REGIONS_DICT.values()

--- a/mkt/api/tests/test_resources.py
+++ b/mkt/api/tests/test_resources.py
@@ -79,7 +79,7 @@ class TestConfig(RestOAuth):
 class TestRegion(RestOAuth):
 
     def test_list(self):
-        res = self.anon.get(urlparams(reverse('regions-list'), limit=100))
+        res = self.anon.get(urlparams(reverse('regions-list')))
         eq_(res.status_code, 200)
         data = json.loads(res.content)
         for row in data['objects']:


### PR DESCRIPTION
- because if you say paginate_by = None, it doesn't do the standard paginate step in the response and will return a list, not a dictionary
- remove limit = 100 in the test which was hiding this issue
