### PR TITLE
Access in-app products by app origin (bug 1027710)

### DIFF
--- a/docs/api/topics/payment.rst
+++ b/docs/api/topics/payment.rst
@@ -228,11 +228,15 @@ In-app products are used for setting up in-app payments without the need to
 host your own JWT signer. This API is for managing your in-app products for use
 with the in-app payment service.
 
+The **origin** refers to the
+`origin <https://developer.mozilla.org/en-US/Apps/Build/Manifest#origin>`_ of the
+packaged app. For example: ``app://foo-app.com``.
+
 .. note:: Feature not complete.
 
-.. note:: Authentication is required.
+.. http:post:: /api/v1/payments/(string:origin)/in-app/
 
-.. http:post:: /api/v1/payments/(string:app_slug)/in-app/
+    .. note:: Authentication is required.
 
     Creates a new in-app product for sale.
 
@@ -259,7 +263,7 @@ with the in-app payment service.
     :param price_id: ID for the :ref:`price tier <price-tiers>`.
     :type price_id: int
 
-.. http:get:: /api/v1/payments/(string:app_slug)/in-app/
+.. http:get:: /api/v1/payments/(string:origin)/in-app/
 
     List the in-app products for this app.
 
@@ -281,7 +285,7 @@ with the in-app payment service.
     :param price_id: ID for the :ref:`price tier <price-tiers>`.
     :type price_id: int
 
-.. http:get:: /api/v1/payments/(string:app_slug)/in-app/(int:id)/
+.. http:get:: /api/v1/payments/(string:origin)/in-app/(int:id)/
 
     Details of an in-app product.
 
@@ -303,7 +307,9 @@ with the in-app payment service.
     :param price_id: ID for the :ref:`price tier <price-tiers>`.
     :type price_id: int
 
-.. http:put:: /api/v1/payments/(string:app_slug)/in-app/(int:id)/
+.. http:put:: /api/v1/payments/(string:origin)/in-app/(int:id)/
+
+    .. note:: Authentication is required.
 
     Update an in-app product.
 
@@ -517,6 +523,8 @@ Developers
 
 Developers of the app will get a special developer receipt that is valid for
 24 hours and does not require payment. See also `Test Receipts`_.
+
+.. _`Test Receipts`: https://developer.mozilla.org/en-US/Marketplace/Monetization/Validating_a_receipt#Test_receipts
 
 Reviewers
 ~~~~~~~~~

--- a/mkt/developers/templates/developers/payments/in-app-products.html
+++ b/mkt/developers/templates/developers/payments/in-app-products.html
@@ -36,34 +36,35 @@
           Your app must define an <a href="{{ origin }}">origin</a> in your manifest so that receipts can be verified properly.
         {% endtrans %}
       </div>
+    {% else %}
+      <div id="in-app-products" class="devhub-form island" data-list-url="{{ url('in-app-products-list', origin=addon.origin) }}"
+           data-detail-url-format="{{ url('in-app-products-detail', origin=addon.origin, pk="{id}") }}">
+        <table id="version-list">
+          <thead>
+            <tr>
+              <th>{{ _('Icon') }}</th>
+              <th>{{ _('Name') }}</th>
+              <th>{{ _('Price Point') }}</th>
+              <th>{{ _('Product ID') }}</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for product in products %}
+              {% include "developers/payments/in-app-product-row.html" %}
+            {% endfor %}
+          </tbody>
+        </table>
+        <p class="listing-footer">
+          <button id="add-in-app-product">{{ _('Add a product') }}</button>
+        </p>
+      </div>
+      <script id="in-app-product-row-template" type="x-template">
+        {% with product=new_product %}
+          {% include "developers/payments/in-app-product-row.html" %}
+        {% endwith %}
+      </script>
     {% endif %}
-
-    <div id="in-app-products" class="devhub-form island" data-list-url="{{ url('in-app-products-list', app_slug=addon.app_slug) }}" data-detail-url-format="{{ url('in-app-products-detail', app_slug=addon.app_slug, pk="{id}") }}">
-      <table id="version-list">
-        <thead>
-          <tr>
-            <th>{{ _('Icon') }}</th>
-            <th>{{ _('Name') }}</th>
-            <th>{{ _('Price Point') }}</th>
-            <th>{{ _('Product ID') }}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for product in products %}
-            {% include "developers/payments/in-app-product-row.html" %}
-          {% endfor %}
-        </tbody>
-      </table>
-      <p class="listing-footer">
-        <button id="add-in-app-product">{{ _('Add a product') }}</button>
-      </p>
-    </div>
-    <script id="in-app-product-row-template" type="x-template">
-      {% with product=new_product %}
-        {% include "developers/payments/in-app-product-row.html" %}
-      {% endwith %}
-    </script>
   </section>
 
   {% include "developers/includes/addons_edit_nav.html" %}

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -190,7 +190,7 @@ class TestInAppProductsView(InappTest):
         eq_(self.get().status_code, 404)
 
     def test_origin(self):
-        self.app.update(is_packaged=True, app_domain='http://f.c/')
+        self.app.update(is_packaged=True, app_domain='http://f.c')
         doc = pq(self.get().content)
         ok_(not doc('section.primary div.notification-box'))
 

--- a/mkt/developers/urls.py
+++ b/mkt/developers/urls.py
@@ -61,7 +61,7 @@ app_detail_patterns = patterns('',
     url('^status$', views.status, name='mkt.developers.apps.versions'),
     url('^blocklist$', views.blocklist, name='mkt.developers.apps.blocklist'),
 
-     # Only present if DEBUG=True.
+    # Only present if DEBUG=True.
     url('^debug/', views.debug, name='mkt.developers.debug'),
 
     # IARC content ratings.
@@ -196,7 +196,7 @@ app_payments.register(r'payments/debug', PaymentDebugViewSet,
 
 payments_api_patterns = patterns('',
     url(r'^payments/', include(api_payments.urls)),
-    url(r'^payments/(?P<app_slug>[^\/]+)/', include(in_app_products.urls)),
+    url(r'^payments/(?P<origin>(app|https?)://[^/]+)/', include(in_app_products.urls)),
     url(r'^apps/app/', include(app_payments.urls)),
 )
 

--- a/mkt/inapp/views.py
+++ b/mkt/inapp/views.py
@@ -18,7 +18,7 @@ class InAppProductViewSet(CORSMixin, MarketplaceView, ModelViewSet):
     cors_allowed_methods = ('get', 'post', 'put', 'patch' 'delete')
     permission_classes = [ByHttpMethod({
         'options': AllowAny,  # Needed for CORS.
-        'get': AllowAuthor,
+        'get': AllowAny,
         'post': AllowAuthor,
         'put': AllowAuthor,
         'patch': AllowAuthor,
@@ -38,8 +38,8 @@ class InAppProductViewSet(CORSMixin, MarketplaceView, ModelViewSet):
 
     def get_app(self):
         if not hasattr(self, 'app'):
-            app_slug = self.kwargs['app_slug']
-            self.app = get_object_or_404(Webapp, app_slug=app_slug)
+            self.app = get_object_or_404(Webapp,
+                                         app_domain=self.kwargs['origin'])
         return self.app
 
     def get_authors(self):


### PR DESCRIPTION
The navigator.mozApps API already gives us access to origin (not app slug) so let's use origin.
