### PR TITLE
clearly show that 3 legged oauth is not required (bug 866176)

### DIFF
--- a/docs/api/topics/authentication.rst
+++ b/docs/api/topics/authentication.rst
@@ -14,7 +14,7 @@ Two options for authentication are available: shared-secret and OAuth.
 Shared Secret
 =============
 
-The Marketplace frontend uses a server-supplied token for authentication,
+The Marketplace front end uses a server-supplied token for authentication,
 stored as a cookie.
 
 .. http:post:: /api/v1/account/login/
@@ -76,24 +76,37 @@ OAuth
 =====
 
 Marketplace provides OAuth 1.0a, allowing third-party apps to interact with its
-API.
-
+API. It provides it in two flavours: 2-legged OAuth, designed for command line
+tools and 3-legged OAuth designed for web sites.
 
 See the `OAuth Guide <http://hueniverse.com/oauth/guide/>`_ and this `authentication flow diagram <http://oauth.net/core/diagram.png>`_ for an overview of OAuth concepts.
-The "Application Name" and "Redirect URI" fields are used by Marketplace when prompting users for authorization, allowing your application to make API requests on their behalf.
-"Application Name" should contain the name of your app, for Marketplace to show users when asking them for authorization.
-"Redirect URI" should contain the URI to redirect the user to, after the user grants access to your app (step D in the diagram linked above).
-These fields can be left blank if this key will only be used to access your own Marketplace account.
-When you are first developing your API to communicate with the Marketplace, you
-should use the development server to test your API.
 
-OAuth URLs
-----------
+Web sites
+---------
+
+Web sites that want to use the Marketplace API on behalf of a user should
+use the 3-legged flow to get an access token per user.
+
+When creating your API token, you should provide two extra fields used by the Marketplace when prompting users for authorization, allowing your application to make API requests on their behalf.
+
+* `Application Name` should contain the name of your app, for Marketplace to show users when asking them for authorization.
+* `Redirect URI` should contain the URI to redirect the user to, after the user grants access to your app (step D in the diagram linked above).
+
+The OAuth URLs on the Marketplace are:
 
  * The Temporary Credential Request URL path is `/oauth/register/`.
  * The Resource Owner Authorization URL path is `/oauth/authorize/`.
  * The Token Request URL path is `/oauth/token/`.
 
+Command-line tools
+------------------
+
+If you would like to use the Marketplace API from a command-line tool you don't
+need to set up the full 3 legged flow. In this case you just need to sign the
+request. Some discussion of this can be found `here <http://blog.nerdbank.net/2011/06/what-is-2-legged-oauth.html>`_.
+
+Once you've created an API key and secret you can use the key and secret in
+your command-line tools.
 
 Production server
 =================
@@ -147,5 +160,12 @@ a reason contained in the response. For example:
         .. code-block:: json
 
             {"reason": "Terms of service not accepted."}
+
+Example clients
+~~~~~~~~~~~~~~~
+
+* The `Marketplace.Python <https://github.com/mozilla/Marketplace.Python/>`_ library uses 2-legged OAuth to authenticate requests.
+
+* Curling is a command library to do requests using `Python <https://github.com/mozilla/Marketplace.Python/>`_.
 
 .. _`example marketplace client`: https://github.com/mozilla/Marketplace.Python

--- a/media/js/devreg/devhub.js
+++ b/media/js/devreg/devhub.js
@@ -31,6 +31,10 @@ $(document).ready(function() {
         initPayments();
     }
 
+    if ($('#submit-api').length) {
+        initAPI();
+    }
+
     // Submission process
     if ($('.addon-submission-process').length) {
         initLicenseFields();
@@ -898,6 +902,21 @@ function generateErrorList(o) {
         list.append($(format('<li>{0}</li>', v)));
     });
     return list;
+}
+
+
+function initAPI() {
+    // As the "Client type" changes, alter the form.
+    var leg = $('#id_oauth_leg');
+    var update = function update() {
+      if (leg.val() === 'command') {
+        $('tr.api-oauth-website').hide();
+      } else {
+        $('tr.api-oauth-website').show();
+      }
+    };
+    leg.on('change', update);
+    update();
 }
 
 

--- a/mkt/developers/forms.py
+++ b/mkt/developers/forms.py
@@ -898,7 +898,7 @@ class CategoryForm(happyforms.Form):
         self.product = kw.pop('product', None)
         super(CategoryForm, self).__init__(*args, **kw)
 
-        self.cats_before = (list(self.product.categories) 
+        self.cats_before = (list(self.product.categories)
                             if self.product.categories else [])
 
         self.initial['categories'] = self.cats_before
@@ -1012,13 +1012,22 @@ class TransactionFilterForm(happyforms.Form):
 
 
 class APIConsumerForm(happyforms.ModelForm):
-    app_name = forms.CharField(required=True)
-    redirect_uri = forms.CharField(validators=[URLValidator()],
-                                   required=True)
+    app_name = forms.CharField(required=False)
+    oauth_leg = forms.ChoiceField(choices=(
+        ('website', _lazy('Web site')),
+        ('command', _lazy('Command line')))
+    )
+    redirect_uri = forms.CharField(validators=[URLValidator()], required=False)
 
     class Meta:
         model = Access
         fields = ('app_name', 'redirect_uri')
+
+    def __init__(self, *args, **kwargs):
+        super(APIConsumerForm, self).__init__(*args, **kwargs)
+        if self.data.get('oauth_leg') == 'website':
+            for field in ['app_name', 'redirect_uri']:
+                self.fields[field].required = True
 
 
 class AppVersionForm(happyforms.ModelForm):

--- a/mkt/developers/templates/developers/api.html
+++ b/mkt/developers/templates/developers/api.html
@@ -1,5 +1,5 @@
 {% extends 'developers/base_impala.html' %}
-{% set title = _('API') %}
+{% set title = _('Marketplace API') %}
 
 {% block title %}{{ hub_page_title(title) }}{% endblock %}
 
@@ -22,8 +22,10 @@
       {% endif %}
       {% trans %}
         <p>
-          Please read the <a href="https://firefox-marketplace-api.readthedocs.org/en/latest/topics/authentication.html#oauth">documentation</a> on how to create a keypair and use it with the Marketplace API.
-          Any testing should occur on the development server and not the production server.
+          There are two main uses for the Marketplace API. From another web site
+          using a traditional OAuth flow or from a command line tool.
+
+          The difference is discussed in the  <a href="https://firefox-marketplace-api.readthedocs.org/en/latest/topics/authentication.html#oauth">Marketplace documentation</a>. Any testing should occur on the <a href="https://marketplace-dev.allizom.org">development server</a> and not the production server.
         </p>
       {% endtrans %}
       {% if not roles %}
@@ -32,9 +34,12 @@
           <table>
             <tbody>
               <tr>
+                <th><strong>{{ _('Client type') }}</strong></th><td>{{ form.oauth_leg.errors }}{{ form.oauth_leg }}</td>
+              </tr>
+              <tr class="api-oauth-website">
                 <th><strong>{{ _('Application Name') }}</strong></th><td>{{ form.app_name.errors }}{{ form.app_name }}</td>
               </tr>
-              <tr>
+              <tr class="api-oauth-website">
                 <th><strong>{{ _('Redirect URI') }}</strong></th><td>{{ form.redirect_uri.errors }}{{ form.redirect_uri }}</td>
               </tr>
             </tbody>
@@ -45,8 +50,9 @@
         </form>
       {% endif %}
     </div>
-    <div class="island devhub-form">
-      {% for consumer in consumers %}
+    <h3>{{ _('OAuth Keys') }}</h3>
+    {% for consumer in consumers %}
+      <div class="island devhub-form">
         <table>
           <tbody>
             <tr>
@@ -55,12 +61,16 @@
             <tr>
               <th><strong>{{ _('Secret') }}</strong></th><td><textarea readonly>{{ consumer.secret }}</textarea></td>
             </tr>
-            <tr>
-              <th><strong>{{ _('Application Name') }}</strong></th><td>{{ consumer.app_name }}</td>
-            </tr>
-            <tr>
-              <th><strong>{{ _('Redirect URI') }}</strong></th><td>{{ consumer.redirect_uri }}</td>
-            </tr>
+            {% if consumer.app_name %}
+              <tr>
+                <th><strong>{{ _('Application Name') }}</strong></th><td>{{ consumer.app_name }}</td>
+              </tr>
+            {% endif %}
+            {% if consumer.redirect_uri %}
+              <tr>
+                <th><strong>{{ _('Redirect URI') }}</strong></th><td>{{ consumer.redirect_uri }}</td>
+              </tr>
+            {% endif %}
           </tbody>
          </table>
          <div class="listing-footer">
@@ -70,9 +80,25 @@
              <button name="delete" class="cancel" value="delete">{{ _('Delete') }}</button>
            </form>
          </div>
-      {% else %}
+      </div>
+    {% else %}
+      <div class="island devhub-form">
         <p><strong>{{ _('You currently do not have an API key.') }}</strong></p>
-      {% endfor %}
-     </div>
+      </div>
+    {% endfor %}
+    {% if consumers %}
+      <h3>{{ _('OAuth Example') }}</h3>
+      <div class="island devhub-form">
+        {% trans %}
+          <p>Example using a Python library for the command-line on Mac OS X using
+          your OAuth credentials:</p>
+        {% endtrans %}
+        <pre>
+pip install curling
+echo '{"{{ settings.DOMAIN }}": {"key": "{{ consumers[0].key }}", "secret": "{{ consumers[0].secret }}"}}' > .curling
+curling {{ settings.SITE_URL }}/api/v1/settings/mine/
+        </pre>
+      </div>
+    {% endif %}
   </section>
 {% endblock %}

--- a/mkt/developers/templates/developers/nav.html
+++ b/mkt/developers/templates/developers/nav.html
@@ -6,10 +6,10 @@
           <a href="{{ url('ecosystem.landing')|urlparams(src='nav') }}">{{ _('Documentation') }}</a>
         </li>
         <li class="slim">
-          <a href="{{ url('mkt.developers.apps.api')|urlparams(src='nav') }}">{{ _('API') }}</a>
+          <a href="{{ url('mkt.developers.validate_app')|urlparams(src='nav') }}">{{ _('Testing Apps') }}</a>
         </li>
         <li class="slim">
-          <a href="{{ url('mkt.developers.validate_app')|urlparams(src='nav') }}">{{ _('Testing Apps') }}</a>
+          <a href="{{ url('mkt.developers.apps.api')|urlparams(src='nav') }}">{{ _('Marketplace API') }}</a>
         </li>
       </ul>
     </nav>

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -725,3 +725,39 @@ class TestIARCGetAppInfoForm(amo.tests.WebappTestCase):
         assert form.is_valid(), form.errors
         with self.assertRaises(django_forms.ValidationError):
             form.save()
+
+
+class TestAPIForm(amo.tests.WebappTestCase):
+
+    def setUp(self):
+        super(TestAPIForm, self).setUp()
+        self.form = forms.APIConsumerForm
+
+    def test_non_url(self):
+        form = self.form({
+            'app_name': 'test',
+            'redirect_uri': 'mailto:cvan@example.com',
+            'oauth_leg': 'website'
+        })
+        assert not form.is_valid()
+        eq_(form.errors['redirect_uri'], ['Enter a valid URL.'])
+
+    def test_non_app_name(self):
+        form = self.form({
+            'redirect_uri': 'mailto:cvan@example.com',
+            'oauth_leg': 'website'
+        })
+        assert not form.is_valid()
+        eq_(form.errors['app_name'], ['This field is required.'])
+
+    def test_command(self):
+        form = self.form({'oauth_leg': 'command'})
+        assert form.is_valid()
+
+    def test_website(self):
+        form = self.form({
+            'app_name': 'test',
+            'redirect_uri': 'https://f.com',
+            'oauth_leg': 'website'
+        })
+        assert form.is_valid()

--- a/mkt/developers/tests/test_views_api.py
+++ b/mkt/developers/tests/test_views_api.py
@@ -31,18 +31,12 @@ class TestAPI(amo.tests.TestCase):
         self.client.logout()
         self.assertLoginRequired(self.client.get(self.url))
 
-    def test_non_url(self):
-        res = self.client.post(
-            self.url,
-            {'app_name': 'test', 'redirect_uri': 'mailto:cvan@example.com'})
-        self.assertFormError(res, 'form', 'redirect_uri',
-                             ['Enter a valid URL.'])
-
     def test_create(self):
         Access.objects.create(user=self.user, key='foo', secret='bar')
         res = self.client.post(
             self.url,
-            {'app_name': 'test', 'redirect_uri': 'https://example.com/myapp'})
+            {'app_name': 'test', 'redirect_uri': 'https://example.com/myapp',
+             'oauth_leg': 'website'})
         self.assertNoFormErrors(res)
         eq_(res.status_code, 200)
         consumers = Access.objects.filter(user=self.user)
@@ -60,14 +54,6 @@ class TestAPI(amo.tests.TestCase):
         res = self.client.post(self.url)
         eq_(res.status_code, 200)
         eq_(Access.objects.filter(user=self.user).count(), 0)
-
-    def test_other(self):
-        self.grant_permission(self.profile, 'What:ever')
-        res = self.client.post(
-            self.url,
-            {'app_name': 'test', 'redirect_uri': 'http://example.com/myapp'})
-        eq_(res.status_code, 200)
-        eq_(Access.objects.filter(user=self.user).count(), 1)
 
 
 class TestContentRating(amo.tests.TestCase):

--- a/mkt/developers/utils.py
+++ b/mkt/developers/utils.py
@@ -1,4 +1,3 @@
-import json
 import os
 import uuid
 from datetime import datetime

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -992,7 +992,7 @@ def terms(request):
 @login_required
 def api(request):
     roles = request.user.groups.filter(name='Admins').exists()
-    f = APIConsumerForm()
+    form = APIConsumerForm()
     if roles:
         messages.error(request,
                        _('Users with the admin role cannot use the API.'))
@@ -1012,15 +1012,16 @@ def api(request):
             access = Access.objects.create(key=key,
                                            user=request.user,
                                            secret=generate())
-            f = APIConsumerForm(request.POST, instance=access)
-            if f.is_valid():
-                f.save()
+            form = APIConsumerForm(request.POST, instance=access)
+            if form.is_valid():
+                form.save()
                 messages.success(request, _('New API key generated.'))
             else:
                 access.delete()
     consumers = list(Access.objects.filter(user=request.user))
     return render(request, 'developers/api.html',
-                  {'consumers': consumers, 'roles': roles, 'form': f})
+                  {'consumers': consumers, 'roles': roles, 'form': form,
+                   'domain': settings.DOMAIN, 'site_url': settings.SITE_URL})
 
 
 @app_view


### PR DESCRIPTION
- add in a clear way for a user landing on the API page to distinguish between 2 and 3 legged oauth
- give a clear example that you can copy and paste right away
