### PR TITLE
s/app_types/app_type in API documentation

### DIFF
--- a/docs/api/topics/search.rst
+++ b/docs/api/topics/search.rst
@@ -36,9 +36,9 @@ Search
     :param optional type: Filters by type of add-on. One of 'app' or
         'theme'.
     :type type: string
-    :param optional app_types: Filters by types of web apps. Any of 'hosted',
+    :param optional app_type: Filters by types of web apps. Any of 'hosted',
         'packaged', or 'privileged'.
-    :type app_types: string
+    :type app_type: string
     :param optional manifest_url: Filters by manifest URL. Requires an
         exact match and should only return a single result if a match is
         found.


### PR DESCRIPTION
I found some discussion about what to call this param here: https://github.com/mozilla/zamboni/commit/b687fcd1e2be56d84fed161073a0638768fe926f#diff-8dd42c21fa965fbc2c1d1b8109465773. Currently, it seems to be called app_type, though.
