### PR TITLE
Remove clean_redis from cron.

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -17,10 +17,6 @@ HOME=/tmp
 50 * * * * %(z_cron)s cleanup_extracted_file
 55 * * * * %(z_cron)s unhide_disabled_files
 
-
-# Every 4 hours.
-40 */4 * * * %(django)s clean_redis
-
 # Twice per day.
 # Use system python to use an older version of sqlalchemy than what is in our venv
 # commented out 2013-03-28, clouserw


### PR DESCRIPTION
It seems like this is no longer needed. Logs for last 30 days show that 0 keys are dropped.

May  5 16:40:05 mktadm1: [][] z.redis:DEBUG [0 0.0%] Dropping 0 keys.

@oremj r?
