### PR TITLE
Clear out AMO reviewer scores

### DIFF
--- a/migrations/800-delete-amo-scores.sql
+++ b/migrations/800-delete-amo-scores.sql
@@ -1,0 +1,3 @@
+DELETE FROM from reviewer_scores where note_key IN (10,11,12,20,21,22,30,31,32,40,50,51,52,60,61,62,80);
+
+# see https://github.com/mozilla/zamboni/blob/master/apps/constants/base.py#L399:L422


### PR DESCRIPTION
They're stale but are included in the performance tables on Marketplace.
