### PR TITLE
Change "Firefox for Desktop" to "Firefox Desktop" (bug 964961)

### DIFF
--- a/locale/af/LC_MESSAGES/messages.po
+++ b/locale/af/LC_MESSAGES/messages.po
@@ -3882,7 +3882,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ar/LC_MESSAGES/messages.po
+++ b/locale/ar/LC_MESSAGES/messages.po
@@ -3932,7 +3932,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/as/LC_MESSAGES/messages.po
+++ b/locale/as/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ast/LC_MESSAGES/messages.po
+++ b/locale/ast/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/be/LC_MESSAGES/messages.po
+++ b/locale/be/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/bg/LC_MESSAGES/messages.po
+++ b/locale/bg/LC_MESSAGES/messages.po
@@ -3864,7 +3864,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/bn_BD/LC_MESSAGES/messages.po
+++ b/locale/bn_BD/LC_MESSAGES/messages.po
@@ -3826,7 +3826,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/bn_IN/LC_MESSAGES/messages.po
+++ b/locale/bn_IN/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/bs/LC_MESSAGES/messages.po
+++ b/locale/bs/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ca/LC_MESSAGES/messages.po
+++ b/locale/ca/LC_MESSAGES/messages.po
@@ -3884,7 +3884,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/cs/LC_MESSAGES/messages.po
+++ b/locale/cs/LC_MESSAGES/messages.po
@@ -3887,7 +3887,7 @@ msgid "Completed"
 msgstr "Dokončeno"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox pro desktop"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/cy/LC_MESSAGES/messages.po
+++ b/locale/cy/LC_MESSAGES/messages.po
@@ -3900,7 +3900,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/da/LC_MESSAGES/messages.po
+++ b/locale/da/LC_MESSAGES/messages.po
@@ -3857,8 +3857,8 @@ msgid "Completed"
 msgstr "Gennemført"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
-msgstr "Firefox til computer"
+msgid "Firefox Desktop"
+msgstr "Firefox Desktop"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81
 msgid "Fully open mobile ecosystem"

--- a/locale/dbg/LC_MESSAGES/messages.po
+++ b/locale/dbg/LC_MESSAGES/messages.po
@@ -4475,7 +4475,7 @@ msgstr "Ƈǿḿƥŀḗŧḗḓ"
 #: mkt/constants/tests/test_platforms.py:15
 #: mkt/constants/tests/test_platforms.py:35
 #: mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Ƒīřḗƒǿẋ ƒǿř Ḓḗşķŧǿƥ"
 
 #: mkt/constants/platforms.py:77

--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -3875,7 +3875,7 @@ msgid "Completed"
 msgstr "Vollständig"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox für Desktop-PCs"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/el/LC_MESSAGES/messages.po
+++ b/locale/el/LC_MESSAGES/messages.po
@@ -3865,7 +3865,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -3867,8 +3867,8 @@ msgid "Completed"
 msgstr "Completed"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
-msgstr "Firefox for Desktop"
+msgid "Firefox Desktop"
+msgstr "Firefox Desktop"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81
 msgid "Fully open mobile ecosystem"

--- a/locale/eo/LC_MESSAGES/messages.po
+++ b/locale/eo/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -3882,7 +3882,7 @@ msgid "Completed"
 msgstr "Completado"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox para escritorio"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/et/LC_MESSAGES/messages.po
+++ b/locale/et/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/eu/LC_MESSAGES/messages.po
+++ b/locale/eu/LC_MESSAGES/messages.po
@@ -3892,7 +3892,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/fa/LC_MESSAGES/messages.po
+++ b/locale/fa/LC_MESSAGES/messages.po
@@ -3832,7 +3832,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ff/LC_MESSAGES/messages.po
+++ b/locale/ff/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/fi/LC_MESSAGES/messages.po
+++ b/locale/fi/LC_MESSAGES/messages.po
@@ -3902,7 +3902,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -3880,7 +3880,7 @@ msgid "Completed"
 msgstr "Complété"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox pour bureau"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/fy_NL/LC_MESSAGES/messages.po
+++ b/locale/fy_NL/LC_MESSAGES/messages.po
@@ -3925,7 +3925,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ga_IE/LC_MESSAGES/messages.po
+++ b/locale/ga_IE/LC_MESSAGES/messages.po
@@ -3912,7 +3912,7 @@ msgid "Completed"
 msgstr "Críochnaithe"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/gd/LC_MESSAGES/messages.po
+++ b/locale/gd/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/gl/LC_MESSAGES/messages.po
+++ b/locale/gl/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/gu/LC_MESSAGES/messages.po
+++ b/locale/gu/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/he/LC_MESSAGES/messages.po
+++ b/locale/he/LC_MESSAGES/messages.po
@@ -3883,7 +3883,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/hi_IN/LC_MESSAGES/messages.po
+++ b/locale/hi_IN/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/hr/LC_MESSAGES/messages.po
+++ b/locale/hr/LC_MESSAGES/messages.po
@@ -3858,7 +3858,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ht/LC_MESSAGES/messages.po
+++ b/locale/ht/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/hu/LC_MESSAGES/messages.po
+++ b/locale/hu/LC_MESSAGES/messages.po
@@ -3872,7 +3872,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/id/LC_MESSAGES/messages.po
+++ b/locale/id/LC_MESSAGES/messages.po
@@ -3840,7 +3840,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/it/LC_MESSAGES/messages.po
+++ b/locale/it/LC_MESSAGES/messages.po
@@ -3876,7 +3876,7 @@ msgid "Completed"
 msgstr "Completato"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox Desktop"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ja/LC_MESSAGES/messages.po
+++ b/locale/ja/LC_MESSAGES/messages.po
@@ -3857,7 +3857,7 @@ msgid "Completed"
 msgstr "完了"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "デスクトップ版 Firefox"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/km/LC_MESSAGES/messages.po
+++ b/locale/km/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/kn/LC_MESSAGES/messages.po
+++ b/locale/kn/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ko/LC_MESSAGES/messages.po
+++ b/locale/ko/LC_MESSAGES/messages.po
@@ -3848,7 +3848,7 @@ msgid "Completed"
 msgstr "완료됨"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ku/LC_MESSAGES/messages.po
+++ b/locale/ku/LC_MESSAGES/messages.po
@@ -3826,7 +3826,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/lij/LC_MESSAGES/messages.po
+++ b/locale/lij/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/lt/LC_MESSAGES/messages.po
+++ b/locale/lt/LC_MESSAGES/messages.po
@@ -3854,7 +3854,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/mk/LC_MESSAGES/messages.po
+++ b/locale/mk/LC_MESSAGES/messages.po
@@ -3828,7 +3828,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ml/LC_MESSAGES/messages.po
+++ b/locale/ml/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/mn/LC_MESSAGES/messages.po
+++ b/locale/mn/LC_MESSAGES/messages.po
@@ -3899,7 +3899,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ms/LC_MESSAGES/messages.po
+++ b/locale/ms/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/my/LC_MESSAGES/messages.po
+++ b/locale/my/LC_MESSAGES/messages.po
@@ -3812,7 +3812,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/nb_NO/LC_MESSAGES/messages.po
+++ b/locale/nb_NO/LC_MESSAGES/messages.po
@@ -3842,7 +3842,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ne_NP/LC_MESSAGES/messages.po
+++ b/locale/ne_NP/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/nl/LC_MESSAGES/messages.po
+++ b/locale/nl/LC_MESSAGES/messages.po
@@ -3876,7 +3876,7 @@ msgid "Completed"
 msgstr "Afgerond"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox voor desktop"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/or/LC_MESSAGES/messages.po
+++ b/locale/or/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/pa/LC_MESSAGES/messages.po
+++ b/locale/pa/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/pl/LC_MESSAGES/messages.po
+++ b/locale/pl/LC_MESSAGES/messages.po
@@ -3887,7 +3887,7 @@ msgid "Completed"
 msgstr "Zakończono"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/pt_BR/LC_MESSAGES/messages.po
+++ b/locale/pt_BR/LC_MESSAGES/messages.po
@@ -3923,7 +3923,7 @@ msgid "Completed"
 msgstr "Finalizado"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox para desktop"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/pt_PT/LC_MESSAGES/messages.po
+++ b/locale/pt_PT/LC_MESSAGES/messages.po
@@ -3874,7 +3874,7 @@ msgid "Completed"
 msgstr "Concluído"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox para computador"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ro/LC_MESSAGES/messages.po
+++ b/locale/ro/LC_MESSAGES/messages.po
@@ -3878,7 +3878,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ru/LC_MESSAGES/messages.po
+++ b/locale/ru/LC_MESSAGES/messages.po
@@ -3899,7 +3899,7 @@ msgid "Completed"
 msgstr "Завершено"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox для десктопа"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/si/LC_MESSAGES/messages.po
+++ b/locale/si/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/sk/LC_MESSAGES/messages.po
+++ b/locale/sk/LC_MESSAGES/messages.po
@@ -3902,7 +3902,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/sl/LC_MESSAGES/messages.po
+++ b/locale/sl/LC_MESSAGES/messages.po
@@ -3898,7 +3898,7 @@ msgid "Completed"
 msgstr "Dokončano"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/sq/LC_MESSAGES/messages.po
+++ b/locale/sq/LC_MESSAGES/messages.po
@@ -3868,7 +3868,7 @@ msgid "Completed"
 msgstr "E plotësuar"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox për Desktop"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/sr/LC_MESSAGES/messages.po
+++ b/locale/sr/LC_MESSAGES/messages.po
@@ -3885,7 +3885,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/sr_Latn/LC_MESSAGES/messages.po
+++ b/locale/sr_Latn/LC_MESSAGES/messages.po
@@ -3879,7 +3879,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/sv/LC_MESSAGES/messages.po
+++ b/locale/sv/LC_MESSAGES/messages.po
@@ -3826,7 +3826,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/locale/sv_SE/LC_MESSAGES/messages.po
@@ -3826,7 +3826,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ta/LC_MESSAGES/messages.po
+++ b/locale/ta/LC_MESSAGES/messages.po
@@ -3827,7 +3827,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/te/LC_MESSAGES/messages.po
+++ b/locale/te/LC_MESSAGES/messages.po
@@ -3826,7 +3826,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/templates/LC_MESSAGES/messages.pot
+++ b/locale/templates/LC_MESSAGES/messages.pot
@@ -4309,7 +4309,7 @@ msgstr ""
 #: mkt/constants/tests/test_platforms.py:15
 #: mkt/constants/tests/test_platforms.py:35
 #: mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77

--- a/locale/th/LC_MESSAGES/messages.po
+++ b/locale/th/LC_MESSAGES/messages.po
@@ -3818,7 +3818,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/tr/LC_MESSAGES/messages.po
+++ b/locale/tr/LC_MESSAGES/messages.po
@@ -3870,7 +3870,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/uk/LC_MESSAGES/messages.po
+++ b/locale/uk/LC_MESSAGES/messages.po
@@ -3855,7 +3855,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/ur/LC_MESSAGES/messages.po
+++ b/locale/ur/LC_MESSAGES/messages.po
@@ -3828,7 +3828,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/vi/LC_MESSAGES/messages.po
+++ b/locale/vi/LC_MESSAGES/messages.po
@@ -3838,7 +3838,7 @@ msgid "Completed"
 msgstr ""
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr ""
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/locale/zh_CN/LC_MESSAGES/messages.po
@@ -3835,7 +3835,7 @@ msgid "Completed"
 msgstr "已完成"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox 桌面版"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/locale/zh_TW/LC_MESSAGES/messages.po
+++ b/locale/zh_TW/LC_MESSAGES/messages.po
@@ -3848,7 +3848,7 @@ msgid "Completed"
 msgstr "完成"
 
 #: mkt/constants/platforms.py:42 mkt/constants/tests/test_platforms.py:15 mkt/constants/tests/test_platforms.py:35 mkt/constants/tests/test_platforms.py:57
-msgid "Firefox for Desktop"
+msgid "Firefox Desktop"
 msgstr "Firefox 桌面版"
 
 #: mkt/constants/platforms.py:77 mkt/constants/platforms.py:81

--- a/mkt/constants/platforms.py
+++ b/mkt/constants/platforms.py
@@ -39,7 +39,7 @@ def FREE_PLATFORMS(request=None, is_packaged=False):
 
     if not is_packaged or (is_packaged and desktop_packaged_enabled):
         platforms += (
-            ('free-desktop', _('Firefox for Desktop')),
+            ('free-desktop', _('Firefox Desktop')),
         )
 
     if not is_packaged or (is_packaged and android_packaged_enabled):

--- a/mkt/constants/tests/test_platforms.py
+++ b/mkt/constants/tests/test_platforms.py
@@ -12,7 +12,7 @@ class TestPlatforms(amo.tests.TestCase):
         platforms = FREE_PLATFORMS()
         expected = (
             ('free-firefoxos', _('Firefox OS')),
-            ('free-desktop', _('Firefox for Desktop')),
+            ('free-desktop', _('Firefox Desktop')),
             ('free-android-mobile', _('Firefox Mobile')),
             ('free-android-tablet', _('Firefox Tablet')),
         )
@@ -32,7 +32,7 @@ class TestPlatforms(amo.tests.TestCase):
                                    is_packaged=True)
         expected = (
             ('free-firefoxos', _('Firefox OS')),
-            ('free-desktop', _('Firefox for Desktop')),
+            ('free-desktop', _('Firefox Desktop')),
         )
         eq_(platforms, expected)
 
@@ -54,7 +54,7 @@ class TestPlatforms(amo.tests.TestCase):
                                    is_packaged=True)
         expected = (
             ('free-firefoxos', _('Firefox OS')),
-            ('free-desktop', _('Firefox for Desktop')),
+            ('free-desktop', _('Firefox Desktop')),
             ('free-android-mobile', _('Firefox Mobile')),
             ('free-android-tablet', _('Firefox Tablet')),
         )


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=964961

Obviously super low-priority and we might want not to do this, but I had to try. This makes the desktop platform selection box properly aligned with the rest :p
