### PR TITLE
Don't reset make_public by accident when editing a PENDING app (bug 993424)

### DIFF
--- a/mkt/developers/tests/test_views_edit.py
+++ b/mkt/developers/tests/test_views_edit.py
@@ -523,6 +523,16 @@ class TestEditBasic(TestEdit):
         releasenotes = self.webapp.current_version.reload().releasenotes
         eq_(res.status_code, 200)
         eq_(releasenotes, data['releasenotes'])
+        # Make sure make_public wasn't reset by accident.
+        eq_(self.webapp.reload().make_public, None)
+
+    def test_edit_release_notes_pending(self):
+        # Like test_edit_release_notes, but with a pending app.
+        file_ = self.webapp.current_version.all_files[0]
+        file_.update(status=amo.STATUS_PENDING)
+        self.webapp.update(status=amo.STATUS_PENDING)
+        self.test_edit_release_notes()
+        eq_(self.webapp.reload().status, amo.STATUS_PENDING)
 
     def test_edit_release_notes_packaged(self):
         # You are not supposed to edit release notes from the basic edit

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -865,6 +865,11 @@ def addons_section(request, addon_id, addon, section, editable=False,
                     appfeatures_form.save()
 
                 if version_form:
+                    # We are re-using version_form without displaying all its
+                    # fields, so we need to override the boolean fields,
+                    # otherwise they'd be considered empty and therefore False.
+                    version_form.cleaned_data['publish_immediately'] = (
+                        version_form.fields['publish_immediately'].initial)
                     version_form.save()
 
                 if 'manifest_url' in form.changed_data:


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=993424

We already set `initial` on the field in the form, but that's not enough to make it work if the field is fully omitted from the HTML we use, which is the case here.
