### PR TITLE
check provider count when creating AccountListFormSet (bug 1007729)

### DIFF
--- a/mkt/developers/forms_payments.py
+++ b/mkt/developers/forms_payments.py
@@ -609,11 +609,15 @@ class AccountListBaseFormSet(BaseFormSet):
             form.save()
 
 
-provider_count = len(settings.PAYMENT_PROVIDERS)
-AccountListFormSet = formset_factory(AccountListForm,
-                                     formset=AccountListBaseFormSet,
-                                     extra=provider_count,
-                                     max_num=provider_count)
+# Wrap the formset_factory call in a function so that extra/max_num works with
+# different values of settings.PAYMENT_PROVIDERS in the tests.
+def AccountListFormSet(*args, **kwargs):
+    provider_count = len(settings.PAYMENT_PROVIDERS)
+    current_form_set = formset_factory(AccountListForm,
+                                       formset=AccountListBaseFormSet,
+                                       extra=provider_count,
+                                       max_num=provider_count)
+    return current_form_set(*args, **kwargs)
 
 
 class ReferenceAccountForm(happyforms.Form):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1007729

This will check the length of `PAYMENT_PROVIDERS` when creating an `AccountListFormSet` instead of at start-up.
