### PR TITLE
log_settings: z.geoip log level to WARNING

### DIFF
--- a/lib/log_settings_base.py
+++ b/lib/log_settings_base.py
@@ -93,6 +93,9 @@ loggers = {
     'z.cron': {
         'level': 'WARNING',
     },
+    'z.geoip': {
+        'level': 'WARNING',
+    },
 }
 
 cfg = {


### PR DESCRIPTION
z.geoip on INFO logs every geodude lookup.
