### PR TITLE
Add a fake User-Agent to tasks fetching remote resources (bug 1018279)

### DIFF
--- a/mkt/developers/tasks.py
+++ b/mkt/developers/tasks.py
@@ -45,6 +45,10 @@ CT_URL = (
     'https://developer.mozilla.org/docs/Web/Apps/Manifest#Serving_manifests'
 )
 
+REQUESTS_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0'
+}
+
 
 @task
 @write
@@ -248,7 +252,8 @@ def get_preview_sizes(ids, **kw):
 def _fetch_content(url):
     with statsd.timer('developers.tasks.fetch_content'):
         try:
-            res = requests.get(url, timeout=30, stream=True)
+            res = requests.get(url, timeout=30, stream=True,
+                               headers=REQUESTS_HEADERS)
 
             if not 200 <= res.status_code < 300:
                 statsd.incr('developers.tasks.fetch_content.error')

--- a/mkt/developers/tests/test_tasks.py
+++ b/mkt/developers/tests/test_tasks.py
@@ -298,6 +298,8 @@ class TestFetchManifest(amo.tests.TestCase):
 
         tasks.fetch_manifest('http://xx.com/manifest.json', self.upload.pk)
         assert validator_mock.called
+        assert self.requests_mock.called
+        eq_(self.requests_mock.call_args[1]['headers'], tasks.REQUESTS_HEADERS)
 
     def check_validation(self, msg=''):
         upload = self.get_upload()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1018279

Sadly necessary because some hosts blacklist the default UA used by python-requests :( I used the UA that the validator was already using when fetching content itself [0], and at the same time didn't want to import it because it's not just a validator issue : we also need that when fetching icons for instance.

[0] https://github.com/mozilla/app-validator/blob/master/appvalidator/testcases/webappbase.py#L17
