### PR TITLE
add missing comm note types (bug 1042758)

### DIFF
--- a/apps/amo/__init__.py
+++ b/apps/amo/__init__.py
@@ -13,7 +13,7 @@ from mkt.constants.platforms import *
 from mkt.constants.search import *
 
 # This is used in multiple other files to access logging, do not remove.
-from .log import (LOG, LOG_BY_ID, LOG_ADMINS, LOG_EDITORS,
+from .log import (_LOG, LOG, LOG_BY_ID, LOG_ADMINS, LOG_EDITORS,
                   LOG_HIDE_DEVELOPER, LOG_KEEP, LOG_REVIEW_QUEUE,
                   LOG_REVIEW_EMAIL_USER, log)
 

--- a/apps/amo/log.py
+++ b/apps/amo/log.py
@@ -676,6 +676,10 @@ class PRIORITY_REVIEW_REQUESTED(_LOG):
     review_queue = True
 
 
+# Adding a log type? If it's a review_queue log type, you have to add a
+# note_type to constants/comm.py.
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 

--- a/migrations/830-allow-null-author.sql
+++ b/migrations/830-allow-null-author.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comm_thread_notes MODIFY COLUMN author_id int(11) unsigned;

--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -181,7 +181,8 @@ class CommunicationNoteManager(models.Manager):
 
 class CommunicationNote(CommunicationPermissionModel):
     thread = models.ForeignKey(CommunicationThread, related_name='notes')
-    author = models.ForeignKey('users.UserProfile', related_name='comm_notes')
+    author = models.ForeignKey('users.UserProfile', related_name='comm_notes',
+                               null=True, blank=True)
     note_type = models.IntegerField(default=comm.NO_ACTION)
     body = models.TextField(null=True)
     reply_to = models.ForeignKey(

--- a/mkt/comm/tests/test_constants.py
+++ b/mkt/comm/tests/test_constants.py
@@ -1,0 +1,28 @@
+import amo
+import amo.tests
+
+import mkt.constants.comm as comm
+
+
+class TestCommConstants(amo.tests.TestCase):
+    def setUp(self):
+        # TODO (hi mat): remove these from amo/log.py.
+        self.blacklist = [
+            amo.LOG.RETAIN_VERSION.id,
+            amo.LOG.REQUEST_VERSION.id,
+            amo.LOG.PRELIMINARY_VERSION.id,
+            amo.LOG.REQUEST_SUPER_REVIEW.id
+        ]
+
+    def test_review_queue_covered(self):
+        """
+        Test that every review queue log has its own note type.
+
+        If this test is failing, tell ngoke to add a new note type.
+        """
+        for log_type in amo.LOG_REVIEW_QUEUE:
+            if log_type in self.blacklist:
+                continue
+
+            assert comm.ACTION_MAP(log_type) != comm.NO_ACTION, log_type
+            assert comm.ACTION_MAP(log_type) in comm.NOTE_TYPES, log_type

--- a/mkt/comm/tests/test_views.py
+++ b/mkt/comm/tests/test_views.py
@@ -309,20 +309,6 @@ class TestThreadList(RestOAuth, CommTestMixin):
         eq_(res.status_code, 201)
         assert self.addon.threads.count()
 
-    @mock.patch('waffle.switch_is_active')
-    def test_create_no_switch(self, waffle_mock):
-        waffle_mock.return_value = False
-        version_factory(addon=self.addon, version='1.1')
-        data = {
-            'app': self.addon.app_slug,
-            'version': '1.1',
-            'note_type': '0',
-            'body': 'flylikebee'
-        }
-        self.addon.addonuser_set.create(user=self.user)
-        res = self.client.post(self.list_url, data=json.dumps(data))
-        eq_(res.status_code, 403)
-
 
 class NoteSetupMixin(RestOAuth, CommTestMixin, AttachmentManagementMixin):
     fixtures = fixture('webapp_337141', 'user_2519', 'user_999',
@@ -448,13 +434,6 @@ class TestNote(NoteSetupMixin):
 
     def test_create_no_perm(self):
         self.thread.update(read_permission_developer=False)
-        res = self.client.post(self.list_url, data=json.dumps(
-            {'note_type': '0', 'body': 'something'}))
-        eq_(res.status_code, 403)
-
-    @mock.patch('waffle.switch_is_active')
-    def test_create_no_switch(self, waffle_mock):
-        waffle_mock.return_value = False
         res = self.client.post(self.list_url, data=json.dumps(
             {'note_type': '0', 'body': 'something'}))
         eq_(res.status_code, 403)

--- a/mkt/comm/utils.py
+++ b/mkt/comm/utils.py
@@ -215,7 +215,7 @@ def send_mail_comm(note):
 
 
 def create_comm_note(app, version, author, body, note_type=comm.NO_ACTION,
-                     perms=None, no_switch=False, attachments=None):
+                     perms=None, attachments=None):
     """
     Creates a note on an app version's thread.
     Creates a thread if a thread doesn't already exist.
@@ -229,20 +229,13 @@ def create_comm_note(app, version, author, body, note_type=comm.NO_ACTION,
                  (e.g. comm.APPROVAL, comm.REJECTION, comm.NO_ACTION).
     perms -- object of groups to grant permission to, will set flags on Thread.
              (e.g. {'developer': False, 'staff': True}).
-    no_switch -- whether to ignore comm switch, needed after we migrate
-                 reviewer tools from ActivityLog to notes.
     attachments -- formset of attachment files
 
     """
-    if not no_switch and not waffle.switch_is_active('comm-dashboard'):
-        return None, None
-
-    # Dict of {'read_permission_GROUP_TYPE': boolean}.
     # Perm for reviewer, senior_reviewer, moz_contact, staff True by default.
-    # Perm for developer False if is escalation or reviewer comment by default.
+    # Perm for developer False if is reviewer-only comment by default.
     perms = perms or {}
-    if 'developer' not in perms and note_type in (comm.ESCALATION,
-                                                  comm.REVIEWER_COMMENT):
+    if 'developer' not in perms and note_type in comm.REVIEWER_NOTE_TYPES:
         perms['developer'] = False
     create_perms = dict(('read_permission_%s' % key, has_perm)
                         for key, has_perm in perms.iteritems())
@@ -280,10 +273,11 @@ def post_create_comm_note(note):
 
     # Add note author to thread.
     author = note.author
-    cc, created_cc = thread.join_thread(author)
-    if not created_cc:
-        # Mark their own note as read.
-        note.mark_read(note.author)
+    if author:
+        cc, created_cc = thread.join_thread(author)
+        if not created_cc:
+            # Mark their own note as read.
+            note.mark_read(note.author)
 
     # Send out emails.
     send_mail_comm(note)

--- a/mkt/constants/comm.py
+++ b/mkt/constants/comm.py
@@ -1,13 +1,11 @@
 from tower import ugettext_lazy as _
 
 
-# Number of days a token is valid for.
-THREAD_TOKEN_EXPIRY = 30
-
-# Number of times a token can be used.
-MAX_TOKEN_USE_COUNT = 5
-
-MAX_ATTACH = 10
+# To add a note type:
+# - assign it a incremented number (MY_NOTE_TYPE = 42)
+# - give it a translation in NOTE_TYPES
+# - if adding from amo/log.py, add it to ACTION_MAP
+# - add the translation to Commbadge settings
 
 # Faith of the seven.
 NO_ACTION = 0
@@ -18,7 +16,6 @@ MORE_INFO_REQUIRED = 4
 ESCALATION = 5
 REVIEWER_COMMENT = 6
 RESUBMISSION = 7
-
 APPROVE_VERSION_WAITING = 8
 ESCALATION_HIGH_ABUSE = 9
 ESCALATION_HIGH_REFUNDS = 10
@@ -26,6 +23,17 @@ ESCALATION_CLEARED = 11
 REREVIEW_CLEARED = 12
 SUBMISSION = 13
 DEVELOPER_COMMENT = 14
+REVIEW_DEVICE_OVERRIDE = 15
+REVIEW_FEATURES_OVERRIDE = 16
+REREVIEW_MANIFEST_CHANGE = 17
+REREVIEW_MANIFEST_URL_CHANGE = 18
+REREVIEW_PREMIUM_TYPE_UPGRADE = 19
+REREVIEW_DEVICES_ADDED = 20
+REREVIEW_FEATURES_CHANGED = 21
+REREVIEW_CONTENT_RATING_ADULT = 22
+ESCALATION_VIP_APP = 22
+ESCALATION_PRERELEASE_APP = 23
+PRIORITY_REVIEW_REQUESTED = 24
 
 NOTE_TYPES = {
     NO_ACTION: _('No action'),
@@ -43,6 +51,17 @@ NOTE_TYPES = {
     REREVIEW_CLEARED: _('Re-review cleared'),
     SUBMISSION: _('App submission notes'),
     DEVELOPER_COMMENT: _('Developer comment'),
+    REVIEW_DEVICE_OVERRIDE: _('Device(s) changed by reviewer'),
+    REVIEW_FEATURES_OVERRIDE: _('Requirement(s) changed by reviewer'),
+    REREVIEW_MANIFEST_CHANGE: _('Rereview due to Manifest Change'),
+    REREVIEW_MANIFEST_URL_CHANGE: _('Rereview due to Manifest URL Change'),
+    REREVIEW_PREMIUM_TYPE_UPGRADE: _('Rrereview due to Premium Type Upgrade'),
+    REREVIEW_DEVICES_ADDED: _('Rereview due to Devices Added'),
+    REREVIEW_FEATURES_CHANGED: _('Rereview due to Requirements Change'),
+    REREVIEW_CONTENT_RATING_ADULT: _('Rereview due to Adult Content Rating'),
+    ESCALATION_VIP_APP: _('Escalation due to VIP App'),
+    ESCALATION_PRERELEASE_APP: _('Escalation due to Prelease App'),
+    PRIORITY_REVIEW_REQUESTED: _('Priority review requested')
 }
 
 # Note types only visible by reviewers and not developers.
@@ -51,9 +70,17 @@ REVIEWER_NOTE_TYPES = (
     REVIEWER_COMMENT,
     ESCALATION_HIGH_ABUSE,
     ESCALATION_HIGH_REFUNDS,
-    ESCALATION_CLEARED
+    ESCALATION_CLEARED,
+    REREVIEW_MANIFEST_CHANGE,
+    REREVIEW_MANIFEST_URL_CHANGE,
+    REREVIEW_PREMIUM_TYPE_UPGRADE,
+    REREVIEW_DEVICES_ADDED,
+    REREVIEW_FEATURES_CHANGED,
+    REREVIEW_CONTENT_RATING_ADULT,
+    ESCALATION_VIP_APP,
+    ESCALATION_PRERELEASE_APP,
+    PRIORITY_REVIEW_REQUESTED
 )
-
 
 # Note types that can be created through the API view.
 API_NOTE_TYPE_WHITELIST = (
@@ -61,10 +88,6 @@ API_NOTE_TYPE_WHITELIST = (
     REVIEWER_COMMENT,
     DEVELOPER_COMMENT,
 )
-
-
-# Prefix of the reply to address in comm emails.
-REPLY_TO_PREFIX = 'commreply+'
 
 
 def U_NOTE_TYPES():
@@ -75,6 +98,8 @@ def U_NOTE_TYPES():
 def ACTION_MAP(activity_action):
     """Maps ActivityLog action ids to Commbadge note types."""
     import amo
+    if isinstance(activity_action, amo._LOG):
+        activity_action = activity_action.id
 
     return {
         amo.LOG.APPROVE_VERSION.id: APPROVAL,
@@ -91,4 +116,29 @@ def ACTION_MAP(activity_action):
         amo.LOG.REREVIEW_CLEARED.id: REREVIEW_CLEARED,
         amo.LOG.WEBAPP_RESUBMIT.id: RESUBMISSION,
         amo.LOG.COMMENT_VERSION.id: REVIEWER_COMMENT,
+        amo.LOG.REVIEW_FEATURES_OVERRIDE.id: REVIEW_FEATURES_OVERRIDE,
+        amo.LOG.REVIEW_DEVICE_OVERRIDE.id: REVIEW_DEVICE_OVERRIDE,
+        amo.LOG.REREVIEW_MANIFEST_CHANGE.id: REREVIEW_MANIFEST_CHANGE,
+        amo.LOG.REREVIEW_MANIFEST_URL_CHANGE.id: REREVIEW_MANIFEST_URL_CHANGE,
+        amo.LOG.REREVIEW_PREMIUM_TYPE_UPGRADE.id:
+            REREVIEW_PREMIUM_TYPE_UPGRADE,
+        amo.LOG.REREVIEW_DEVICES_ADDED.id: REREVIEW_DEVICES_ADDED,
+        amo.LOG.REREVIEW_FEATURES_CHANGED.id: REREVIEW_FEATURES_CHANGED,
+        amo.LOG.CONTENT_RATING_TO_ADULT.id:
+            REREVIEW_CONTENT_RATING_ADULT,
+        amo.LOG.ESCALATION_VIP_APP.id: ESCALATION_VIP_APP,
+        amo.LOG.ESCALATION_PRERELEASE_APP.id: ESCALATION_PRERELEASE_APP,
+        amo.LOG.PRIORITY_REVIEW_REQUESTED.id: PRIORITY_REVIEW_REQUESTED
     }.get(activity_action, NO_ACTION)
+
+
+# Number of days a token is valid for.
+THREAD_TOKEN_EXPIRY = 30
+
+# Number of times a token can be used.
+MAX_TOKEN_USE_COUNT = 5
+
+MAX_ATTACH = 10
+
+# Prefix of the reply to address in comm emails.
+REPLY_TO_PREFIX = 'commreply+'

--- a/mkt/developers/utils.py
+++ b/mkt/developers/utils.py
@@ -131,8 +131,8 @@ def escalate_app(app, version, user, msg, email_template, log_type):
     EscalationQueue.objects.get_or_create(addon=app)
 
     # Create comm note
-    create_comm_note(app, version, user, msg, note_type=comm.ESCALATION,
-                     perms={'developer': False})
+    create_comm_note(app, version, user, msg,
+                     note_type=comm.ACTION_MAP(log_type))
 
     # Log action
     amo.log(log_type, app, version, created=datetime.now(),

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -218,7 +218,7 @@ def status(request, addon_id, addon):
             form.save()
             create_comm_note(addon, addon.latest_version,
                              request.user, form.data['notes'],
-                             note_type=comm.RESUBMISSION, no_switch=True)
+                             note_type=comm.RESUBMISSION)
             if addon.vip_app:
                 handle_vip(addon, addon.current_version, request.user)
 

--- a/mkt/lookup/views.py
+++ b/mkt/lookup/views.py
@@ -243,7 +243,7 @@ def app_summary(request, addon_id):
         msg = u'Priority Review Requested'
         # Create notes and log entries.
         create_comm_note(app, app.latest_version, request.user, msg,
-                         note_type=comm.NO_ACTION)
+                         note_type=comm.PRIORITY_REVIEW_REQUESTED)
         amo.log(amo.LOG.PRIORITY_REVIEW_REQUESTED, app, app.latest_version,
                 created=datetime.now(), details={'comments': msg})
 

--- a/mkt/reviewers/models.py
+++ b/mkt/reviewers/models.py
@@ -9,7 +9,10 @@ import commonware.log
 import amo
 import amo.models
 from amo.utils import cache_ns_key
+
+import mkt.constants.comm as comm
 from mkt.access.models import Group
+from mkt.comm.utils import create_comm_note
 from mkt.developers.models import ActivityLog
 from mkt.translations.fields import save_signal, TranslatedField
 from mkt.users.models import UserProfile
@@ -353,6 +356,12 @@ class RereviewQueue(amo.models.ModelBase):
                     details={'comments': message})
         else:
             amo.log(event, addon, addon.current_version)
+
+        # TODO: if we ever get rid of ActivityLog for reviewer notes, replace
+        # all flag calls to use the comm constant and not have to use
+        # ACTION_MAP.
+        create_comm_note(addon, addon.current_version, None, message,
+                         note_type=comm.ACTION_MAP(event))
 
 
 def cleanup_queues(sender, instance, **kwargs):

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -35,6 +35,7 @@ from lib.crypto.tests import mock_sign
 from mkt.abuse.models import AbuseReport
 from mkt.access.models import Group, GroupUser
 from mkt.api.tests.test_oauth import RestOAuth
+from mkt.comm.models import CommunicationNote
 from mkt.comm.utils import create_comm_note
 from mkt.constants import comm, MANIFEST_CONTENT_TYPE
 from mkt.constants.features import FeatureProfile
@@ -1278,6 +1279,8 @@ class TestReviewApp(AppReviewerTest, AccessMixin, AttachmentManagementMixin,
         assert url in body, 'Could not find apps detail URL in %s' % msg
 
     def _check_log(self, action):
+        assert CommunicationNote.objects.filter(
+            note_type=comm.ACTION_MAP(action.id)).exists(), action
         assert AppLog.objects.filter(
             addon=self.app, activity_log__action=action.id).exists(), (
                 "Didn't find `%s` action in logs." % action.short)

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -107,16 +107,10 @@ class ReviewBase(object):
             details['files'] = [f.id for f in self.files]
 
         # Commbadge (the future).
-        perm_overrides = {
-            comm.ESCALATION: {'developer': False},
-            comm.REVIEWER_COMMENT: {'developer': False},
-        }
         note_type = comm.ACTION_MAP(action.id)
         self.comm_thread, self.comm_note = create_comm_note(
             self.addon, self.version, self.request.user,
             self.data['comments'], note_type=note_type,
-            # Ignore switch so we don't have to re-migrate new notes.
-            perms=perm_overrides.get(note_type), no_switch=True,
             attachments=self.attachment_formset)
 
         # ActivityLog (ye olde).

--- a/mkt/submit/forms.py
+++ b/mkt/submit/forms.py
@@ -349,7 +349,7 @@ class AppDetailsBasicForm(TranslationFormMixin, happyforms.ModelForm):
         if self.data['notes']:
             create_comm_note(self.instance, self.instance.versions.latest(),
                              self.request.user, self.data['notes'],
-                             note_type=comm.SUBMISSION, no_switch=True)
+                             note_type=comm.SUBMISSION)
         self.instance = super(AppDetailsBasicForm, self).save(commit=True)
         uses_flash = self.cleaned_data.get('flash')
         af = self.instance.get_latest_file()


### PR DESCRIPTION
Some new review log types were added while I wasn't lookin'.

Also ignore switches when creating any type comm notes.
