### PR TITLE
Reviewers api auth 1032603

### DIFF
--- a/media/js/devreg/devhub.js
+++ b/media/js/devreg/devhub.js
@@ -1,3 +1,11 @@
+// Send the Authorization header to local URLs.
+$(document).ajaxSend(function(event, xhr, ajaxSettings) {
+    var userToken = require('login').userToken();
+    if (isLocalUrl(ajaxSettings.url) && userToken) {
+        xhr.setRequestHeader('Authorization', 'mkt-shared-secret ' + userToken);
+    }
+});
+
 $(document).ready(function() {
     // Edit Add-on
     if (document.getElementById('edit-addon')) {

--- a/media/js/devreg/in_app_products.js
+++ b/media/js/devreg/in_app_products.js
@@ -1,4 +1,4 @@
-(function (login) {
+(function () {
     function PricePointFormatter() {
         // A mapping from PricePointId to FormattedPriceDeferred.
         var pricePoints = {};
@@ -184,9 +184,6 @@
                 method: method,
                 url: self.url(),
                 data: self.product,
-                headers: {
-                    Authorization: 'mkt-shared-secret ' + login.userToken(),
-                },
             }).always(function () {
                 self.saveButton.attr('disabled', false);
             }).done(function (product) {
@@ -301,4 +298,4 @@
         component: InAppProductComponent,
         componentAttrs: {startEditing: true},
     });
-})(require('login'));
+})();

--- a/media/js/devreg/utils.js
+++ b/media/js/devreg/utils.js
@@ -173,3 +173,9 @@ function urlencode(kwargs) {
 function urlparams(url, kwargs) {
     return baseurl(url) + '?' + urlencode(_.defaults(kwargs, querystring(url)));
 }
+
+function isLocalUrl(url) {
+    var a = document.createElement('a');
+    a.href = url;
+    return a.hostname === window.location.hostname;
+}

--- a/media/js/lib/csrf.js
+++ b/media/js/lib/csrf.js
@@ -1,11 +1,10 @@
 // CSRF Tokens
 // Hijack the AJAX requests, and insert a CSRF token as a header.
 $(document).ajaxSend(function(event, xhr, ajaxSettings) {
-    var csrf, $meta;
-    // Block anything that starts with 'http:', 'https:', '://' or '//'.
-    if (!/^((https?:)|:?[/]{2})/.test(ajaxSettings.url)) {
-        // Only send the token to relative URLs i.e. locally.
-        $meta = $('meta[name=csrf]');
+    // Block anything that starts with '<text>://', '://' or '//'.
+    if (isLocalUrl(ajaxSettings.url)) {
+        var $meta = $('meta[name=csrf]');
+        var csrf;
         if (!z.anonymous && $meta.length) {
             csrf = $meta.attr('content');
         } else {

--- a/mkt/asset_bundles.py
+++ b/mkt/asset_bundles.py
@@ -159,7 +159,6 @@ JS = {
         'js/lib/format.js',
         'js/lib/jquery.cookie.js',
         'js/lib/stick.js',
-        'js/lib/csrf.js',
         'js/common/fakefilefield.js',
         'js/devreg/gettext.js',
         'js/devreg/tracking.js',
@@ -175,6 +174,7 @@ JS = {
         'js/devreg/notification.js',
         'js/devreg/outgoing_links.js',
         'js/devreg/utils.js',
+        'js/lib/csrf.js',
 
         'js/impala/serializers.js',
         'js/common/keys.js',
@@ -232,6 +232,7 @@ JS = {
     'mkt/in-app-payments': (
         'js/lib/jquery-1.11.1.js',
         'js/devreg/inapp_payments.js',
+        'js/devreg/utils.js',
         'js/lib/csrf.js',
         'js/impala/serializers.js',
         'js/devreg/login.js',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1032603

We no longer support cookie base API authentication so we should send the `Authorization` header for AJAX requests to the app. This is handled similarly to [how it is done for CSRF](https://github.com/mozilla/zamboni/blob/a332ca4a09813550c82766705b21a59a5e2f3b4b/media/js/lib/csrf.js).
