### PR TITLE
Removed `send_new_region_emails` from migration

### DIFF
--- a/migrations/826-add-bd-region.py
+++ b/migrations/826-add-bd-region.py
@@ -1,7 +1,6 @@
 from mkt.constants import regions
-from mkt.developers.cron import exclude_new_region, send_new_region_emails
+from mkt.developers.cron import exclude_new_region
 
 
 def run():
     exclude_new_region([regions.BD])
-    send_new_region_emails([regions.BD])


### PR DESCRIPTION
We will run this on prod only manually.
