### PR TITLE
Putting back link to Submit A New App (bug 1042942)

### DIFF
--- a/mkt/developers/templates/developers/nav.html
+++ b/mkt/developers/templates/developers/nav.html
@@ -11,6 +11,9 @@
         <li class="slim">
           <a href="{{ url('mkt.developers.apps.api')|urlparams(src='nav') }}">{{ _('Marketplace API') }}</a>
         </li>
+        <li id="submit-app" class="slim">
+          <a href="{{ url('submit.app')|urlparams(src='nav') }}">{{ _('Submit a New App') }}</a>
+        </li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
Took this out as part of #2329, but that may have been going too far. Putting it back where I found it now.
