### PR TITLE
rename zamboni url to marketplace and remove one env (bug 1021991)

### DIFF
--- a/docs/topics/install-zamboni/installation.rst
+++ b/docs/topics/install-zamboni/installation.rst
@@ -219,16 +219,6 @@ More info: http://stackoverflow.com/questions/22334776/installing-pillow-pil-on-
 Settings
 --------
 
-.. note::
-
-    Also see the Multiple Sites section below for using settings files to run
-    the Add-ons and Marketplace sites side by side.
-
-.. note::
-
-    There is a :doc:`settings-changelog`, this can be useful for people who are already
-    setup but want to know what has recently changed.
-
 Most of zamboni is already configured in ``settings.py``, but there's one thing
 you'll need to configure locally, the database. The easiest way to do that
 is by setting an environment variable (see next section).
@@ -243,23 +233,9 @@ Environment settings
 --------------------
 
 Out of the box, zamboni should work without any need for settings changes.
-A few settings are configurable from the environment, they are:
-
-* ``DATABASE``: from the ``ZAMBONI_DATABASE`` environment variable, configured
-  using https://github.com/kennethreitz/dj-database-url. Example::
-
-    export ZAMBONI_DATABASE=mysql://root:@localhost:3306/zamboni
-
-* ``HOSTNAME``: from the ``ZAMBONI_HOSTNAME`` environment variable. Set this
-  if you'd like to access the site somewhere other than your current hostname.
-  Example::
-
-    export ZAMBONI_HOSTNAME=marketplace.local
-
-* ``SOLITUDE_HOSTS``: from the ``SOLITUDE_URL`` environment variable. Set this
-  if you are connecting zamboni to solitude. Example::
-
-    export SOLITUDE_HOSTS=http://localhost:8001
+Some settings are configurable from the environment. See the
+`marketplace docs`_ for information on the environment variables and how
+they affect zamboni.
 
 Database
 --------
@@ -317,83 +293,19 @@ migrations like this::
 More info on schematic: https://github.com/mozilla/schematic
 
 
-Multiple sites
---------------
-
-We now run multiple sites off the zamboni code base. The current sites are:
-
-- *default* the Add-ons site at https://addons.mozilla.org/
-
-- *mkt* the Firefox Marketplace at https://marketplace.firefox.com/
-
-There are modules in zamboni for each of these base settings to make minor
-modifications to settings, url, templates and so on. Start by copying the
-template from ``docs/settings/settings_local.dev.py`` into a custom file.
-
-To run the Add-ons site, make a ``settings_local_amo.py`` file with this import
-header::
-
-    from default.settings import *
-
-Or to run the Marketplace site, make a ``settings_local_mkt.py`` file with
-these imports::
-
-    from mkt.settings import *
-
-
 Run the Server
 --------------
 
 If you've gotten the system requirements, downloaded ``zamboni`` and
 ``zamboni-lib``, set up your virtualenv with the compiled packages, and
-configured your settings and database, you're good to go.
+configured your settings and database, you're good to go::
 
-To choose which site you want to run, use the `settings` command line
-argument to pass in a local settings file you created above.
-
-
-Run The Add-ons Server
-~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-    ./manage.py runserver --settings=settings_local_amo 0.0.0.0:8000
-
-.. note::
-
-   If you don't have a LESS compiler already installed, opening
-   http://localhost:8000 in your browser will raise a 500 server error.
-   If you don't want to run through the :doc:`./advanced-installation`
-   documentation just right now, you can disable all LESS pre-processing by
-   adding the following line to your settings_local file::
-
-      LESS_PREPROCESS = False
-
-   Be aware, however, that this will make the site VERY slow, as a huge amount
-   of LESS files will be served to your browser on EACH request, and each of
-   those will be compiled on the fly by the LESS javascript compiler.
-
-
-Run The Marketplace Server
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-    ./manage.py runserver --settings=settings_local_mkt 0.0.0.0:8000
-
-
+    ./manage.py runserver
 
 Persona
 -------
 
 We use `Persona <https://login.persona.org/>`_ to log in and create accounts.
-In order for this to work you need to set ``SITE_URL`` and ``STATIC_URL`` in
-your local settings file based on how you run your dev server. Here is an
-example::
-
-    SITE_URL = 'http://localhost:8000'
-    STATIC_URL = SITE_URL + '/'  # STATIC_URL must have a trailing slash.
-
 
 Create an Admin User
 --------------------
@@ -527,3 +439,5 @@ elasticsearch, LESS, and Stylus.  Learn more about installing these on the
     Although we make an effort to keep advanced items as optional installs
     you might need to install some components in order to run tests or start
     up the development server.
+
+.. _`marketplace docs`: http://marketplace.readthedocs.org/en/latest/topics/setup.html

--- a/mkt/api/models.py
+++ b/mkt/api/models.py
@@ -13,6 +13,7 @@ REQUEST_TOKEN = 0
 ACCESS_TOKEN = 1
 TOKEN_TYPES = ((REQUEST_TOKEN, u'Request'), (ACCESS_TOKEN, u'Access'))
 
+
 class Access(ModelBase):
     key = models.CharField(max_length=255, unique=True)
     secret = AESField(max_length=255, aes_key='api:access:secret')

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import socket
+from urlparse import urlparse
 
 from django.utils.functional import lazy
 
@@ -24,7 +25,8 @@ ROOT_PACKAGE = os.path.basename(ROOT)
 
 # The host currently running the site.  Only use this in code for good reason;
 # the site is designed to run on a cluster and should continue to support that
-HOSTNAME = os.environ.get('ZAMBONI_HOSTNAME', socket.gethostname())
+HOSTNAME = urlparse(os.environ.get('MARKETPLACE_URL',
+                                   'http://' + socket.gethostname())).netloc
 
 try:
     # If we have build ids available, we'll grab them here and add them to our
@@ -480,12 +482,12 @@ APP_FEATURES_VERSION = 4
 # It must match that of the pay server that processes nav.mozPay().
 # In webpay this is the DOMAIN setting and on B2G this must match
 # what's in the provider whitelist.
-APP_PURCHASE_AUD = 'localhost'
+APP_PURCHASE_AUD = DOMAIN
 
 # This is the iss (issuer) for app purchase JWTs.
 # It must match that of the pay server that processes nav.mozPay().
 # In webpay this is the ISSUER setting.
-APP_PURCHASE_KEY = 'localhost'
+APP_PURCHASE_KEY = DOMAIN
 
 # This is the shared secret key for signing app purchase JWTs.
 # It must match that of the pay server that processes nav.mozPay().


### PR DESCRIPTION
- rename ZAMBONI_URL to MARKETPLACE_URL since that's more descriptive
- for hostname, pull it out of the URL, removing the need for an environment variable
