### PR TITLE
have -dev languages to be prod languages + dbg (bug 1016125)

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 
 from mkt.settings import ROOT
-from django.utils.functional import lazy
 
 
 _tmpdirs = set()
@@ -95,25 +94,6 @@ DEBUG_TOOLBAR_CONFIG = {
 
 MOZMARKET_VENDOR_EXCLUDE = []
 
-# These are the default languages. If you want a constrainted set for your
-# tests, you should add those in the tests.
-
-
-def lazy_langs(languages):
-    from product_details import product_details
-    if not product_details.languages:
-        return {}
-    return dict([(i.lower(), product_details.languages[i]['native'])
-                 for i in languages])
-
-AMO_LANGUAGES = (
-    'af', 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en-US', 'es', 'eu', 'fa',
-    'fi', 'fr', 'ga-IE', 'he', 'hu', 'id', 'it', 'ja', 'ko', 'mn', 'nl', 'pl',
-    'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq', 'sv-SE', 'uk', 'vi',
-    'zh-CN', 'zh-TW',
-)
-LANGUAGES = lazy(lazy_langs, dict)(AMO_LANGUAGES)
-LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
 TASK_USER_ID = '4043307'
 
 PASSWORD_HASHERS = (

--- a/sites/altdev/settings_mkt.py
+++ b/sites/altdev/settings_mkt.py
@@ -85,12 +85,7 @@ VALIDATOR_IAF_URLS = ['https://marketplace.firefox.com',
 # Override the limited marketplace ones with these ones from AMO. Because
 # the base gets overridden in the mkt.settings file, we'll set them back again.
 # Note the addition of dbg here.
-AMO_LANGUAGES = (
-    'af', 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en-US', 'es', 'eu', 'fa',
-    'fi', 'fr', 'ga-IE', 'he', 'hu', 'id', 'it', 'ja', 'ko', 'mn', 'nl', 'pl',
-    'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sr-Latn', 'sv-SE',
-    'tr', 'uk', 'vi', 'zh-CN', 'zh-TW', 'dbg'
-)
+AMO_LANGUAGES = AMO_LANGUAGES + ('dbg',)
 LANGUAGES = lazy(lazy_langs, dict)(AMO_LANGUAGES)
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
 HIDDEN_LANGUAGES = (

--- a/sites/dev/settings_mkt.py
+++ b/sites/dev/settings_mkt.py
@@ -87,12 +87,7 @@ VALIDATOR_IAF_URLS = ['https://marketplace.firefox.com',
 # Override the limited marketplace ones with these ones from AMO. Because
 # the base gets overridden in the mkt.settings file, we'll set them back again.
 # Note the addition of dbg here.
-AMO_LANGUAGES = (
-    'af', 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en-US', 'es', 'eu', 'fa',
-    'fi', 'fr', 'ga-IE', 'he', 'hu', 'id', 'it', 'ja', 'ko', 'mn', 'nl', 'pl',
-    'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sr-Latn', 'sv-SE',
-    'tr', 'uk', 'vi', 'zh-CN', 'zh-TW', 'dbg'
-)
+AMO_LANGUAGES = AMO_LANGUAGES + ('dbg',)
 LANGUAGES = lazy(lazy_langs, dict)(AMO_LANGUAGES)
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
 HIDDEN_LANGUAGES = (


### PR DESCRIPTION
r? @clouserw

This was causing Punjabi (pa) to not be included in the `body[data-languages]` set in the `index.html` template used by Fireplace.

I've just made all the other settings files include all of prod's languages + 'dbg'. If there are some languages we want to test on -dev/stage before we ship them to production, then we can add those to the appropriate settings files when the time comes.
