### PR TITLE
Allow admins to remove all tags (bug 1012649)

### DIFF
--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -368,21 +368,19 @@ class AdminSettingsForm(PreviewForm):
         updates.update({'priority_review': self.cleaned_data.get('priority_review')})
         addon.update(**updates)
 
-        tags = self.cleaned_data.get('tags')
-        if tags:
-            tags_new = self.cleaned_data['tags']
-            tags_old = [slugify(t, spaces=True) for t in self.get_tags(addon)]
+        tags_new = self.cleaned_data['tags']
+        tags_old = [slugify(t, spaces=True) for t in self.get_tags(addon)]
 
-            add_tags = set(tags_new) - set(tags_old)
-            del_tags = set(tags_old) - set(tags_new)
+        add_tags = set(tags_new) - set(tags_old)
+        del_tags = set(tags_old) - set(tags_new)
 
-            # Add new tags.
-            for t in add_tags:
-                Tag(tag_text=t).save_tag(addon)
+        # Add new tags.
+        for t in add_tags:
+            Tag(tag_text=t).save_tag(addon)
 
-            # Remove old tags.
-            for t in del_tags:
-                Tag(tag_text=t).remove_tag(addon)
+        # Remove old tags.
+        for t in del_tags:
+            Tag(tag_text=t).remove_tag(addon)
 
         geodata = addon.geodata
         geodata.banner_regions = self.cleaned_data.get('banner_regions')

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -567,6 +567,19 @@ class TestAdminSettingsForm(TestAdmin):
             self.webapp.tags.values_list('tag_text', flat=True),
             ['tag two', 'tag three'])
 
+    def test_removing_all_tags(self):
+        Tag(tag_text='tag one').save_tag(self.webapp)
+        eq_(self.webapp.tags.count(), 1)
+
+        self.data.update({'tags': ''})
+        form = forms.AdminSettingsForm(self.data, **self.kwargs)
+        assert form.is_valid(), form.errors
+        form.save(self.webapp)
+
+        eq_(self.webapp.tags.count(), 0)
+        self.assertSetEqual(
+            self.webapp.tags.values_list('tag_text', flat=True), [])
+
     def test_banner_message(self):
         self.data.update({
             'banner_message_en-us': u'Oh Hai.',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1012649

`clean_tags` already return an empty set when there are no tags, so that `if` was preventing us from removing all tags from the the addon.
