### PR TITLE
Firefox Accounts login flow for developer pages (bug 1021295)

### DIFF
--- a/apps/constants/base.py
+++ b/apps/constants/base.py
@@ -447,6 +447,8 @@ LOGIN_SOURCE_BROWSERID = 1
 LOGIN_SOURCE_MMO_BROWSERID = 2
 # Everyone who signed up for AMO once it uses BrowserID.
 LOGIN_SOURCE_AMO_BROWSERID = 3
+# Signups via Firefox Accounts.
+LOGIN_SOURCE_FXA = 4
 
 # These are logins that use BrowserID.
 LOGIN_SOURCE_BROWSERIDS = [LOGIN_SOURCE_BROWSERID, LOGIN_SOURCE_AMO_BROWSERID,

--- a/media/js/devreg/login.js
+++ b/media/js/devreg/login.js
@@ -2,31 +2,32 @@ define('login', ['notification'], function(notification) {
 
     var requestedLogin = false;
     var readyForReload = false;
+    if (z.body.data('persona-url')) {
+      z.doc.bind('login', function(skipDialog) {
+          if (readyForReload) {
+              window.location.reload();
+              return;
+          }
+          if (skipDialog) {
+              startLogin();
+          } else {
+              $('.overlay.login').addClass('show');
+          }
+      }).on('click', '.browserid', function(e) {
+          if (readyForReload) {
+              window.location.reload();
+              return;
+          }
 
-    z.doc.bind('login', function(skipDialog) {
-        if (readyForReload) {
-            window.location.reload();
-            return;
-        }
-        if (skipDialog) {
-            startLogin();
-        } else {
-            $('.overlay.login').addClass('show');
-        }
-    }).on('click', '.browserid', function(e) {
-        if (readyForReload) {
-            window.location.reload();
-            return;
-        }
-
-        var $this = $(this);
-        $this.addClass('loading-submit');
-        z.doc.on('logincancel', function() {
-            $this.removeClass('loading-submit').blur();
-        });
-        startLogin();
-        e.preventDefault();
-    });
+          var $this = $(this);
+          $this.addClass('loading-submit');
+          z.doc.on('logincancel', function() {
+              $this.removeClass('loading-submit').blur();
+          });
+          startLogin();
+          e.preventDefault();
+      });
+    }
 
     function startLogin() {
         requestedLogin = true;
@@ -147,19 +148,21 @@ define('login', ['notification'], function(notification) {
         return localStorage.getItem(_prefix('user'));
     }
 
-    // Load `include.js` from persona.org, and drop login hotness like it's hot.
-    var s = document.createElement('script');
-    s.onload = init_persona;
-    if (z.capabilities.firefoxOS) {
-        // Load the Firefox OS include that knows how to handle native Persona.
-        // Once this functionality lands in the normal include we can stop
-        // doing this special case. See bug 821351.
-        s.src = z.body.data('native-persona-url');
-    } else {
-        s.src = z.body.data('persona-url');
+    if (z.body.data('persona-url')) {
+        // Load `include.js` from persona.org, and drop login hotness like it's hot.
+        var s = document.createElement('script');
+        s.onload = init_persona;
+        if (z.capabilities.firefoxOS) {
+            // Load the Firefox OS include that knows how to handle native Persona.
+            // Once this functionality lands in the normal include we can stop
+            // doing this special case. See bug 821351.
+            s.src = z.body.data('native-persona-url');
+        } else {
+            s.src = z.body.data('persona-url');
+        }
+        document.body.appendChild(s);
+        $('.browserid').css('cursor', 'wait');
     }
-    document.body.appendChild(s);
-    $('.browserid').css('cursor', 'wait');
 
     return {
         userToken: userToken,

--- a/mkt/developers/templates/developers/login.html
+++ b/mkt/developers/templates/developers/login.html
@@ -9,7 +9,12 @@
       <h1>{{ _('Sign in') }}</h1>
       <p>{{ _('You must sign in to proceed.') }}</p>
       <p class="proceed">
+      {% if waffle.switch('firefox-accounts') %}
+        <a class="button prominent browserid"
+           href="{{ url('fxa_login') }}?to={{ to }}">{{ _('Sign in / Sign up') }}</a>
+      {% else %}
         <a class="button prominent browserid" href="#">{{ _('Sign in / Sign up') }}</a>
+      {% endif %}
       </p>
     </div>
   </section>

--- a/mkt/developers/templates/developers/skeleton_impala.html
+++ b/mkt/developers/templates/developers/skeleton_impala.html
@@ -48,10 +48,12 @@
         data-user="{{ user_data(amo_user)|json }}"
         data-readonly="{{ settings.READ_ONLY|json }}"
         data-media-url="{{ MEDIA_URL }}"
+      {% if not waffle.switch('firefox-accounts') %}
         data-login-url="{{ url('account-login') }}"
         data-persona-url="{{ settings.BROWSERID_JS_URL }}"
         data-native-persona-url="{{ settings.NATIVE_BROWSERID_JS_URL }}"
         data-persona-unverified-issuer="{{ settings.UNVERIFIED_ISSUER }}"
+      {% endif %}
         data-collect-timings="{{ url('amo.timing.record') }}:{{ collect_timings_percent }}"
         data-locales="{{ ','.join(settings.LANGUAGE_URL_MAP.keys()) }}"
         {% block bodyattrs %}{% endblock %}>
@@ -74,7 +76,11 @@
 
 
               {% if not logged %}
-                <a href="#" class="browserid">{{ _('Sign In') }}</a>
+                {% if waffle.switch('firefox-accounts') %}
+                  <a href="{{ fxa_login_link() }}" class="browserid">{{ _('Sign In') }}</a>
+                {% else %}
+                 <a href="#" class="browserid">{{ _('Sign In') }}</a>
+                {% endif %}
               {% endif %}
             </div>
           {% endif %}
@@ -132,6 +138,12 @@
       <div class="overlay centre login">
         <section>
           <h2>{{ _('Please sign in') }}</h2>
+        {% if waffle.switch('firefox-accounts') %}
+          <footer>
+            <a class="button browserid"
+               href="{{ fxa_login_link() }}">{{ _('Sign in / Sign up') }}</a>
+          </footer>
+        {% else %}
           <p>
             {% trans url='https://login.persona.org/' %}
               Just log in or register with your
@@ -141,6 +153,7 @@
           <footer>
             <a class="button browserid" href="#">{{ _('Sign in / Sign up') }}</a>
           </footer>
+        {% endif %}
         </section>
       </div>
     {% endif %}
@@ -156,3 +169,4 @@
     {% block js_extras %}{% endblock %}
   </body>
 </html>
+

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -707,6 +707,14 @@ FIREPLACE_URL = ''
 # Where to find ffmpeg and totem if it's not in the PATH.
 FFMPEG_BINARY = 'ffmpeg'
 
+FXA_CLIENT_ID = '56fc6da8d185c8e3'
+FXA_CLIENT_SECRET = 'd1a8f0088e565d066c3d9f28587f5875a800e0a1618a4aaeabd00e162ac583a3'
+FXA_OAUTH_URL = 'https://oauth.dev.lcip.org'
+if DEBUG:
+    # In DEBUG mode, don't require HTTPS for FxA oauth redirects.
+    import os
+    os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+
 # GeoIP server settings
 # This flag overrides the GeoIP server functions and will force the
 # return of the GEOIP_DEFAULT_VAL

--- a/mkt/urls.py
+++ b/mkt/urls.py
@@ -14,7 +14,7 @@ from mkt.developers.views import login
 from mkt.operators.urls import url_patterns as operator_patterns
 from mkt.purchase.urls import webpay_services_patterns
 from mkt.reviewers.urls import url_patterns as reviewer_url_patterns
-from mkt.users.views import logout
+from mkt.users.views import fxa_authorize, fxa_login, logout
 
 
 admin.autodiscover()
@@ -77,6 +77,12 @@ urlpatterns = patterns('',
 
     url('^oauth/authorize/$', oauth.authorize,
         name='mkt.developers.oauth_authorize'),
+
+    url('^fxa/authorize/$', fxa_authorize,
+        name='fxa_authorize'),
+
+    url('^fxa/login/$', fxa_login,
+        name='fxa_login'),
 
     url('^api/', include('mkt.api.urls')),
 

--- a/mkt/users/helpers.py
+++ b/mkt/users/helpers.py
@@ -3,6 +3,8 @@ import random
 import jinja2
 from jingo import register
 
+from amo import urlresolvers, utils
+
 
 @register.function
 def emaillink(email, title=None, klass=None):
@@ -37,3 +39,17 @@ def user_data(amo_user):
         email = amo_user.email
 
     return {'anonymous': anonymous, 'currency': currency, 'email': email}
+
+
+@register.function
+@jinja2.contextfunction
+def fxa_login_link(context):
+    next = context['request'].path
+
+    qs = context['request'].GET.urlencode()
+
+    if qs:
+        next += '?' + qs
+
+    l = utils.urlparams(urlresolvers.reverse('fxa_login'), to=next)
+    return l

--- a/mkt/users/tests/test_views.py
+++ b/mkt/users/tests/test_views.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 import json
 from datetime import datetime
+import urllib
 
+from django.test.utils import override_settings
+
+import mock
 from nose.tools import eq_, ok_
 from waffle import helpers  # NOQA
 
@@ -32,7 +36,7 @@ class TestAjax(amo.tests.TestCase):
         r = self.client.get(reverse('users.ajax'), {'q': 'ajax@mozilla.com'},
                             follow=True)
         data = json.loads(r.content)
-        eq_(data, {'status': 1, 'message': '', 'name': u'\xe0j\xe6x', 
+        eq_(data, {'status': 1, 'message': '', 'name': u'\xe0j\xe6x',
                    'id': u.id})
 
     def test_ajax_xss(self):
@@ -98,3 +102,143 @@ class TestLogout(amo.tests.TestCase):
         url = urlparams(reverse('users.logout'), to='http://ev.il/developers/')
         res = self.client.get(url, follow=True)
         self.assertRedirects(res, '/', status_code=302)
+
+
+class TestAlreadyLoggedIn(amo.tests.TestCase):
+    fixtures = fixture('user_999')
+
+    def setUp(self):
+        super(TestAlreadyLoggedIn, self).setUp()
+        self.url = reverse('users.login')
+        self.user = UserProfile.objects.get(email='regular@mozilla.com')
+        ok_(self.client.login(username=self.user.email, password='password'))
+
+    def test_double_login(self):
+        # If you go to the login page when you're already logged in we bounce
+        # you.
+        r = self.client.get(self.url, follow=True)
+        self.assert3xx(r, '/')
+
+    def test_ok_redirects(self):
+        r = self.client.get(self.url + '?to=/developers/submit/terms/', follow=True)
+        self.assert3xx(r, '/developers/submit/terms')
+
+    def test_bad_redirects(self):
+        for redirect in ['http://xx.com',
+                         'data:text/html,<script>window.alert("xss")</script>',
+                         'mailto:test@example.com',
+                         'file:///etc/passwd',
+                         'javascript:window.alert("xss");']:
+            r = self.client.get(self.url + '?to=' + redirect, follow=True)
+            self.assert3xx(r, '/')
+
+
+class LoginPageTests(amo.tests.TestCase):
+    fixtures = fixture('user_999')
+
+    def setUp(self):
+        super(LoginPageTests, self).setUp()
+        self.url = reverse('users.login')
+
+    def test_login_link(self):
+        r = self.client.get(self.url)
+        eq_(r.status_code, 200)
+        sel = pq(r.content)('.proceed .button')
+        eq_(sel.length, 1)
+        eq_(sel[0].get('href'), '#')
+
+    def test_fxa_login_redirect(self):
+        self.create_switch('firefox-accounts')
+        r = self.client.get(self.url + '?to=/developers/submit/terms')
+        sel = pq(r.content)('.proceed .button')
+        eq_(sel.length, 1)
+        eq_(urllib.unquote(sel[0].get('href')),
+            '/fxa/login/?to=/developers/submit/terms')
+
+
+class LoginHeaderTests(amo.tests.TestCase):
+    fixtures = fixture('user_999')
+
+    def setUp(self):
+        super(LoginHeaderTests, self).setUp()
+        self.url = reverse('ecosystem.landing')
+
+    def test_login_link(self):
+        r = self.client.get(self.url)
+        eq_(r.status_code, 200)
+        sel = pq(r.content)('#site-header .browserid')
+        eq_(sel.length, 1)
+        eq_(sel[0].get('href'), '#')
+
+    def test_fxa_login_link(self):
+        self.create_switch('firefox-accounts')
+        r = self.client.get(self.url)
+        eq_(r.status_code, 200)
+        sel = pq(r.content)('#site-header .browserid')
+        eq_(sel.length, 1)
+        eq_(urllib.unquote(sel[0].get('href')), '/fxa/login/?to=/developers/')
+
+
+class FirefoxAccountTests(amo.tests.TestCase):
+    fixtures = fixture('user_999')
+
+    def setUp(self):
+        super(FirefoxAccountTests, self).setUp()
+        self.create_switch('firefox-accounts')
+
+    @override_settings(FXA_OAUTH_URL='https://fxa.example.com')
+    def test_fxa_login_redirect(self):
+        url = reverse('fxa_login')
+        r = self.client.get(url)
+        eq_(r.status_code, 302)
+        ok_(urllib.unquote(r['location']).startswith(
+            'https://fxa.example.com/v1/authorization?'))
+
+    def do_authorize(self, args):
+        with mock.patch('mkt.users.views.get_fxa_session') as get_session:
+            m = get_session()
+            m.fetch_token.return_value = {'access_token': 'fake'}
+            m.post().json.return_value = {
+                'user': 'fake-uid',
+                'email': 'regular@mozilla.com'
+            }
+            url = reverse('fxa_authorize')
+            return self.client.get(url, args)
+
+    @override_settings(FXA_OAUTH_URL='https://fxa.example.com')
+    def test_fxa_authorize(self):
+        self.client.get(reverse('fxa_login'))
+        r = self.do_authorize({})
+        eq_(r.status_code, 302)
+        eq_(r['location'], 'http://testserver/')
+
+    @override_settings(FXA_OAUTH_URL='https://fxa.example.com')
+    def test_fxa_authorize_redirect_to(self):
+        self.client.get(reverse('fxa_login'),
+                        {'to': '/developers/terms'})
+        r = self.do_authorize({})
+        eq_(r.status_code, 302)
+        eq_(r['location'], 'http://testserver/developers/terms')
+
+    @override_settings(FXA_OAUTH_URL='https://fxa.example.com')
+    def test_fxa_authorize_no_login(self):
+        r = self.do_authorize({})
+        eq_(r.status_code, 400)
+
+    @override_settings(FXA_OAUTH_URL='https://fxa.example.com')
+    def test_fxa_authorize_newaccount(self):
+        self.client.get(reverse('fxa_login'))
+
+        with mock.patch('mkt.users.views.get_fxa_session') as get_session:
+            m = get_session()
+            m.fetch_token.return_value = {'access_token': 'fake'}
+            m.post().json.return_value = {
+                'user': 'fake-uid',
+                'email': 'newacct@mozilla.com'
+            }
+            url = reverse('fxa_authorize')
+            r = self.client.get(url)
+        eq_(r.status_code, 302)
+        eq_(r['location'], 'http://testserver/')
+        eq_(UserProfile.objects.filter(email='newacct@mozilla.com',
+                                       username='fake-uid').count(), 1)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -85,6 +85,7 @@ recaptcha-client==1.0.6
 receipts==0.2.9
 redis==2.8.0
 requests==2.0.0
+requests_oauthlib==0.4.1
 schematic==0.2
 signing_clients==0.1.7
 six==1.4.1


### PR DESCRIPTION
Turning on the `firefox-accounts` switch should make the login page and header login link go through the FxA login flow.
