### PR TITLE
Do not force portrait orientation (bug 844186)

### DIFF
--- a/mkt/site/tests/test_views.py
+++ b/mkt/site/tests/test_views.py
@@ -101,12 +101,6 @@ class TestManifest(amo.tests.TestCase):
         content = json.loads(response.content)
         eq_(content['name'], 'Mozilla Fruitstand')
 
-    def test_manifest_orientation(self):
-        response = self.client.get(self.url)
-        eq_(response.status_code, 200)
-        content = json.loads(response.content)
-        eq_(content['orientation'], ['portrait-primary'])
-
     def test_manifest_etag(self):
         resp = self.client.get(self.url)
         etag = resp.get('Etag')

--- a/mkt/site/views.py
+++ b/mkt/site/views.py
@@ -83,8 +83,7 @@ def manifest(request):
             'marketplace-app-rating': {'href': '/'},
             'marketplace-category': {'href': '/'},
             'marketplace-search': {'href': '/'},
-        },
-        'orientation': ['portrait-primary']
+        }
     }
     if get_carrier():
         data['launch_path'] = urlparams('/', carrier=get_carrier())


### PR DESCRIPTION
The zamboni part of unlocking portrait orientation (so orientation can match device).
