### PR TITLE
Rename ADDON_ICON_SIZES and only generate the ones we need (bug 885329)

### DIFF
--- a/apps/amo/utils.py
+++ b/apps/amo/utils.py
@@ -46,7 +46,7 @@ from html5lib.serializer.htmlserializer import HTMLSerializer
 from jingo import env
 from PIL import Image, ImageFile, PngImagePlugin
 
-from amo import ADDON_ICON_SIZES
+from amo import APP_ICON_SIZES
 from amo.urlresolvers import linkify_with_outgoing, reverse
 from mkt.translations.models import Translation
 from mkt.users.models import UserNotification
@@ -483,7 +483,7 @@ def resize_image(src, dst, size=None, remove_src=True, locally=False):
 
 
 def remove_icons(destination):
-    for size in ADDON_ICON_SIZES:
+    for size in APP_ICON_SIZES:
         filename = '%s-%s.png' % (destination, size)
         if storage.exists(filename):
             storage.delete(filename)

--- a/apps/constants/base.py
+++ b/apps/constants/base.py
@@ -306,8 +306,8 @@ MAX_TAGS = 20
 MIN_TAG_LENGTH = 2
 MAX_CATEGORIES = 2
 
-# Icon upload sizes
-ADDON_ICON_SIZES = [32, 48, 64, 128, 256, 512]
+# Icon sizes we want to generate and expose in the API.
+APP_ICON_SIZES = [32, 48, 64, 128]
 
 # Preview upload sizes [thumb, full]
 ADDON_PREVIEW_SIZES = [(200, 150), (700, 525)]

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -697,7 +697,7 @@ class AppFormMedia(AddonFormBase):
 
             remove_icons(destination)
             tasks.resize_icon.delay(upload_path, destination,
-                                    amo.ADDON_ICON_SIZES,
+                                    amo.APP_ICON_SIZES,
                                     set_modified_on=[addon])
 
         return super(AppFormMedia, self).save(commit)

--- a/mkt/developers/tasks.py
+++ b/mkt/developers/tasks.py
@@ -293,7 +293,7 @@ def save_icon(webapp, content):
     dirname = webapp.get_icon_dir()
     destination = os.path.join(dirname, '%s' % webapp.id)
     remove_icons(destination)
-    resize_icon(tmp_dst, destination, amo.ADDON_ICON_SIZES,
+    resize_icon(tmp_dst, destination, amo.APP_ICON_SIZES,
                 set_modified_on=[webapp])
 
     # Need to set the icon type so .get_icon_url() works

--- a/mkt/developers/tests/test_tasks.py
+++ b/mkt/developers/tests/test_tasks.py
@@ -472,7 +472,7 @@ class TestFetchIcon(BaseWebAppTest):
         biggest = max([int(size) for size in manifest['icons']])
 
         icon_dir = webapp.get_icon_dir()
-        for size in amo.ADDON_ICON_SIZES:
+        for size in amo.APP_ICON_SIZES:
             if not size <= biggest:
                 continue
             icon_path = os.path.join(icon_dir, '%s-%s.png'

--- a/mkt/submit/tests/test_views.py
+++ b/mkt/submit/tests/test_views.py
@@ -795,7 +795,7 @@ class TestDetails(TestSubmit):
         eq_(rp.status_code, 302)
         ad = self.get_webapp()
         eq_(ad.icon_type, 'image/png')
-        for size in amo.ADDON_ICON_SIZES:
+        for size in amo.APP_ICON_SIZES:
             fn = '%s-%s.png' % (ad.id, size)
             assert os.path.exists(os.path.join(ad.get_icon_dir(), fn)), (
                 'Expected %s in %s' % (fn, os.listdir(ad.get_icon_dir())))

--- a/mkt/webapps/management/commands/convert_icons.py
+++ b/mkt/webapps/management/commands/convert_icons.py
@@ -13,7 +13,7 @@ from mkt.webapps.models import Addon
 
 
 extensions = ['.png', '.jpg', '.gif']
-sizes = amo.ADDON_ICON_SIZES
+sizes = amo.APP_ICON_SIZES
 size_suffixes = ['-%s' % s for s in sizes]
 
 

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -606,11 +606,11 @@ class Addon(amo.models.OnChangeMixin, amo.models.ModelBase):
             icon_type_split = self.icon_type.split('/')
 
         # Get the closest allowed size without going over.
-        if (size not in amo.ADDON_ICON_SIZES
-                and size >= amo.ADDON_ICON_SIZES[0]):
-            size = [s for s in amo.ADDON_ICON_SIZES if s < size][-1]
-        elif size < amo.ADDON_ICON_SIZES[0]:
-            size = amo.ADDON_ICON_SIZES[0]
+        if (size not in amo.APP_ICON_SIZES
+                and size >= amo.APP_ICON_SIZES[0]):
+            size = [s for s in amo.APP_ICON_SIZES if s < size][-1]
+        elif size < amo.APP_ICON_SIZES[0]:
+            size = amo.APP_ICON_SIZES[0]
 
         # Figure out what to return for an image URL.
         if not self.icon_type:

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -148,7 +148,7 @@ class AppSerializer(serializers.ModelSerializer):
 
     def get_icons(self, app):
         return dict([(icon_size, app.get_icon_url(icon_size))
-                     for icon_size in (32, 48, 64, 128)])
+                     for icon_size in amo.APP_ICON_SIZES])
 
     def get_payment_account(self, app):
 

--- a/mkt/webpay/webpay_jwt.py
+++ b/mkt/webpay/webpay_jwt.py
@@ -81,7 +81,7 @@ class WebAppProduct(object):
 
     def icons(self):
         icons = {}
-        for size in amo.ADDON_ICON_SIZES:
+        for size in amo.APP_ICON_SIZES:
             icons[str(size)] = absolutify(self.webapp.get_icon_url(size))
 
         return icons


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=885329

We should probably deprecate 32x32 and 48x48 as well, but that's for another bug.
