### PR TITLE
feed es view serializers (bug 1036216)

### DIFF
--- a/mkt/api/fields.py
+++ b/mkt/api/fields.py
@@ -197,13 +197,16 @@ class ESTranslationSerializerField(TranslationSerializerField):
 
     def fetch_single_translation(self, obj, source, field):
         translations = self.fetch_all_translations(obj, source, field) or {}
+
         return (translations.get(self.requested_language) or
-                translations.get(obj.default_locale) or
+                translations.get(getattr(obj, 'default_locale', None)) or
                 translations.get(settings.LANGUAGE_CODE) or None)
 
     def field_to_native(self, obj, field_name):
         if field_name:
             field_name = '%s%s' % (field_name, self.suffix)
+        if not hasattr(obj, field_name):
+            return
         return super(ESTranslationSerializerField, self).field_to_native(obj,
             field_name)
 

--- a/mkt/feed/fields.py
+++ b/mkt/feed/fields.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from mkt.api.fields import ESTranslationSerializerField
+from mkt.search.serializers import ESAppSerializer
 from mkt.webapps.serializers import AppSerializer
 
 
@@ -11,3 +13,43 @@ class FeedCollectionMembershipField(serializers.RelatedField):
     """
     def to_native(self, qs, use_es=False):
         return AppSerializer(qs, context=self.context).data
+
+
+class AppESField(serializers.Field):
+    """
+    Deserialize an app id using ESAppSerializer.
+
+    For object-to-app relations in ES, we store app IDs as a property of the
+    object. Since we want to limit ES queries, we batch-query for objects,
+    and then batch-query for apps. Afterwards, we set up app_map which is
+    used to deserialize app IDs to app ES data. This class helps deserialize
+    using that map and expects app IDs (i.e., passed through source).
+
+    self.context['app_map'] -- mapping from app ID to app ES object
+    """
+    def __init__(self, *args, **kwargs):
+        self.many = kwargs.pop('many', False)
+        super(AppESField, self).__init__(*args, **kwargs)
+
+    def to_native(self, app_ids):
+        """App ID to serialized app."""
+        if self.many:
+            # Deserialize app ID to ES app data.
+            partially_deserialized_apps = [
+                self.context['app_map'][app_id] for app_id in app_ids]
+            # Deserialize ES app data to full data.
+            apps = ESAppSerializer(
+                partially_deserialized_apps, many=True,
+                context=self.context).data
+            return apps
+        else:
+            # Single object, app_ids is only one app ID.
+            app = ESAppSerializer(self.context['app_map'][app_ids],
+                                  context=self.context).data
+            return app
+
+    def from_native(self, data):
+        if self.many:
+            return [app['id'] for app in data['apps']]
+        else:
+            return data['id']

--- a/mkt/feed/serializers.py
+++ b/mkt/feed/serializers.py
@@ -5,18 +5,21 @@ from rest_framework import relations, serializers
 from rest_framework.reverse import reverse
 
 import mkt.carriers
+import mkt.feed.constants as feed
 import mkt.regions
-from mkt.api.fields import (SlugChoiceField, SplitField,
-                            TranslationSerializerField, UnicodeChoiceField)
+from mkt.api.fields import (ESTranslationSerializerField, SlugChoiceField,
+                            SplitField, TranslationSerializerField,
+                            UnicodeChoiceField)
 from mkt.api.serializers import URLSerializerMixin
 from mkt.carriers import CARRIER_CHOICE_DICT
 from mkt.constants.categories import CATEGORY_CHOICES
 from mkt.regions import REGIONS_CHOICES_ID_DICT
+from mkt.search.serializers import BaseESSerializer
 from mkt.submit.serializers import PreviewSerializer
 from mkt.webapps.serializers import AppSerializer
 
 from . import constants
-from .fields import FeedCollectionMembershipField
+from .fields import AppESField, FeedCollectionMembershipField
 from .models import (FeedApp, FeedBrand, FeedCollection,
                      FeedCollectionMembership, FeedItem, FeedShelf)
 
@@ -55,6 +58,14 @@ class BaseFeedCollectionSerializer(ValidateSlugMixin, URLSerializerMixin,
         fields = ('apps', 'slug', 'url')
 
 
+class BaseFeedCollectionESSerializer(BaseESSerializer):
+    """
+    Base serializer for subclasses of BaseFeedCollection that serializes ES
+    representation.
+    """
+    apps = AppESField(source='_app_ids', many=True)
+
+
 class FeedImageField(serializers.HyperlinkedRelatedField):
     read_only = True
 
@@ -79,9 +90,9 @@ class FeedAppSerializer(ValidateSlugMixin, URLSerializerMixin,
     """
     app = SplitField(relations.PrimaryKeyRelatedField(required=True),
                      AppSerializer())
-    description = TranslationSerializerField(required=False)
     background_image = FeedImageField(
         source='*', view_name='api-v2:feed-app-image-detail', format='png')
+    description = TranslationSerializerField(required=False)
     preview = SplitField(relations.PrimaryKeyRelatedField(required=False),
                          PreviewSerializer())
     pullquote_rating = serializers.IntegerField(required=False)
@@ -94,6 +105,30 @@ class FeedAppSerializer(ValidateSlugMixin, URLSerializerMixin,
                   'url')
         model = FeedApp
         url_basename = 'feedapps'
+
+
+class FeedAppESSerializer(FeedAppSerializer, BaseESSerializer):
+    """
+    A serializer for the FeedApp class that serializes ES representation.
+    """
+    app = AppESField(source='_app_id')
+    background_image = FeedImageField(
+        source='*', view_name='api-v2:feed-app-image-detail', format='png')
+    description = ESTranslationSerializerField(required=False)
+    preview = serializers.Field(source='preview')
+    pullquote_text = ESTranslationSerializerField(required=False)
+
+    def fake_object(self, data):
+        feed_app = self._attach_fields(FeedApp(), data, (
+            'id', 'background_color', 'image_hash', 'pullquote_attribution',
+            'pullquote_rating', 'slug', 'type'
+        ))
+        feed_app = self._attach_translations(feed_app, data, (
+            'description', 'pullquote_text'
+        ))
+
+        feed_app._app_id = data.get('app')
+        return feed_app
 
 
 class FeedBrandSerializer(BaseFeedCollectionSerializer):
@@ -112,23 +147,26 @@ class FeedBrandSerializer(BaseFeedCollectionSerializer):
         url_basename = 'feedbrands'
 
 
-class FeedShelfSerializer(BaseFeedCollectionSerializer):
+class FeedBrandESSerializer(FeedBrandSerializer,
+                            BaseFeedCollectionESSerializer):
     """
-    A serializer for the FeedBrand class, a type of collection that allows
-    editors to quickly create content without involving localizers.
+    A serializer for the FeedBrand class for ES representation.
     """
-    background_image = FeedImageField(
-        source='*', view_name='api-v2:feed-shelf-image-detail', format='png')
-    carrier = SlugChoiceField(choices_dict=mkt.carriers.CARRIER_MAP)
-    description = TranslationSerializerField(required=False)
-    name = TranslationSerializerField()
-    region = SlugChoiceField(choices_dict=mkt.regions.REGION_LOOKUP)
+    def fake_object(self, data):
+        brand = self._attach_fields(FeedBrand(), data, (
+            'id', 'layout', 'slug', 'type'
+        ))
+        brand._app_ids = data.get('apps')
+        return brand
 
-    class Meta:
-        fields = ('apps', 'background_color', 'background_image', 'carrier',
-                  'description', 'id', 'name', 'region', 'slug', 'url')
-        model = FeedShelf
-        url_basename = 'feedshelves'
+
+class FeedBrandSearchSerializer(FeedBrandSerializer):
+    """
+    A simpler serializer for the FeedBrand class that does not include apps.
+    """
+    class Meta(FeedBrandSerializer.Meta):
+        fields = ('app_count', 'id', 'layout', 'preview_icon', 'slug', 'type',
+                  'url')
 
 
 class FeedCollectionSerializer(BaseFeedCollectionSerializer):
@@ -176,6 +214,72 @@ class FeedCollectionSerializer(BaseFeedCollectionSerializer):
         return ret
 
 
+class FeedCollectionESSerializer(FeedCollectionSerializer,
+                                 BaseFeedCollectionESSerializer):
+    """
+    A serializer for the FeedCollection class for ES representation.
+    """
+    description = ESTranslationSerializerField(required=False)
+    name = ESTranslationSerializerField(required=False)
+
+    def fake_object(self, data):
+        collection = self._attach_fields(FeedCollection(), data, (
+            'id', 'background_color', 'image_hash', 'slug', 'type'
+        ))
+        collection = self._attach_translations(collection, data, (
+            'name', 'description'
+        ))
+
+        collection._app_ids = data.get('apps')
+
+        # Attach groups.
+        if data.get('group_apps'):
+            for app_id, app in self.context['app_map'].items():
+                app.update(data['group_names'][data['group_apps'][app_id]])
+
+        return collection
+
+
+class FeedShelfSerializer(BaseFeedCollectionSerializer):
+    """
+    A serializer for the FeedBrand class, a type of collection that allows
+    editors to quickly create content without involving localizers.
+    """
+    background_image = FeedImageField(
+        source='*', view_name='api-v2:feed-shelf-image-detail', format='png')
+    carrier = SlugChoiceField(choices_dict=mkt.carriers.CARRIER_MAP)
+    description = TranslationSerializerField(required=False)
+    name = TranslationSerializerField()
+    region = SlugChoiceField(choices_dict=mkt.regions.REGION_LOOKUP)
+
+    class Meta:
+        fields = ('apps', 'background_color', 'background_image', 'carrier',
+                  'description', 'id', 'name', 'region', 'slug', 'url')
+        model = FeedShelf
+        url_basename = 'feedshelves'
+
+
+class FeedShelfESSerializer(FeedShelfSerializer,
+                            BaseFeedCollectionESSerializer):
+    """
+    A serializer for the FeedShelf class for ES representation.
+    """
+    description = ESTranslationSerializerField(required=False)
+    name = ESTranslationSerializerField(required=False)
+
+    def fake_object(self, data):
+        shelf = self._attach_fields(FeedShelf(), data, (
+            'id', 'background_color', 'carrier', 'image_hash', 'region',
+            'slug'
+        ))
+        shelf = self._attach_translations(shelf, data, (
+            'description', 'name'
+        ))
+
+        shelf._app_ids = data.get('apps')
+        return shelf
+
+
 class FeedItemSerializer(URLSerializerMixin, serializers.ModelSerializer):
     """
     A serializer for the FeedItem class, which wraps all items that live on the
@@ -185,8 +289,7 @@ class FeedItemSerializer(URLSerializerMixin, serializers.ModelSerializer):
         choices_dict=mkt.carriers.CARRIER_MAP)
     region = SlugChoiceField(required=False,
         choices_dict=mkt.regions.REGION_LOOKUP)
-    category = UnicodeChoiceField(required=False,
-        choices=CATEGORY_CHOICES)
+    category = UnicodeChoiceField(required=False, choices=CATEGORY_CHOICES)
     item_type = serializers.SerializerMethodField('get_item_type')
 
     # Types of objects that are allowed to be a feed item.
@@ -247,3 +350,40 @@ class FeedItemSerializer(URLSerializerMixin, serializers.ModelSerializer):
                     'Feed item region does not match operator shelf region.')
 
         return attrs
+
+
+class FeedItemESSerializer(FeedItemSerializer, BaseESSerializer):
+    """
+    A serializer for the FeedItem class from an ES object, which wraps all
+    items that live on the feed.
+
+    It will turn something like
+
+    >> {'item_type': 'app', 'carrier': 1, 'region': 1, 'app': 140L, 'id': 229L}
+
+    into a fully serialized FeedItem.
+
+    self.context['app_map'] -- mapping of app IDs to ES app objects.
+    self.context['feed_element_map'] -- mapping of feed element IDs to ES feed
+                                        element objects.
+    self.context['request'] -- Django request, mainly for translations.
+    """
+    app = FeedAppESSerializer(required=False, source='_app')
+    brand = FeedBrandESSerializer(required=False, source='_brand')
+    collection = FeedCollectionESSerializer(required=False,
+                                            source='_collection')
+    shelf = FeedShelfESSerializer(required=False, source='_shelf')
+
+    def fake_object(self, data):
+        feed_item = self._attach_fields(FeedItem(), data, (
+            'id', 'carrier', 'category', 'item_type', 'region',
+        ))
+
+        # Already fetched the feed element from ES. Set it to deserialize.
+        for item_type in self.Meta.item_types:
+            setattr(
+                feed_item, '_%s' % item_type,
+                self.context['feed_element_map'][item_type].get(data.get(
+                    item_type)))
+
+        return feed_item

--- a/mkt/feed/tests/test_serializers.py
+++ b/mkt/feed/tests/test_serializers.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
+
 from nose.tools import eq_
-from rest_framework import serializers
+from rest_framework.serializers import ValidationError
 
 import amo
 import amo.tests
 
+import mkt.feed.constants as feed
+from mkt.feed import serializers
 from mkt.feed.constants import COLLECTION_LISTING, COLLECTION_PROMO
 from mkt.feed.models import FeedBrand, FeedShelf
 from mkt.feed.tests.test_models import FeedAppMixin, FeedTestMixin
@@ -12,6 +16,208 @@ from mkt.feed.serializers import (FeedAppSerializer, FeedBrandSerializer,
                                   FeedCollectionSerializer,
                                   FeedShelfSerializer, FeedItemSerializer)
 from mkt.regions import RESTOFWORLD
+from mkt.webapps.indexers import WebappIndexer
+
+
+class TestFeedAppSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def test_basic(self):
+        data = {
+            'app': 337141,
+            'background_color': '#B90000',
+            'type': 'icon',
+            'description': {
+                'en-US': u'pan-fried potatoes'
+            },
+            'slug': 'aaa'
+        }
+        serializer = serializers.FeedAppSerializer(data=data)
+        assert serializer.is_valid()
+
+
+class TestFeedAppESSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def setUp(self):
+        self.feedapp = self.feed_app_factory(
+            app_type=feed.FEEDAPP_DESC, description={'en-US': 'test'})
+        self.data_es = self.feedapp.get_indexer().extract_document(
+            None, obj=self.feedapp)
+
+        self.app_map = {
+            self.feedapp.app_id: WebappIndexer.extract_document(
+                self.feedapp.app_id)
+        }
+
+    def test_deserialize(self):
+        data = serializers.FeedAppESSerializer(self.data_es, context={
+            'app_map': self.app_map,
+            'request': amo.tests.req_factory_factory('')
+        }).data
+        eq_(data['app']['id'], self.feedapp.app_id)
+        eq_(data['description']['en-US'], 'test')
+
+    def test_deserialize_many(self):
+        data = serializers.FeedAppESSerializer(
+            [self.data_es, self.data_es], context={
+                'app_map': self.app_map,
+                'request': amo.tests.req_factory_factory('')
+        }, many=True).data
+        eq_(data[0]['app']['id'], self.feedapp.app_id)
+        eq_(data[1]['description']['en-US'], 'test')
+
+
+class TestFeedBrandSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def setUp(self):
+        self.app_ids = [amo.tests.app_factory().id for i in range(3)]
+        self.brand = self.feed_brand_factory(app_ids=self.app_ids)
+        super(TestFeedBrandSerializer, self).setUp()
+
+    def test_deserialize(self):
+        data = serializers.FeedBrandSerializer(self.brand).data
+        eq_(data['slug'], self.brand.slug)
+        eq_(data['layout'], self.brand.layout)
+        eq_(data['type'], self.brand.type)
+        self.assertSetEqual([app['id'] for app in data['apps']], self.app_ids)
+
+
+class TestFeedBrandESSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def setUp(self):
+        self.apps = [amo.tests.app_factory() for i in range(3)]
+        self.app_ids = [app.id for app in self.apps]
+
+        self.brand = self.feed_brand_factory(app_ids=self.app_ids)
+        self.data_es = self.brand.get_indexer().extract_document(
+            None, obj=self.brand)
+
+        self.app_map = dict((app.id, WebappIndexer.extract_document(app.id))
+                            for app in self.apps)
+
+    def test_deserialize(self):
+        data = serializers.FeedBrandESSerializer(self.data_es, context={
+            'app_map': self.app_map,
+            'request': amo.tests.req_factory_factory('')
+        }).data
+        self.assertSetEqual([app['id'] for app in data['apps']],
+                            [app.id for app in self.apps])
+        eq_(data['type'], self.brand.type)
+
+
+class TestFeedCollectionSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def setUp(self):
+        super(TestFeedCollectionSerializer, self).setUp()
+        self.data = {
+            'background_color': '#FF4E00',
+            'name': {'en-US': 'Potato'},
+            'description': {'en-US': 'Potato, tomato'},
+            'type': COLLECTION_PROMO
+        }
+
+    def validate(self, **attrs):
+        return (serializers.FeedCollectionSerializer()
+                .validate_background_color(attrs=self.data,
+                                           source='background_color'))
+
+    def test_validate_promo_bg(self):
+        self.validate()
+
+    def test_validate_promo_nobg(self):
+        del self.data['background_color']
+        with self.assertRaises(ValidationError):
+            self.validate()
+
+    def test_validate_listing_bg(self):
+        self.data['type'] = COLLECTION_LISTING
+        self.validate()
+
+    def test_validate_listing_nobg(self):
+        self.data['type'] = COLLECTION_LISTING
+        del self.data['background_color']
+        self.validate()
+
+
+class TestFeedCollectionESSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def setUp(self):
+        self.apps = [amo.tests.app_factory() for i in range(3)]
+        self.app_ids = [app.id for app in self.apps]
+
+        self.collection = self.feed_collection_factory(
+            app_ids=self.app_ids, description={'de': 'test'},
+            name={'en-US': 'test'})
+        self.data_es = self.collection.get_indexer().extract_document(
+            None, obj=self.collection)
+
+        self.app_map = dict((app.id, WebappIndexer.extract_document(app.id))
+                            for app in self.apps)
+
+    def test_deserialize(self):
+        data = serializers.FeedCollectionESSerializer(self.data_es, context={
+            'app_map': self.app_map,
+            'request': amo.tests.req_factory_factory('')
+        }).data
+        self.assertSetEqual([app['id'] for app in data['apps']],
+                            [app.id for app in self.apps])
+        eq_(data['description']['de'], 'test')
+        eq_(data['name']['en-US'], 'test')
+        return data
+
+    def test_deserialize_grouped_apps(self):
+        self.collection = self.feed_collection_factory(
+            app_ids=self.app_ids, grouped=True, description={'de': 'test'},
+            name={'en-US': 'test'})
+        self.data_es = self.collection.get_indexer().extract_document(
+            None, obj=self.collection)
+        data = self.test_deserialize()
+        for i, app in enumerate(data['apps']):
+            group = app['group']['en-US']
+            if not i == 2:
+                eq_(group, 'first-group')
+            else:
+                eq_(group, 'second-group')
+
+
+class TestFeedShelfSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def setUp(self):
+        self.app_ids = [amo.tests.app_factory().id for i in range(3)]
+        self.shelf = self.feed_shelf_factory(app_ids=self.app_ids)
+        super(TestFeedShelfSerializer, self).setUp()
+
+    def test_deserialize(self):
+        data = serializers.FeedShelfSerializer(self.shelf).data
+        eq_(data['slug'], self.shelf.slug)
+        self.assertSetEqual([app['id'] for app in data['apps']], self.app_ids)
+
+
+class TestFeedShelfESSerializer(FeedTestMixin, amo.tests.TestCase):
+
+    def setUp(self):
+        self.apps = [amo.tests.app_factory() for i in range(3)]
+        self.app_ids = [app.id for app in self.apps]
+
+        self.shelf = self.feed_shelf_factory(
+            app_ids=self.app_ids, description={'de': 'test'},
+            name={'en-US': 'test'})
+        self.data_es = self.shelf.get_indexer().extract_document(
+            None, obj=self.shelf)
+
+        self.app_map = dict((app.id, WebappIndexer.extract_document(app.id))
+                            for app in self.apps)
+
+    def test_deserialize(self):
+        data = serializers.FeedShelfESSerializer(self.data_es, context={
+            'app_map': self.app_map,
+            'request': amo.tests.req_factory_factory('')
+        }).data
+        self.assertSetEqual([app['id'] for app in data['apps']],
+                            [app.id for app in self.apps])
+        eq_(data['carrier'], 'telefonica')
+        eq_(data['region'], 'restofworld')
+        eq_(data['description']['de'], 'test')
+        eq_(data['name']['en-US'], 'test')
 
 
 class TestFeedItemSerializer(FeedAppMixin, amo.tests.TestCase):
@@ -22,8 +228,8 @@ class TestFeedItemSerializer(FeedAppMixin, amo.tests.TestCase):
 
     def serializer(self, item=None, **context):
         if not item:
-            return FeedItemSerializer(context=context)
-        return FeedItemSerializer(item, context=context)
+            return serializers.FeedItemSerializer(context=context)
+        return serializers.FeedItemSerializer(item, context=context)
 
     def validate(self, **attrs):
         return self.serializer().validate(attrs=attrs)
@@ -32,7 +238,7 @@ class TestFeedItemSerializer(FeedAppMixin, amo.tests.TestCase):
         self.validate(app=self.feedapps[0])
 
     def test_validate_fails_no_items(self):
-        with self.assertRaises(serializers.ValidationError):
+        with self.assertRaises(ValidationError):
             self.validate(app=None)
 
     def validate_shelf(self, **attrs):
@@ -49,11 +255,11 @@ class TestFeedItemSerializer(FeedAppMixin, amo.tests.TestCase):
         self.validate_shelf()
 
     def test_validate_shelf_fails_region(self):
-        with self.assertRaises(serializers.ValidationError):
+        with self.assertRaises(ValidationError):
             self.validate_shelf(region='br')
 
     def test_validate_shelf_fails_carrier(self):
-        with self.assertRaises(serializers.ValidationError):
+        with self.assertRaises(ValidationError):
             self.validate_shelf(carrier='telenor')
 
     def test_region_handles_worldwide(self):
@@ -62,83 +268,51 @@ class TestFeedItemSerializer(FeedAppMixin, amo.tests.TestCase):
             'item_type': 'app',
             'app': self.feedapps[0].id,
         }
-        serializer = FeedItemSerializer(data=data)
+        serializer = serializers.FeedItemSerializer(data=data)
         assert serializer.is_valid()
         assert serializer.object.region == RESTOFWORLD.id
 
 
-class TestFeedAppSerializer(FeedTestMixin, amo.tests.TestCase):
-
-    def test_basic(self):
-        data = {
-            'app': 337141,
-            'background_color': '#B90000',
-            'type': 'icon',
-            'description': {
-                'en-US': u'pan-fried potatoes'
-            },
-            'slug': 'aaa'
-        }
-        serializer = FeedAppSerializer(data=data)
-        assert serializer.is_valid()
-
-
-class TestFeedBrandSerializer(FeedTestMixin, amo.tests.TestCase):
+class TestFeedItemESSerializer(FeedTestMixin, amo.tests.TestCase):
 
     def setUp(self):
-        self.app_ids = [amo.tests.app_factory().id for i in range(3)]
-        self.brand = self.feed_brand_factory(app_ids=self.app_ids)
-        super(TestFeedBrandSerializer, self).setUp()
+        self.feed = self.feed_factory()
+        self.data_es = [
+            feed_item.get_indexer().extract_document(None, obj=feed_item)
+            for feed_item in self.feed]
 
-    def test_serialization(self):
-        data = FeedBrandSerializer(self.brand).data
-        eq_(data['slug'], self.brand.slug)
-        eq_(data['layout'], self.brand.layout)
-        eq_(data['type'], self.brand.type)
-        self.assertSetEqual([app['id'] for app in data['apps']], self.app_ids)
+        # Denormalize feed elements into the serializer context.
+        self.app_map = {}
+        self.feed_element_map = defaultdict(dict)
+        for i, feed_item in enumerate(self.data_es):
+            feed_element = getattr(self.feed[i], feed_item['item_type'])
+            self.feed_element_map[feed_item['item_type']][feed_element.id] = (
+                feed_element.get_indexer().extract_document(None,
+                                                            obj=feed_element))
 
+            # Denormalize apps into serializer context.
+            if hasattr(feed_element, 'apps'):
+                for app in feed_element.apps():
+                    self.app_map[app.id] = WebappIndexer.extract_document(
+                        None, obj=app)
+            else:
+                self.app_map[feed_element.app_id] = (
+                    WebappIndexer.extract_document(feed_element.app_id))
 
-class TestFeedCollectionSerializer(FeedTestMixin, amo.tests.TestCase):
+    def test_deserialize_many(self):
+        data = serializers.FeedItemESSerializer(self.data_es, context={
+            'app_map': self.app_map,
+            'feed_element_map': self.feed_element_map,
+            'request': amo.tests.req_factory_factory('')
+        }, many=True).data
 
-    def setUp(self):
-        super(TestFeedCollectionSerializer, self).setUp()
-        self.data = {
-            'background_color': '#FF4E00',
-            'name': {'en-US': 'Potato'},
-            'description': {'en-US': 'Potato, tomato'},
-            'type': COLLECTION_PROMO
-        }
+        eq_(data[0]['app']['app']['id'], self.feed[0].app.app.id)
 
-    def validate(self, **attrs):
-        return FeedCollectionSerializer().validate_background_color(
-            attrs=self.data, source='background_color')
+        eq_(data[1]['brand']['apps'][0]['id'],
+            self.feed[1].brand.apps()[0].id)
 
-    def test_validate_promo_bg(self):
-        self.validate()
+        eq_(data[2]['collection']['apps'][0]['id'],
+            self.feed[2].collection.apps()[0].id)
 
-    def test_validate_promo_nobg(self):
-        del self.data['background_color']
-        with self.assertRaises(serializers.ValidationError):
-            self.validate()
-
-    def test_validate_listing_bg(self):
-        self.data['type'] = COLLECTION_LISTING
-        self.validate()
-
-    def test_validate_listing_nobg(self):
-        self.data['type'] = COLLECTION_LISTING
-        del self.data['background_color']
-        self.validate()
-
-
-class TestFeedShelfSerializer(FeedTestMixin, amo.tests.TestCase):
-
-    def setUp(self):
-        self.app_ids = [amo.tests.app_factory().id for i in range(3)]
-        self.shelf = self.feed_shelf_factory(app_ids=self.app_ids)
-        super(TestFeedShelfSerializer, self).setUp()
-
-    def test_serialization(self):
-        data = FeedShelfSerializer(self.shelf).data
-        eq_(data['slug'], self.shelf.slug)
-        self.assertSetEqual([app['id'] for app in data['apps']], self.app_ids)
+        eq_(data[3]['shelf']['apps'][0]['id'],
+            self.feed[3].shelf.apps()[0].id)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1181,6 +1181,9 @@ class Preview(amo.models.ModelBase):
 
     def _image_url(self, url_template):
         if self.modified is not None:
+            if isinstance(self.modified, unicode):
+                self.modified = datetime.datetime.strptime(self.modified,
+                                                           '%Y-%m-%dT%H:%M:%S')
             modified = int(time.mktime(self.modified.timetuple()))
         else:
             modified = 0

--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -350,10 +350,10 @@ class TestESAppToDict(amo.tests.ESTestCase):
         self.refresh('webapp')
 
     def get_obj(self):
-        return S(WebappIndexer).filter(id=self.app.pk).execute().objects[0]
+        return S(WebappIndexer).filter(id=self.app.pk).execute().results[0]
 
     def serialize(self):
-        serializer = ESAppSerializer(instance=self.get_obj(),
+        serializer = ESAppSerializer(self.get_obj(),
                                      context={'request': self.request})
         return serializer.data
 


### PR DESCRIPTION
Breaking https://github.com/mozilla/zamboni/pull/2298/ up.
- Extract stuff from ESAppSerializer to a BaseESSerializer that reuses the `mock_object` stuff.
- FeedItemESSerializer -> FeedApp/Brand/Collection/ShelfESSerializer -> ESAppSerializer
- The serializers expect `app_map` and `feed_element_map` in the context. This is because we do batch ES queries in the view and we map back the IDs to ES objects in the serializers.
