### PR TITLE
Display notification on pages only the owner can edit (bug 939075)

### DIFF
--- a/mkt/developers/templates/developers/apps/owner.html
+++ b/mkt/developers/templates/developers/apps/owner.html
@@ -17,6 +17,12 @@
   </header>
 
   <section id="edit-addon" class="primary devhub-form manage" role="main">
+    {% if not can_edit %}
+      <div class="notification-box">
+        <p>{{ _('Only the app owner(s) can edit this page.') }}</p>
+      </div>
+    {% endif %}
+
     <h2>{{ _('Team Members') }}</h2>
 
     <div class="island">

--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -46,6 +46,12 @@
         {{ form.paid_platforms }}
       </div>
 
+      {% if not can_edit %}
+        <div class="notification-box">
+          <p>{{ _('Only the app owner(s) can edit this page.') }}</p>
+        </div>
+      {% endif %}
+
       <section id="submit-payment-type">
         {% if not is_paid %}
           <h2>{{ _('App Compatibility') }}</h2>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=939075

![only-owner](https://cloud.githubusercontent.com/assets/187006/3190013/ba553024-ecc9-11e3-99c2-c9b1d0667931.png)
