### PR TITLE
Add migration for firefox accounts (bug 1021296)

### DIFF
--- a/migrations/806-waffle-switch-fxaccounts.sql
+++ b/migrations/806-waffle-switch-fxaccounts.sql
@@ -1,0 +1,4 @@
+INSERT INTO waffle_switch (name, active, note, created, modified)
+    VALUES ('firefox-accounts', 0,
+            'This switches us to using Firefox Accounts instead of Persona.'
+            , NOW(), NOW());


### PR DESCRIPTION
This is the Zamboni side of the equation, I still need to pull the waffle flags into Fireplace.
