### PR TITLE
Expose 'is_offline' everywhere in the API, not just in search (bug 861303)

### DIFF
--- a/apps/amo/__init__.py
+++ b/apps/amo/__init__.py
@@ -89,6 +89,12 @@ class CachedProperty(object):
             raise TypeError('read only attribute')
         obj.__dict__[self.__name__] = value
 
+    def __delete__(self, obj):
+        if not self.writable:
+            raise TypeError('read only attribute')
+        del obj.__dict__[self.__name__]
+
+
 # For unproven performance gains put firefox and thunderbird parsing
 # here instead of constants
 FIREFOX.latest_version = product_details.firefox_versions['LATEST_FIREFOX_VERSION']

--- a/mkt/fireplace/serializers.py
+++ b/mkt/fireplace/serializers.py
@@ -16,11 +16,12 @@ class FireplaceAppSerializer(BaseFireplaceAppSerializer, SimpleAppSerializer):
     class Meta(SimpleAppSerializer.Meta):
         fields = ['author', 'banner_message', 'banner_regions', 'categories',
                   'content_ratings', 'current_version', 'description',
-                  'device_types', 'homepage', 'icons', 'id', 'is_packaged',
-                  'manifest_url', 'name', 'payment_required', 'premium_type',
-                  'previews', 'price', 'price_locale', 'privacy_policy',
-                  'public_stats', 'release_notes', 'ratings', 'slug', 'status',
-                  'support_email', 'support_url', 'upsell', 'user']
+                  'device_types', 'homepage', 'icons', 'id', 'is_offline',
+                  'is_packaged', 'manifest_url', 'name', 'payment_required',
+                  'premium_type', 'previews', 'price', 'price_locale',
+                  'privacy_policy', 'public_stats', 'release_notes', 'ratings',
+                  'slug', 'status', 'support_email', 'support_url', 'upsell',
+                  'user']
         exclude = []
 
 

--- a/mkt/search/serializers.py
+++ b/mkt/search/serializers.py
@@ -23,7 +23,6 @@ from versions.models import Version
 class ESAppSerializer(AppSerializer):
     # Fields specific to search.
     absolute_url = serializers.SerializerMethodField('get_absolute_url')
-    is_offline = serializers.BooleanField()
     reviewed = serializers.DateField()
 
     # Override previews, because we don't need the full PreviewSerializer.
@@ -47,8 +46,7 @@ class ESAppSerializer(AppSerializer):
     support_url = ESTranslationSerializerField()
 
     class Meta(AppSerializer.Meta):
-        fields = AppSerializer.Meta.fields + ['absolute_url', 'is_offline',
-                                              'reviewed']
+        fields = AppSerializer.Meta.fields + ['absolute_url', 'reviewed']
 
     def __init__(self, *args, **kwargs):
         super(ESAppSerializer, self).__init__(*args, **kwargs)

--- a/mkt/search/tests/test_views.py
+++ b/mkt/search/tests/test_views.py
@@ -222,6 +222,7 @@ class TestApi(RestOAuth, ESTestCase):
             eq_(obj['icons']['128'], self.webapp.get_icon_url(128))
             ok_(obj['icons']['128'].endswith('?modified=fakehash'))
             eq_(obj['id'], long(self.webapp.id))
+            eq_(obj['is_offline'], False)
             eq_(obj['manifest_url'], self.webapp.get_manifest_url())
             eq_(obj['payment_account'], None)
             self.assertApiUrlEqual(obj['privacy_policy'],
@@ -540,6 +541,8 @@ class TestApi(RestOAuth, ESTestCase):
         eq_(res.status_code, 200)
         obj = res.json['objects'][0]
         eq_(obj['slug'], self.webapp.app_slug)
+        eq_(obj['is_packaged'], False)
+        eq_(obj['is_offline'], False)
 
     def test_app_type_packaged(self):
         self.webapp.update(is_packaged=True)
@@ -550,6 +553,8 @@ class TestApi(RestOAuth, ESTestCase):
         eq_(res.status_code, 200)
         obj = res.json['objects'][0]
         eq_(obj['slug'], self.webapp.app_slug)
+        eq_(obj['is_packaged'], True)
+        eq_(obj['is_offline'], True)
 
     def test_app_type_privileged(self):
         # Override the class-decorated patch.

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -68,6 +68,7 @@ class AppSerializer(serializers.ModelSerializer):
     homepage = TranslationSerializerField(required=False)
     icons = serializers.SerializerMethodField('get_icons')
     id = serializers.IntegerField(source='pk', required=False)
+    is_offline = serializers.BooleanField(read_only=True)
     is_packaged = serializers.BooleanField(read_only=True)
     manifest_url = serializers.CharField(source='get_manifest_url',
                                          read_only=True)
@@ -112,7 +113,7 @@ class AppSerializer(serializers.ModelSerializer):
             'app_type', 'author', 'banner_message', 'banner_regions',
             'categories', 'content_ratings', 'created', 'current_version',
             'default_locale', 'description', 'device_types', 'homepage',
-            'icons', 'id', 'is_packaged', 'manifest_url', 'name',
+            'icons', 'id', 'is_offline', 'is_packaged', 'manifest_url', 'name',
             'payment_account', 'payment_required', 'premium_type', 'previews',
             'price', 'price_locale', 'privacy_policy', 'public_stats',
             'release_notes', 'ratings', 'regions', 'resource_uri', 'slug',

--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -42,6 +42,18 @@ class TestAppSerializer(amo.tests.TestCase):
         a = AppSerializer(instance=app, context={'request': self.request})
         return a.data
 
+    def test_packaged(self):
+        res = self.serialize(self.app)
+        eq_(res['is_packaged'], False)
+        eq_(res['is_offline'], False)
+
+        self.app.update(is_packaged=True)
+        del self.app.is_offline  # cached_property, need to be reset.
+
+        res = self.serialize(self.app)
+        eq_(res['is_packaged'], True)
+        eq_(res['is_offline'], True)
+
     def test_no_previews(self):
         eq_(self.serialize(self.app)['previews'], [])
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=861303

Prerequisite to exposing whether an app works offline or not in the UI.
