### PR TITLE
slim down the serializers for the actual feed (fireplace home page)

### DIFF
--- a/mkt/feed/constants.py
+++ b/mkt/feed/constants.py
@@ -103,3 +103,8 @@ FEED_TYPE_APP = 'app'
 FEED_TYPE_BRAND = 'brand'
 FEED_TYPE_COLL = 'collection'
 FEED_TYPE_SHELF = 'shelf'
+
+# Number of apps we need to deserialize for the homepage/actual feed.
+HOME_NUM_APPS_BRAND = 6
+HOME_NUM_APPS_COLL = 3
+HOME_NUM_APPS_SHELF = 0

--- a/mkt/feed/tests/test_fields.py
+++ b/mkt/feed/tests/test_fields.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from nose.tools import eq_
+
+import amo.tests
+
+import mkt.feed.constants as feed
+from mkt.feed.fields import AppESField
+from mkt.feed.tests.test_models import FeedTestMixin
+from mkt.webapps.indexers import WebappIndexer
+
+
+class TestAppESField(amo.tests.TestCase):
+
+    def test_deserialize_single(self):
+        app = amo.tests.app_factory(description={'en-US': 'lol'})
+        app_map = {app.id: app.get_indexer().extract_document(app.id)}
+        field = AppESField(source='app')
+        field.context = {'app_map': app_map,
+                         'request': amo.tests.req_factory_factory('')}
+        data = field.to_native(app.id)
+
+        eq_(data['id'], app.id)
+        eq_(data['slug'], app.app_slug)
+        eq_(data['description'], {'en-US': 'lol'})
+
+    def test_deserialize_multi(self):
+        apps = [amo.tests.app_factory(), amo.tests.app_factory()]
+        app_map = dict((app.id, app.get_indexer().extract_document(app.id))
+                       for app in apps)
+        field = AppESField(many=True)
+        field.context = {'app_map': app_map,
+                         'request': amo.tests.req_factory_factory('')}
+        data = field.to_native([app.id for app in apps])
+
+        eq_(len(data), 2)
+        eq_(data[0]['id'], apps[0].id)
+        eq_(data[1]['id'], apps[1].id)
+
+    def test_deserialize_limit(self):
+        apps = [amo.tests.app_factory(), amo.tests.app_factory()]
+        app_map = dict((app.id, app.get_indexer().extract_document(app.id))
+                       for app in apps)
+        field = AppESField(many=True, limit=1)
+        field.context = {'app_map': app_map,
+                         'request': amo.tests.req_factory_factory('')}
+        data = field.to_native([app.id for app in apps])
+
+        eq_(len(data), 1)
+        eq_(data[0]['id'], apps[0].id)
+
+        field.limit = 0
+        data = field.to_native([app.id for app in apps])
+        eq_(len(data), 0)

--- a/mkt/feed/tests/test_serializers.py
+++ b/mkt/feed/tests/test_serializers.py
@@ -353,5 +353,5 @@ class TestFeedItemESSerializer(FeedTestMixin, amo.tests.TestCase):
         eq_(data[2]['collection']['apps'][0]['id'],
             self.feed[2].collection.apps()[0].id)
 
-        eq_(data[3]['shelf']['apps'][0]['id'],
-            self.feed[3].shelf.apps()[0].id)
+        assert data[3]['shelf']['carrier']
+        assert data[3]['shelf']['region']

--- a/mkt/feed/tests/test_views.py
+++ b/mkt/feed/tests/test_views.py
@@ -1155,6 +1155,9 @@ class TestFeedView(BaseTestFeedESView, BaseTestFeedItemViewSet):
             if feed_elm.get('app'):
                 ok_(feed_elm['app']['id'])
             else:
+                if feed_item['item_type'] == feed.FEED_TYPE_SHELF:
+                    # Shelves don't display app data on feed.
+                    continue
                 ok_(len(feed_elm['apps']))
                 for app in feed_elm['apps']:
                     ok_(app['id'])

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -524,6 +524,40 @@ class ESAppSerializer(BaseESSerializer, AppSerializer):
         return obj.es_data['tags']
 
 
+class BaseESAppFeedSerializer(ESAppSerializer):
+    icons = serializers.SerializerMethodField('get_icons')
+
+    def get_icons(self, obj):
+        """Only need the 64px icon."""
+        return {
+            '64': obj.get_icon_url(64)
+        }
+
+
+class ESAppFeedSerializer(BaseESAppFeedSerializer):
+    """
+    App serializer targetted towards the Feed, Fireplace's homepage.
+    Specifically for Feed Apps, Collections, Shelves that only need app icons.
+    """
+    class Meta(ESAppSerializer.Meta):
+        fields = [
+            'icons', 'id', 'slug'
+        ]
+
+
+class ESAppFeedBrandSerializer(BaseESAppFeedSerializer):
+    """
+    App serializer targetted towards the Feed, Fireplace's homepage.
+    Specifically for Feed Brands that feature the whole app tile rather than
+    just an icon.
+    """
+    class Meta(ESAppSerializer.Meta):
+        fields = [
+            'content_ratings', 'icons', 'id', 'is_packaged', 'manifest_url',
+            'name', 'ratings', 'slug'
+        ]
+
+
 class SimpleAppSerializer(AppSerializer):
     """
     App serializer with fewer fields (and fewer db queries as a result).
@@ -539,7 +573,6 @@ class SimpleAppSerializer(AppSerializer):
 
 
 class SimpleESAppSerializer(ESAppSerializer):
-
     class Meta(SimpleAppSerializer.Meta):
         pass
 


### PR DESCRIPTION
For the  feed page:
- feedapps only need 1 app icon
- brands only need 6 apps with just basic metadata
- collections only need 3 app icons
- shelves don't need any apps
