### PR TITLE
add `package_path` to non-Fireplace ES API results (bug 1029186)

### DIFF
--- a/mkt/search/serializers.py
+++ b/mkt/search/serializers.py
@@ -31,6 +31,7 @@ class ESAppSerializer(AppSerializer):
     categories = serializers.SlugRelatedField(read_only=True,
         many=True, slug_field='slug', source='all_categories')
     manifest_url = serializers.CharField(source='manifest_url')
+    package_path = serializers.SerializerMethodField('get_package_path')
 
     # Override translations, because we want a different field.
     banner_message = ESTranslationSerializerField(
@@ -174,6 +175,9 @@ class ESAppSerializer(AppSerializer):
 
     def get_absolute_url(self, obj):
         return absolutify(obj.get_absolute_url())
+
+    def get_package_path(self, obj):
+        return obj.es_data.get('package_path')
 
     def get_tags(self, obj):
         return obj.es_data['tags']

--- a/mkt/search/tests/test_views.py
+++ b/mkt/search/tests/test_views.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.db.models.query import QuerySet
 from django.http import QueryDict
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 
 from mock import MagicMock, patch
 from nose.tools import eq_, ok_
@@ -225,6 +226,7 @@ class TestApi(RestOAuth, ESTestCase):
             eq_(obj['id'], long(self.webapp.id))
             eq_(obj['is_offline'], False)
             eq_(obj['manifest_url'], self.webapp.get_manifest_url())
+            eq_(obj['package_path'], None)
             eq_(obj['payment_account'], None)
             self.assertApiUrlEqual(obj['privacy_policy'],
                                    '/apps/app/337141/privacy/')
@@ -537,25 +539,29 @@ class TestApi(RestOAuth, ESTestCase):
         eq_(obj['slug'], self.webapp.app_slug)
 
     def test_app_type_hosted(self):
-        res = self.client.get(self.url,
-                              data={'app_type': 'hosted'})
+        res = self.client.get(self.url, data={'app_type': 'hosted'})
         eq_(res.status_code, 200)
         obj = res.json['objects'][0]
         eq_(obj['slug'], self.webapp.app_slug)
         eq_(obj['is_packaged'], False)
         eq_(obj['is_offline'], False)
+        eq_(obj['package_path'], None)
 
+    @override_settings(SITE_URL='http://hy.fr')
     def test_app_type_packaged(self):
         self.webapp.update(is_packaged=True)
+        f = self.webapp.current_version.all_files[0]
+
         self.refresh('webapp')
 
-        res = self.client.get(self.url,
-                              data={'app_type': 'packaged'})
+        res = self.client.get(self.url, data={'app_type': 'packaged'})
         eq_(res.status_code, 200)
         obj = res.json['objects'][0]
         eq_(obj['slug'], self.webapp.app_slug)
         eq_(obj['is_packaged'], True)
         eq_(obj['is_offline'], True)
+        eq_(obj['package_path'],
+            '%s/downloads/file/%s/%s' % (settings.SITE_URL, f.id, f.filename))
 
     def test_app_type_privileged(self):
         # Override the class-decorated patch.
@@ -563,8 +569,7 @@ class TestApi(RestOAuth, ESTestCase):
             self.webapp.update(is_packaged=True)
             self.refresh('webapp')
 
-            res = self.client.get(self.url,
-                                  data={'app_type': 'packaged'})
+            res = self.client.get(self.url, data={'app_type': 'packaged'})
             eq_(res.status_code, 200)
             eq_(len(res.json['objects']), 0)
 

--- a/mkt/webapps/indexers.py
+++ b/mkt/webapps/indexers.py
@@ -138,6 +138,8 @@ class WebappIndexer(BaseIndexer):
                     # Name for suggestions.
                     'name_suggest': {'type': 'completion', 'payloads': True},
                     'owners': {'type': 'long'},
+                    'package_path': {'type': 'string',
+                                     'index': 'not_analyzed'},
                     'popularity': {'type': 'long'},
                     'premium_type': {'type': 'byte'},
                     'previews': {
@@ -292,6 +294,7 @@ class WebappIndexer(BaseIndexer):
                 'has_info_request': None,
             }
         d['manifest_url'] = obj.get_manifest_url()
+        d['package_path'] = obj.get_package_path()
         d['name'] = list(
             set(string for _, string in obj.translations[obj.name_id]))
         d['name_sort'] = unicode(obj.name).lower()

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -65,9 +65,8 @@ class AppSerializer(serializers.ModelSerializer):
         queryset=Category.objects.filter(type=amo.ADDON_WEBAPP))
     content_ratings = serializers.SerializerMethodField('get_content_ratings')
     created = serializers.DateField(read_only=True)
-    current_version = serializers.CharField(
-        source='current_version.version',
-        read_only=True)
+    current_version = serializers.CharField(source='current_version.version',
+                                            read_only=True)
     default_locale = serializers.CharField(read_only=True)
     device_types = SemiSerializerMethodField('get_device_types')
     description = TranslationSerializerField(required=False)
@@ -79,8 +78,8 @@ class AppSerializer(serializers.ModelSerializer):
     manifest_url = serializers.CharField(source='get_manifest_url',
                                          read_only=True)
     name = TranslationSerializerField(required=False)
-    package_path = serializers.CharField(
-        source='get_package_path', read_only=True)
+    package_path = serializers.CharField(source='get_package_path',
+                                         read_only=True)
     payment_account = serializers.SerializerMethodField('get_payment_account')
     payment_required = serializers.SerializerMethodField(
         'get_payment_required')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1029186

it's already in the app detail resource:
http://localhost:8000/api/v1/apps/app/marketplace/

this adds it to ES:
http://localhost:8000/api/v1/apps/search/?q=marketplace

r? @robhudson 
