### PR TITLE
Allow CORS requests for packaged apps' zip files

### DIFF
--- a/mkt/downloads/tests/test_views.py
+++ b/mkt/downloads/tests/test_views.py
@@ -76,3 +76,6 @@ class TestDownload(BasePackagedAppTest):
         res = self.client.get(self.url)
         eq_(res.status_code, 200)
         assert settings.XSENDFILE_HEADER in res
+
+    def test_has_cors(self):
+        self.assertCORS(self.client.get(self.url), 'get')

--- a/mkt/downloads/views.py
+++ b/mkt/downloads/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 import commonware.log
 
 import amo
+from amo.decorators import allow_cross_site_request
 from amo.utils import HttpResponseSendFile
 from mkt.access import acl
 from mkt.files.models import File
@@ -13,6 +14,7 @@ from mkt.webapps.models import Webapp
 log = commonware.log.getLogger('z.downloads')
 
 
+@allow_cross_site_request
 def download_file(request, file_id, type=None):
     file = get_object_or_404(File, pk=file_id)
     webapp = get_object_or_404(Webapp, pk=file.version.addon_id,


### PR DESCRIPTION
Here's another one, if you don't mind.
