### PR TITLE
Work-around (not really a fix) by keeping local 'require' (bug 1036381)

### DIFF
--- a/media/js/devreg/devhub.js
+++ b/media/js/devreg/devhub.js
@@ -1,10 +1,12 @@
 // Send the Authorization header to local URLs.
-$(document).ajaxSend(function(event, xhr, ajaxSettings) {
-    var userToken = require('login').userToken();
-    if (isLocalUrl(ajaxSettings.url) && userToken) {
-        xhr.setRequestHeader('Authorization', 'mkt-shared-secret ' + userToken);
-    }
-});
+(function (require) {
+    $(document).ajaxSend(function(event, xhr, ajaxSettings) {
+        var userToken = require('login').userToken();
+        if (isLocalUrl(ajaxSettings.url) && userToken) {
+            xhr.setRequestHeader('Authorization', 'mkt-shared-secret ' + userToken);
+        }
+    });
+})(require);
 
 $(document).ready(function() {
     // Edit Add-on


### PR DESCRIPTION
Work around to prevent getting undefined `require` until we figure out a better long-term fix for the problem that caused us to set require to undefined in the first place (see 
https://github.com/mozilla/zamboni/blob/master/media/js/lib/diff_match_patch_uncompressed.js#L22 )
