### PR TITLE
Allow anonymous users to subscribe to the newsletter API (bug 1046888)

### DIFF
--- a/docs/api/topics/accounts.rst
+++ b/docs/api/topics/accounts.rst
@@ -149,10 +149,14 @@ Feedback
 Newsletter signup
 =================
 
-This resource requests that the current user be subscribed to the
-Marketplace newsletter.
-
 .. http:post:: /api/v1/account/newsletter/
+
+    This resource requests that the email passed in the request parameters be
+    subscribed to the Marketplace newsletter.
+
+    .. note:: Authentication is optional.
+
+    .. note:: This endpoint is rate-limited at 30 requests per hour per user/IP.
 
    **Request**
 
@@ -162,3 +166,4 @@ Marketplace newsletter.
    **Response**
 
    :status 204: Successfully signed up.
+   :status 429: exceeded rate limit.

--- a/mkt/account/tests/test_views.py
+++ b/mkt/account/tests/test_views.py
@@ -653,9 +653,12 @@ class TestNewsletter(RestOAuth):
 
     @patch('basket.subscribe')
     def test_signup_anonymous(self, subscribe):
-        res = self.anon.post(self.url)
-        eq_(res.status_code, 403)
-        ok_(not subscribe.called)
+        res = self.anon.post(self.url,
+                               data=json.dumps({'email': 'bob@example.com'}))
+        eq_(res.status_code, 204)
+        subscribe.assert_called_with(
+            'bob@example.com', 'marketplace', lang='en-US',
+            country='restofworld', trigger_welcome='Y', optin='Y', format='H')
 
     @patch('basket.subscribe')
     def test_signup(self, subscribe):

--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -74,7 +74,7 @@ class InstalledView(CORSMixin, MarketplaceView, ListAPIView):
                 '-installed__created')
 
 
-class CreateAPIViewWithoutModel(CreateAPIView):
+class CreateAPIViewWithoutModel(MarketplaceView, CreateAPIView):
     """
     A base class for APIs that need to support a create-like action, but
     without being tied to a Django Model.
@@ -250,8 +250,14 @@ class LogoutView(CORSMixin, DestroyAPIView):
 
 
 class NewsletterView(CORSMixin, CreateAPIViewWithoutModel):
-    permission_classes = (IsAuthenticated,)
+    class NewsletterThrottle(UserRateThrottle):
+        scope = 'newsletter'
+        THROTTLE_RATES = {
+            'newsletter': '30/hour',
+        }
+
     serializer_class = NewsletterSerializer
+    throttle_classes = (NewsletterThrottle,)
 
     def response_success(self, request, serializer, data=None):
         return Response({}, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1046888

For about:apps we are going to let anonymous users subscribe to the newsletter. Since the API already required an email to be passed (without forcing it to be the same as the email on the current user account) we just need to change the permission class.
