### PR TITLE
Replace mimetype with content_type in HttpResponses (bug 1020943)

### DIFF
--- a/mkt/commonplace/views.py
+++ b/mkt/commonplace/views.py
@@ -92,7 +92,7 @@ def appcache_manifest(request):
     if not repo or repo not in settings.COMMONPLACE_REPOS_APPCACHED:
         return HttpResponseNotFound()
     template = appcache_manifest_template(repo)
-    return HttpResponse(template, mimetype='text/cache-manifest')
+    return HttpResponse(template, content_type='text/cache-manifest')
 
 
 @memoize('appcache-manifest-template')

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -1014,7 +1014,7 @@ def attachment(request, attachment):
     else:
         filename = urllib.quote(a.filename())
         response = http.HttpResponse(fsock,
-                                     mimetype='application/force-download')
+                                     content_type='application/force-download')
         response['Content-Disposition'] = 'attachment; filename=%s' % filename
         response['Content-Length'] = os.path.getsize(full_path)
     return response

--- a/mkt/site/views.py
+++ b/mkt/site/views.py
@@ -95,7 +95,7 @@ def manifest(request):
     @etag(lambda r: manifest_etag)
     def _inner_view(request):
         response = HttpResponse(manifest_content,
-                                mimetype='application/x-web-app-manifest+json')
+            content_type='application/x-web-app-manifest+json')
         return response
 
     return _inner_view(request)
@@ -118,7 +118,7 @@ def yogafire_minifest(request):
 def robots(request):
     """Generate a `robots.txt`."""
     template = render(request, 'site/robots.txt')
-    return HttpResponse(template, mimetype='text/plain')
+    return HttpResponse(template, content_type='text/plain')
 
 
 @csrf_exempt


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1020943

`mimetype` is deprecated: https://docs.djangoproject.com/en/1.6/ref/request-response/#django.http.HttpResponse.__init__
