### PR TITLE
Keep editor stats columns on the same row (bug 994656)

### DIFF
--- a/media/css/devreg/reviewers.styl
+++ b/media/css/devreg/reviewers.styl
@@ -352,6 +352,10 @@ table.data-grid .addon-version-notes a {
     float: left;
 }
 
+.editor-stats {
+    clear: both;
+}
+
 .editor-stats-title span,
 .editor-stats-title a {
     font-weight: bold;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=994656

Before
![screenshot 2014-07-08 13 22 02](https://cloud.githubusercontent.com/assets/211578/3513641/c89ac3dc-06c4-11e4-8fc6-68efadd6eeba.png)

After
![screenshot 2014-07-08 13 26 19](https://cloud.githubusercontent.com/assets/211578/3513658/01283162-06c5-11e4-9681-3864c5818a46.png)
