### PR TITLE
feed item indexer for es feed (bug 1036216)

### DIFF
--- a/lib/es/management/commands/reindex_mkt.py
+++ b/lib/es/management/commands/reindex_mkt.py
@@ -1,7 +1,7 @@
 """
 Marketplace ElasticSearch Indexer.
 
-Currently indexes apps and feed elements.
+Currently creates the indexes and re-indexes apps and feed elements.
 """
 import logging
 import os
@@ -28,26 +28,29 @@ logger = logging.getLogger('z.elasticsearch')
 # logging.getLogger('elasticsearch').setLevel(logging.DEBUG)
 # logging.getLogger('elasticsearch.trace').setLevel(logging.DEBUG)
 
-
 # The subset of settings.ES_INDEXES we are concerned with.
+# Referenced from amo.tests.ESTestCase so update that if you are modifying the
+# structure of INDEXES.
+ES_INDEXES = settings.ES_INDEXES
 INDEXES = (
     # Index, Indexer, chunk size.
-    (settings.ES_INDEXES['webapp'], WebappIndexer, 100),
+    (ES_INDEXES['webapp'], WebappIndexer, 100),
     # Currently using 500 since these are manually created by a curator and
     # there will probably never be this many.
-    (settings.ES_INDEXES['mkt_feed_app'], f_indexers.FeedAppIndexer, 500),
-    (settings.ES_INDEXES['mkt_feed_brand'], f_indexers.FeedBrandIndexer, 500),
-    (settings.ES_INDEXES['mkt_feed_collection'],
-     f_indexers.FeedCollectionIndexer, 500),
-    (settings.ES_INDEXES['mkt_feed_shelf'], f_indexers.FeedShelfIndexer, 500),
+    (ES_INDEXES['mkt_feed_app'], f_indexers.FeedAppIndexer, 500),
+    (ES_INDEXES['mkt_feed_brand'], f_indexers.FeedBrandIndexer, 500),
+    (ES_INDEXES['mkt_feed_collection'], f_indexers.FeedCollectionIndexer, 500),
+    (ES_INDEXES['mkt_feed_shelf'], f_indexers.FeedShelfIndexer, 500),
+    # Currently using 1000 since FeedItem documents are pretty small.
+    (ES_INDEXES['mkt_feed_item'], f_indexers.FeedItemIndexer, 1000),
 )
 
 INDEX_DICT = {
     # In case we want to index only a subset of indexes.
-    'webapp': [INDEXES[0]],
-    'feed': [INDEXES[1], INDEXES[2], INDEXES[3], INDEXES[4]],
+    'apps': [INDEXES[0]],
+    'feed': [INDEXES[1], INDEXES[2], INDEXES[3], INDEXES[4], INDEXES[5]],
+    'feeditems': [INDEXES[5]],
 }
-
 
 ES = elasticsearch.Elasticsearch(hosts=settings.ES_HOSTS)
 

--- a/mkt/feed/indexers.py
+++ b/mkt/feed/indexers.py
@@ -1,11 +1,16 @@
 """
-Indexers for FeedApp, FeedBrand, FeedCollection are for Curator Tools search.
+Indexers for FeedApp, FeedBrand, FeedCollection, FeedShelf, FeedItem for
+feed homepage and curation tool search.
 """
+from collections import defaultdict
+
 from amo.utils import attach_trans_dict
 
 import mkt.carriers
+import mkt.feed.constants as feed
 import mkt.regions
 from mkt.search.indexers import BaseIndexer
+from mkt.translations.utils import format_translation_es
 from mkt.webapps.models import Webapp
 
 
@@ -21,16 +26,30 @@ class FeedAppIndexer(BaseIndexer):
         """Returns an Elasticsearch mapping for this MappingType"""
         doc_type = cls.get_mapping_type_name()
 
-        return {
+        mapping = {
             doc_type: {
                 'properties': {
-                    'id': {'type': 'integer'},
-                    'name': {'type': 'string', 'analyzer': 'default_icu'},
+                    'id': {'type': 'long'},
+                    'app': {'type': 'long'},
+                    'background_color': {'type': 'string',
+                                         'index': 'not_analyzed'},
+                    'has_image': {'type': 'boolean'},
+                    'item_type': {'type': 'string', 'index': 'not_analyzed'},
+                    'preview': {'type': 'object', 'dynamic': 'true'},
+                    'pullquote_attribution': {'type': 'string',
+                                              'index': 'not_analyzed'},
+                    'pullquote_rating': {'type': 'short'},
+                    'pullquote_text': {'type': 'string',
+                                       'analyzer': 'default_icu'},
+                    'search_names': {'type': 'string',
+                                     'analyzer': 'default_icu'},
                     'slug': {'type': 'string'},
                     'type': {'type': 'string', 'index': 'not_analyzed'},
                 }
             }
         }
+
+        return cls.attach_translation_mappings(mapping, ('description',))
 
     @classmethod
     def extract_document(cls, obj_id, obj=None):
@@ -38,16 +57,34 @@ class FeedAppIndexer(BaseIndexer):
         if obj is None:
             obj = cls.get_model().get(pk=obj_id)
 
-        # Attach translations to app object for the app name.
+        # Attach translations for searching and indexing.
+        attach_trans_dict(cls.get_model(), [obj])
         attach_trans_dict(Webapp, [obj.app])
 
-        return {
+        doc = {
             'id': obj.id,
-            'name': list(set(string for _, string
-                             in obj.app.translations[obj.app.name_id])),
+            'app': obj.app_id,
+            'background_color': obj.background_color,
+            'has_image': obj.has_image,
+            'item_type': feed.FEED_TYPE_APP,
+            'preview': {'id': obj.preview.id,
+                        'image_url': obj.preview.image_url,
+                        'thumbnail_url': obj.preview.thumbnail_url}
+                       if getattr(obj, 'preview') else None,
+            'pullquote_attribution': obj.pullquote_attribution,
+            'pullquote_rating': obj.pullquote_rating,
+            'search_names': list(
+                set(string for _, string
+                    in obj.app.translations[obj.app.name_id])),
             'slug': obj.slug,
             'type': obj.type,
         }
+
+        # Handle localized fields.
+        for field in ('description', 'pullquote_text'):
+            doc.update(format_translation_es(obj, field))
+
+        return doc
 
 
 class FeedBrandIndexer(BaseIndexer):
@@ -63,7 +100,9 @@ class FeedBrandIndexer(BaseIndexer):
         return {
             doc_type: {
                 'properties': {
-                    'id': {'type': 'integer'},
+                    'id': {'type': 'long'},
+                    'apps': {'type': 'long'},
+                    'item_type': {'type': 'string', 'index': 'not_analyzed'},
                     'slug': {'type': 'string'},
                     'type': {'type': 'string'},
                 }
@@ -77,9 +116,11 @@ class FeedBrandIndexer(BaseIndexer):
 
         return {
             'id': obj.id,
-            'slug': obj.slug,
-            'type': obj.type,
-        }
+            'apps': list(obj.apps().values_list('id', flat=True)),
+            'item_type': feed.FEED_TYPE_BRAND,
+        'slug': obj.slug,
+        'type': obj.type,
+    }
 
 
 class FeedCollectionIndexer(BaseIndexer):
@@ -92,33 +133,66 @@ class FeedCollectionIndexer(BaseIndexer):
     def get_mapping(cls):
         doc_type = cls.get_mapping_type_name()
 
-        return {
+        mapping = {
             doc_type: {
                 'properties': {
-                    'id': {'type': 'integer'},
-                    'name': {'type': 'string', 'analyzer': 'default_icu'},
+                    'id': {'type': 'long'},
+                    'apps': {'type': 'long'},
+                    'group_apps': {'type': 'object', 'dynamic': 'true'},
+                    'group_names': {'type': 'object', 'dynamic': 'true'},
+                    'has_image': {'type': 'boolean'},
+                    'item_type': {'type': 'string', 'index': 'not_analyzed'},
+                    'search_names': {'type': 'string',
+                                     'analyzer': 'default_icu'},
                     'slug': {'type': 'string'},
                     'type': {'type': 'string', 'index': 'not_analyzed'},
                 }
             }
         }
 
+        return cls.attach_translation_mappings(mapping, ('description',
+                                                         'name'))
+
     @classmethod
     def extract_document(cls, obj_id, obj=None):
-        from mkt.feed.models import FeedCollection
+        from mkt.feed.models import FeedCollection, FeedCollectionMembership
 
         if obj is None:
             obj = cls.get_model().get(pk=obj_id)
 
-        attach_trans_dict(FeedCollection, [obj])
+        attach_trans_dict(cls.get_model(), [obj])
 
-        return {
+        doc = {
             'id': obj.id,
-            'name': list(set(string for _, string
-                             in obj.translations[obj.name_id])),
+            'apps': list(obj.apps().values_list('id', flat=True)),
+            'group_apps': {},  # Map of app IDs to index in group_names below.
+            'group_names': [],  # List of ES-serialized group names.
+            'has_image': obj.has_image,
+            'item_type': feed.FEED_TYPE_COLL,
+            'search_names': list(
+                set(string for _, string
+                    in obj.translations[obj.name_id])),
             'slug': obj.slug,
             'type': obj.type,
         }
+
+        # Grouped apps. Key off of translation, pointed to app IDs.
+        memberships = obj.feedcollectionmembership_set.all()
+        attach_trans_dict(FeedCollectionMembership, memberships)
+        for member in memberships:
+            if member.group:
+                grp_translation = format_translation_es(member, 'group')
+                if grp_translation not in doc['group_names']:
+                    doc['group_names'].append(grp_translation)
+
+                doc['group_apps'][member.app_id] = doc['group_names'].index(
+                    grp_translation)
+
+        # Handle localized fields.
+        for field in ('description', 'name'):
+            doc.update(format_translation_es(obj, field))
+
+        return doc
 
 
 class FeedShelfIndexer(BaseIndexer):
@@ -131,17 +205,24 @@ class FeedShelfIndexer(BaseIndexer):
     def get_mapping(cls):
         doc_type = cls.get_mapping_type_name()
 
-        return {
+        mapping = {
             doc_type: {
                 'properties': {
-                    'id': {'type': 'integer'},
-                    'name': {'type': 'string', 'analyzer': 'default_icu'},
-                    'slug': {'type': 'string'},
+                    'id': {'type': 'long'},
+                    'apps': {'type': 'long'},
                     'carrier': {'type': 'string', 'index': 'not_analyzed'},
+                    'has_image': {'type': 'boolean'},
+                    'item_type': {'type': 'string', 'index': 'not_analyzed'},
                     'region': {'type': 'string', 'index': 'not_analyzed'},
+                    'search_names': {'type': 'string',
+                                     'analyzer': 'default_icu'},
+                    'slug': {'type': 'string'},
                 }
             }
         }
+
+        return cls.attach_translation_mappings(mapping, ('description',
+                                                         'name'))
 
     @classmethod
     def extract_document(cls, obj_id, obj=None):
@@ -150,13 +231,72 @@ class FeedShelfIndexer(BaseIndexer):
         if obj is None:
             obj = cls.get_model().get(pk=obj_id)
 
-        attach_trans_dict(FeedShelf, [obj])
+        attach_trans_dict(cls.get_model(), [obj])
+
+        doc = {
+            'id': obj.id,
+            'apps': list(obj.apps().values_list('id', flat=True)),
+            'carrier': mkt.carriers.CARRIER_CHOICE_DICT[obj.carrier].slug,
+            'has_image': obj.has_image,
+            'item_type': feed.FEED_TYPE_SHELF,
+            'region': mkt.regions.REGIONS_CHOICES_ID_DICT[obj.region].slug,
+            'search_names': list(set(string for _, string
+                                     in obj.translations[obj.name_id])),
+            'slug': obj.slug,
+        }
+
+        # Handle localized fields.
+        for field in ('description', 'name'):
+            doc.update(format_translation_es(obj, field))
+
+        return doc
+
+
+class FeedItemIndexer(BaseIndexer):
+    @classmethod
+    def get_model(cls):
+        from mkt.feed.models import FeedItem
+        return FeedItem
+
+    @classmethod
+    def get_mapping(cls):
+        doc_type = cls.get_mapping_type_name()
+
+        return {
+            doc_type: {
+                'properties': {
+                    'id': {'type': 'long'},
+                    'app': {'type': 'long'},
+                    'brand': {'type': 'long'},
+                    'carrier': {'type': 'integer'},
+                    'category': {'type': 'integer'},
+                    'collection': {'type': 'long'},
+                    'item_type': {'type': 'string', 'index': 'not_analyzed'},
+                    'region': {'type': 'integer'},
+                    'shelf': {'type': 'long'},
+                }
+            }
+        }
+
+    @classmethod
+    def extract_document(cls, obj_id, obj=None):
+        from mkt.feed.models import FeedItem
+
+        if obj is None:
+            obj = cls.get_model().get(pk=obj_id)
 
         return {
             'id': obj.id,
-            'name': list(set(string for _, string
-                             in obj.translations[obj.name_id])),
-            'slug': obj.slug,
-            'carrier': mkt.carriers.CARRIER_CHOICE_DICT[obj.carrier].slug,
-            'region': mkt.regions.REGIONS_CHOICES_ID_DICT[obj.region].slug,
+            'app': obj.app_id if obj.item_type == feed.FEED_TYPE_APP
+                   else None,
+            'brand': obj.brand_id if obj.item_type == feed.FEED_TYPE_BRAND
+                     else None,
+            'carrier': obj.carrier,
+            'category': obj.category,
+            'collection': obj.collection_id if
+                          obj.item_type == feed.FEED_TYPE_COLL else None,
+            'item_type': obj.item_type,
+            'region': obj.region,
+            'shelf': obj.shelf_id if obj.item_type == feed.FEED_TYPE_SHELF
+                     else None,
         }

--- a/mkt/feed/models.py
+++ b/mkt/feed/models.py
@@ -23,6 +23,7 @@ from amo.decorators import use_master
 from amo.models import SlugField
 
 import mkt.carriers
+import mkt.feed.constants as feed
 import mkt.regions
 from mkt.collections.fields import ColorField
 from mkt.constants.categories import CATEGORY_CHOICES
@@ -210,6 +211,7 @@ class FeedBrand(BaseFeedCollection):
         abstract = False
         db_table = 'mkt_feed_brand'
 
+    @classmethod
     def get_indexer(self):
         return indexers.FeedBrandIndexer
 
@@ -248,6 +250,7 @@ class FeedCollection(BaseFeedCollection, BaseFeedImage):
         abstract = False
         db_table = 'mkt_feed_collection'
 
+    @classmethod
     def get_indexer(self):
         return indexers.FeedCollectionIndexer
 
@@ -320,6 +323,7 @@ class FeedShelf(BaseFeedCollection, BaseFeedImage):
         abstract = False
         db_table = 'mkt_feed_shelf'
 
+    @classmethod
     def get_indexer(self):
         return indexers.FeedShelfIndexer
 
@@ -353,6 +357,7 @@ class FeedApp(BaseFeedImage, amo.models.ModelBase):
     class Meta:
         db_table = 'mkt_feed_app'
 
+    @classmethod
     def get_indexer(self):
         return indexers.FeedAppIndexer
 
@@ -400,6 +405,10 @@ class FeedItem(amo.models.ModelBase):
         db_table = 'mkt_feed_item'
         ordering = ('order',)
 
+    @classmethod
+    def get_indexer(cls):
+        return indexers.FeedItemIndexer
+
 
 # Maintain ElasticSearch index.
 @receiver(models.signals.post_save, sender=FeedApp,
@@ -410,6 +419,8 @@ class FeedItem(amo.models.ModelBase):
           dispatch_uid='feedcollection.search.index')
 @receiver(models.signals.post_save, sender=FeedShelf,
           dispatch_uid='feedshelf.search.index')
+@receiver(models.signals.post_save, sender=FeedItem,
+          dispatch_uid='feeditem.search.index')
 def update_search_index(sender, instance, **kw):
     index.delay([instance.id], instance.get_indexer())
 

--- a/mkt/feed/tests/test_indexers.py
+++ b/mkt/feed/tests/test_indexers.py
@@ -3,8 +3,10 @@ from nose.tools import eq_
 import amo.tests
 
 import mkt.carriers
+import mkt.feed.constants as feed
 import mkt.regions
-from mkt.feed.models import FeedApp, FeedBrand, FeedCollection, FeedShelf
+from mkt.feed.models import (FeedApp, FeedBrand, FeedCollection, FeedItem,
+                             FeedShelf)
 from mkt.feed.tests.test_models import FeedTestMixin
 from mkt.webapps.models import Webapp
 
@@ -14,8 +16,18 @@ class BaseFeedIndexerTest(object):
     def test_model(self):
         eq_(self.indexer.get_model(), self.model)
 
+    def test_get_mapping_ok(self):
+        assert isinstance(self.indexer.get_mapping(), dict)
+
     def _get_doc(self):
         return self.indexer.extract_document(self.obj.pk, self.obj)
+
+    def _get_test_l10n(self):
+        return {'en-US': 'ustext', 'de': 'detext'}
+
+    def _assert_test_l10n(self, ts_obj):
+        eq_(ts_obj, [{'lang': 'de', 'string': 'detext'},
+                     {'lang': 'en-US', 'string': 'ustext'}])
 
 
 class TestFeedAppIndexer(FeedTestMixin, BaseFeedIndexerTest,
@@ -23,14 +35,26 @@ class TestFeedAppIndexer(FeedTestMixin, BaseFeedIndexerTest,
 
     def setUp(self):
         self.app = Webapp.objects.get(pk=337141)
-        self.obj = self.feed_app_factory()
+        self.obj = self.feed_app_factory(
+            background_color='#DDDDDD', image_hash='LOL',
+            description=self._get_test_l10n(), pullquote_attribution='mscott',
+            pullquote_rating=4, pullquote_text=self._get_test_l10n(),
+            app_type=feed.FEEDAPP_QUOTE)
         self.indexer = self.obj.get_indexer()()
         self.model = FeedApp
 
     def test_extract(self):
         doc = self._get_doc()
         eq_(doc['id'], self.obj.id)
-        assert self.app.name.localized_string in doc['name']
+        eq_(doc['app'], self.app.id)
+        eq_(doc['background_color'], '#DDDDDD')
+        self._assert_test_l10n(doc['description_translations'])
+        eq_(doc['has_image'], True)
+        eq_(doc['item_type'], feed.FEED_TYPE_APP)
+        eq_(doc['pullquote_attribution'], 'mscott')
+        eq_(doc['pullquote_rating'], 4)
+        self._assert_test_l10n(doc['pullquote_text_translations'])
+        assert self.app.name.localized_string in doc['search_names']
         eq_(doc['slug'], self.obj.slug)
         eq_(doc['type'], self.obj.type)
 
@@ -49,19 +73,39 @@ class TestFeedBrandIndexer(FeedTestMixin, BaseFeedIndexerTest,
         eq_(doc['slug'], self.obj.slug)
         eq_(doc['type'], self.obj.type)
 
+        eq_(doc['apps'], list(self.obj.apps().values_list('id', flat=True)))
+        eq_(doc['item_type'], feed.FEED_TYPE_BRAND)
+
 
 class TestFeedCollectionIndexer(FeedTestMixin, BaseFeedIndexerTest,
                                 amo.tests.TestCase):
 
     def setUp(self):
-        self.obj = self.feed_collection_factory()
+        self.app_ids = [amo.tests.app_factory().id for app in range(3)]
+        self.obj = self.feed_collection_factory(
+            app_ids=self.app_ids, name=self._get_test_l10n(),
+            description=self._get_test_l10n(), image_hash='LOL',
+            coll_type=feed.COLLECTION_PROMO, grouped=True)
         self.indexer = self.obj.get_indexer()()
         self.model = FeedCollection
 
     def test_extract(self):
         doc = self._get_doc()
         eq_(doc['id'], self.obj.id)
-        assert self.obj.name.localized_string in doc['name']
+        self.assertSetEqual(doc['apps'], self.app_ids)
+        self._assert_test_l10n(doc['description_translations'])
+        eq_(doc['group_apps'], {doc['apps'][0]: 0,
+                                doc['apps'][1]: 0,
+                                doc['apps'][2]: 1})
+        eq_(doc['group_names'],
+            [{'group_translations': [{'lang': 'en-US',
+                                      'string': 'first-group'}]},
+             {'group_translations': [{'lang': 'en-US',
+                                      'string': 'second-group'}]}])
+        eq_(doc['has_image'], True)
+        eq_(doc['item_type'], feed.FEED_TYPE_COLL)
+        self._assert_test_l10n(doc['name_translations'])
+        assert self.obj.name.localized_string in doc['search_names']
         eq_(doc['slug'], self.obj.slug)
         eq_(doc['type'], self.obj.type)
 
@@ -70,16 +114,44 @@ class TestFeedShelfIndexer(FeedTestMixin, BaseFeedIndexerTest,
                            amo.tests.TestCase):
 
     def setUp(self):
-        self.obj = self.feed_shelf_factory()
+        self.app_ids = [amo.tests.app_factory().id for app in range(3)]
+        self.obj = self.feed_shelf_factory(
+            app_ids=self.app_ids, name=self._get_test_l10n(),
+            description=self._get_test_l10n(), image_hash='LOL')
         self.indexer = self.obj.get_indexer()()
         self.model = FeedShelf
 
     def test_extract(self):
         doc = self._get_doc()
         eq_(doc['id'], self.obj.id)
-        assert self.obj.name.localized_string in doc['name']
-        eq_(doc['slug'], self.obj.slug)
+        self.assertSetEqual(doc['apps'], self.app_ids)
         eq_(doc['carrier'],
             mkt.carriers.CARRIER_CHOICE_DICT[self.obj.carrier].slug)
+        self._assert_test_l10n(doc['description_translations'])
+        eq_(doc['has_image'], True)
+        self._assert_test_l10n(doc['name_translations'])
         eq_(doc['region'],
             mkt.regions.REGIONS_CHOICES_ID_DICT[self.obj.region].slug)
+        assert self.obj.name.localized_string in doc['search_names']
+        eq_(doc['slug'], self.obj.slug)
+
+
+class TestFeedItemIndexer(FeedTestMixin, BaseFeedIndexerTest,
+                          amo.tests.TestCase):
+
+     def setUp(self):
+        self.obj = self.feed_item_factory(item_type=feed.FEED_TYPE_APP)
+        self.indexer = self.obj.get_indexer()()
+        self.model = FeedItem
+
+     def test_extract(self):
+        doc = self._get_doc()
+        eq_(doc['id'], self.obj.id)
+        eq_(doc['carrier'], self.obj.carrier)
+        eq_(doc['category'], None)
+        eq_(doc['item_type'], feed.FEED_TYPE_APP)
+        eq_(doc['region'], self.obj.region)
+        eq_(doc['app'], self.obj.app_id)
+        eq_(doc['brand'], None)
+        eq_(doc['collection'], None)
+        eq_(doc['shelf'], None)

--- a/mkt/feed/tests/test_models.py
+++ b/mkt/feed/tests/test_models.py
@@ -39,7 +39,8 @@ class FeedTestMixin(object):
         count = FeedCollection.objects.count()
         coll = FeedCollection.objects.create(
             name=name, slug='feed-coll-%s' % count, type=coll_type, **kwargs)
-        coll.set_apps(app_ids or [337141])
+        app_ids = app_ids or [337141]
+        coll.set_apps(app_ids)
 
         if grouped:
             for i, mem in enumerate(coll.feedcollectionmembership_set.all()):

--- a/mkt/feed/views.py
+++ b/mkt/feed/views.py
@@ -305,16 +305,16 @@ class FeedElementSearchView(CORSMixin, APIView):
         }
 
         feed_app_ids = ([pk[0] for pk in S(FeedAppIndexer).query(
-            name__fuzzy=q, **query).values_list('id')])
+            search_names__fuzzy=q, **query).values_list('id')])
 
         feed_brand_ids = [pk[0] for pk in S(FeedBrandIndexer).query(
             **query).values_list('id')]
 
         feed_collection_ids = ([pk[0] for pk in S(FeedCollectionIndexer).query(
-            name__fuzzy=q, **query).values_list('id')])
+            search_names__fuzzy=q, **query).values_list('id')])
 
         feed_shelf_ids = ([pk[0] for pk in S(FeedShelfIndexer).query(
-            name__fuzzy=q, slug__fuzzy=q, carrier__prefix=q, region=q,
+            search_names__fuzzy=q, slug__fuzzy=q, carrier__prefix=q, region=q,
             should=True).values_list('id')])
 
         # Dehydrate.

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -693,6 +693,7 @@ ES_INDEXES = {
     'mkt_feed_brand': 'feed_brands',
     'mkt_feed_collection': 'feed_collections',
     'mkt_feed_shelf': 'feed_shelves',
+    'mkt_feed_item': 'feed_items',
     # Adding an index? Don't forget to add the indexer to ESTestCase.
     # Also add the index to reindex_mkt.py.
 }

--- a/mkt/translations/utils.py
+++ b/mkt/translations/utils.py
@@ -95,3 +95,20 @@ def transfield_changed(field, initial, data):
     data = [('%s_%s' % (field, k), v) for k, v in data[field].iteritems()
             if k != 'init']
     return set(initial) != set(data)
+
+
+def format_translation_es(obj, field):
+    """
+    Returns a denormalized format of a localized field for ES to be
+    deserialized by ESTranslationSerializerField.
+    """
+    from amo.utils import to_language
+
+    extend_with_me = {}
+    extend_with_me['%s_translations' % field] = [
+        {'lang': to_language(lang), 'string': string}
+        for lang, string
+        in obj.translations[getattr(obj, '%s_id' % field)]
+        if string
+    ]
+    return extend_with_me

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1413,6 +1413,10 @@ class Webapp(Addon):
             if not hasattr(self, '_geodata'):
                 Geodata.objects.create(addon=self)
 
+    @classmethod
+    def get_indexer(cls):
+        return WebappIndexer
+
     @staticmethod
     def transformer(apps):
         if not apps:
@@ -1471,15 +1475,6 @@ class Webapp(Addon):
             app.all_versions = v_dict.get(app.id, [])
 
         return apps
-
-    @staticmethod
-    def indexing_transformer(apps):
-        """Attach everything we need to index apps."""
-        transforms = (attach_devices, attach_prices, attach_tags,
-                      attach_translations)
-        for t in transforms:
-            qs = apps.transform(t)
-        return qs
 
     @property
     def geodata(self):

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -341,8 +341,7 @@ def index_webapps(ids, **kw):
     indices = Reindexing.get_indices(index)
 
     es = WebappIndexer.get_es(urls=settings.ES_URLS)
-    qs = Webapp.indexing_transformer(Webapp.with_deleted.no_cache().filter(
-        id__in=ids))
+    qs = Webapp.with_deleted.no_cache().filter(id__in=ids)
     for obj in qs:
         doc = WebappIndexer.extract_document(obj.id, obj)
         for idx in indices:

--- a/mkt/webapps/tests/test_indexers.py
+++ b/mkt/webapps/tests/test_indexers.py
@@ -43,8 +43,7 @@ class TestWebappIndexer(amo.tests.TestCase):
             ok_(k in keys, 'Key %s not found in mapping properties' % k)
 
     def _get_doc(self):
-        qs = Webapp.indexing_transformer(
-            Webapp.objects.no_cache().filter(id__in=[self.app.pk]))
+        qs = Webapp.objects.no_cache().filter(id__in=[self.app.pk])
         obj = qs[0]
         return obj, WebappIndexer.extract_document(obj.pk, obj)
 


### PR DESCRIPTION
Breaking https://github.com/mozilla/zamboni/pull/2298 up.
- Index the FeedItem -> FeedApp/Brand/Collection/Shelf -> Apps relation in ES using denormalization "schema"
- FeedItem store FeedApp/Brand/Collection/Shelf IDs
- FeedApp/Brand/Collection/Shelf store app IDs
- Some special logic for grouped feed collections

Related serializers at https://github.com/mozilla/zamboni/pull/2313
