### PR TITLE
return only the essentials for `product_as_dict` (bug 1028009)

### DIFF
--- a/apps/amo/tests/test_models.py
+++ b/apps/amo/tests/test_models.py
@@ -1,4 +1,3 @@
-
 from mock import Mock
 from nose.tools import eq_
 

--- a/mkt/site/helpers.py
+++ b/mkt/site/helpers.py
@@ -105,13 +105,6 @@ def market_button(context, product, receipt_type=None, classes=None):
 
 def product_as_dict(request, product, purchased=None, receipt_type=None,
                     src=''):
-    # Dev environments might not have authors set.
-    author = ''
-    author_url = ''
-    if product.listed_authors:
-        author = product.listed_authors[0].name
-        author_url = product.listed_authors[0].get_url_path()
-
     receipt_url = (reverse('receipt.issue', args=[product.app_slug]) if
                    receipt_type else product.get_detail_url('record'))
     token_url = reverse('generate-reviewer-token', args=[product.app_slug])
@@ -119,6 +112,8 @@ def product_as_dict(request, product, purchased=None, receipt_type=None,
     src = src or request.GET.get('src', '')
     reviewer = receipt_type == 'reviewer'
 
+    # This is the only info. we need to render the app buttons on the
+    # Reviewer Tools pages.
     ret = {
         'id': product.id,
         'name': product.name,
@@ -127,24 +122,9 @@ def product_as_dict(request, product, purchased=None, receipt_type=None,
         'manifest_url': product.get_manifest_url(reviewer),
         'recordUrl': urlparams(receipt_url, src=src),
         'tokenUrl': token_url,
-        'author': author,
-        'author_url': author_url,
-        'iconUrl': product.get_icon_url(64),
         'is_packaged': product.is_packaged,
         'src': src
     }
-
-    # Add in previews to the dict.
-    if product.all_previews:
-        previews = []
-        for p in product.all_previews:
-            preview = {
-                'fullUrl': jinja2.escape(p.image_url),
-                'type': jinja2.escape(p.filetype),
-                'thumbUrl': jinja2.escape(p.thumbnail_url),
-            }
-            previews.append(preview)
-        ret.update({'previews': previews})
 
     if product.premium:
         ret.update({

--- a/mkt/site/tests/test_helpers.py
+++ b/mkt/site/tests/test_helpers.py
@@ -3,10 +3,13 @@ from django.conf import settings
 
 import fudge
 import mock
+from nose.tools import eq_
 
 import amo
 import amo.tests
-from mkt.site.helpers import css, js
+from mkt.site.helpers import css, js, product_as_dict
+from mkt.site.fixtures import fixture
+from mkt.webapps.models import Webapp
 
 
 class TestCSS(amo.tests.TestCase):
@@ -101,3 +104,28 @@ class TestJS(amo.tests.TestCase):
         # Should be called with `debug=True`.
         fake_js.expects('js').with_args('mkt/devreg', True, False, False)
         js(context, 'mkt/devreg')
+
+
+class TestProductAsDict(amo.tests.TestCase):
+    fixtures = fixture('webapp_337141')
+
+    def test_correct(self):
+        request = mock.Mock(GET={'src': 'poop'})
+        app = Webapp.objects.get(id=337141)
+
+        data = product_as_dict(request, app)
+        eq_(data['src'], 'poop')
+        eq_(data['is_packaged'], False)
+        eq_(data['categories'], [])
+        eq_(data['name'], 'Something Something Steamcube!')
+        eq_(data['id'], '337141')
+        eq_(data['manifest_url'], 'http://micropipes.com/temp/steamcube.webapp')
+
+        tokenUrl = '/reviewers/app/something-something/token'
+        recordUrl = '/app/something-something/purchase/record?src=poop'
+        assert tokenUrl in data['tokenUrl'], (
+            'Invalid Token URL. Expected %s; Got %s'
+            % (tokenUrl, data['tokenUrl'])
+        assert recordUrl in data['recordUrl'], (
+            'Invalid Record URL. Expected %s; Got %s'
+            % (recordUrl, data['recordUrl'])


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1028009

r? @robhudson @diox
