### PR TITLE
Cleanup current_version and latest_version

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -723,8 +723,8 @@ def addon_factory(status=amo.STATUS_PUBLIC, version_kw={}, file_kw={}, **kw):
     # Save 1.
     a = Addon.objects.create(type=type_, **kwargs)
     version = version_factory(file_kw, addon=a, **version_kw)  # Save 2.
-    a.update_version()
     a.status = status
+    a.update_version()
 
     # Put signals back.
     post_save.connect(app_update_search_index, sender=Webapp,

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -306,12 +306,16 @@ class TestAppCreateHandler(CreateHandler, AMOPaths):
     def test_dehydrate(self):
         app = self.create_app()
         res = self.client.put(self.get_url, data=json.dumps(self.base_data()))
+        app = app.reload()
+        version = app.current_version
+
         eq_(res.status_code, 202)
         res = self.client.get(self.get_url + '?lang=en')
         eq_(res.status_code, 200)
         data = json.loads(res.content)
-        eq_(set(app.reload().categories), set(data['categories']))
-        eq_(data['current_version'], app.current_version.version)
+
+        eq_(set(app.categories), set(data['categories']))
+        eq_(data['current_version'], version and version.version)
         self.assertSetEqual(data['device_types'],
                             [n.api_name for n in amo.DEVICE_TYPES.values()])
         eq_(data['homepage'], u'http://www.whatever.com')

--- a/mkt/comm/tests/test_commands.py
+++ b/mkt/comm/tests/test_commands.py
@@ -16,7 +16,7 @@ class TestMigrateActivityLog(amo.tests.TestCase):
 
     def setUp(self):
         self.app = amo.tests.app_factory(status=amo.STATUS_PENDING)
-        self.version = self.app.current_version
+        self.version = self.app.latest_version
         self.user = UserProfile.objects.get()
 
     def _assert(self, cmb_action):

--- a/mkt/constants/base.py
+++ b/mkt/constants/base.py
@@ -75,21 +75,18 @@ PUBLISH_PRIVATE = 2
 REVIEWED_STATUSES = (STATUS_PUBLIC, STATUS_APPROVED)
 UNREVIEWED_STATUSES = (STATUS_PENDING,)
 VALID_STATUSES = (STATUS_PENDING, STATUS_PUBLIC, STATUS_APPROVED)
-# We don't show addons/versions with UNREVIEWED_STATUS in public.
-LISTED_STATUSES = tuple(st for st in VALID_STATUSES
-                        if st not in (STATUS_PENDING, STATUS_APPROVED))
-
-# An addon in one of these statuses is awaiting a review.
-STATUS_UNDER_REVIEW = (STATUS_PENDING,)
+# LISTED_STATUSES are statuses that should return a 200 on the app detail page
+# for anonymous users.
+LISTED_STATUSES = (STATUS_PUBLIC,)
 
 # An add-on in one of these statuses can become premium.
-PREMIUM_STATUSES = (STATUS_NULL,) + STATUS_UNDER_REVIEW
+PREMIUM_STATUSES = (STATUS_NULL, STATUS_PENDING)
 
 # Newly submitted apps begin life at this status.
 WEBAPPS_UNREVIEWED_STATUS = STATUS_PENDING
 
 # These apps have been approved and are listed; or could be without further
-# review
+# review.
 WEBAPPS_APPROVED_STATUSES = (STATUS_PUBLIC, STATUS_APPROVED)
 
 # An app with this status makes its detail page "invisible".

--- a/mkt/detail/tests/test_views.py
+++ b/mkt/detail/tests/test_views.py
@@ -17,24 +17,25 @@ from mkt.site.fixtures import fixture
 
 
 class TestPackagedManifest(amo.tests.TestCase):
-    fixtures = ['base/users'] + fixture('webapp_337141')
+    fixtures = fixture('webapp_337141', 'group_editor', 'user_editor',
+                       'user_editor_group')
 
     def setUp(self):
         self.app = Webapp.objects.get(pk=337141)
         self.app.update(is_packaged=True)
         # Create a fake package to go along with the app.
-        latest_file = self.app.get_latest_file()
-        with storage.open(latest_file.file_path,
+        self.latest_file = self.app.get_latest_file()
+        with storage.open(self.latest_file.file_path,
                           mode='w') as package:
             test_package = zipfile.ZipFile(package, 'w')
             test_package.writestr('manifest.webapp', 'foobar')
             test_package.close()
-            latest_file.update(hash=latest_file.generate_hash())
+            self.latest_file.update(hash=self.latest_file.generate_hash())
 
         self.url = self.app.get_manifest_url()
 
     def tearDown(self):
-        storage.delete(self.app.get_latest_file().file_path)
+        storage.delete(self.latest_file.file_path)
 
     def get_digest_from_manifest(self, manifest=None):
         if manifest is None:

--- a/mkt/developers/templates/developers/apps/edit/basic.html
+++ b/mkt/developers/templates/developers/apps/edit/basic.html
@@ -135,7 +135,7 @@
                 {{ some_html_tip() }}
               {% else %}
                 <div id="addon-releasenotes" class="prose">
-                  {{ addon.current_version|all_locales('releasenotes', nl2br=True, prettify_empty=True) }}
+                  {{ version|all_locales('releasenotes', nl2br=True, prettify_empty=True) }}
                 </div>
               {% endif %}
             </td>

--- a/mkt/developers/templates/developers/apps/listing/items.html
+++ b/mkt/developers/templates/developers/apps/listing/items.html
@@ -33,7 +33,7 @@
               <strong>{{ _('Packaged App Version:') }}</strong>
               {{ addon.current_version }}
             </li>
-            {% if addon.current_version != addon.latest_version %}
+            {% if addon.is_pending() or addon.current_version != addon.latest_version %}
               <li class="item-latest-version">
                 <strong>{{ _('Pending Version:') }}</strong>
                 {{ addon.latest_version }}

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -514,7 +514,7 @@ class TestAppVersionForm(amo.tests.TestCase):
     def test_post_publish_not_pending(self):
         # Using the current_version, which is public.
         form = self._get_form(self.app.current_version,
-                             data={'publish_immediately': False})
+                              data={'publish_immediately': False})
         eq_(form.is_valid(), True)
         form.save()
         self.app.reload()

--- a/mkt/developers/tests/test_views_api.py
+++ b/mkt/developers/tests/test_views_api.py
@@ -206,7 +206,8 @@ class TestContentRatingPingback(RestOAuth):
                     {
                         'TYPE': 'string',
                         'NAME': 'interactive_elements',
-                        'VALUE': 'Shares Info,Shares Location,Digital Purchases,Users Interact'
+                        'VALUE': ('Shares Info,Shares Location,'
+                                  'Digital Purchases,Users Interact')
                     }
                 ]
             }
@@ -270,7 +271,7 @@ class TestContentRatingPingback(RestOAuth):
              'has_digital_purchases', 'has_users_interact'])
 
         eq_(app.status, amo.STATUS_PENDING)
-        assert app.current_version.nomination
+        assert app.latest_version.nomination
 
     @override_settings(SECRET_KEY='foo')
     def test_token_mismatch(self):

--- a/mkt/developers/tests/test_views_edit.py
+++ b/mkt/developers/tests/test_views_edit.py
@@ -517,7 +517,7 @@ class TestEditBasic(TestEdit):
         self.webapp.save()
         data = self.get_dict(releasenotes=u'I can hâz release notes')
         res = self.client.post(self.edit_url, data)
-        releasenotes = self.webapp.current_version.reload().releasenotes
+        releasenotes = self.webapp.reload().latest_version.releasenotes
         eq_(res.status_code, 200)
         eq_(releasenotes, data['releasenotes'])
         # Make sure publish_type wasn't reset by accident.
@@ -570,7 +570,7 @@ class TestEditCountryLanguage(TestEdit):
         for c in countries.split(', '):
             clean_countries.append(strip_whitespace(c))
 
-        ## eq_(langs, u'English (US) (default), Deutsch, Espa\xf1ol')
+        # eq_(langs, u'English (US) (default), Deutsch, Espa\xf1ol')
         # XXX The above line is correct. But if Jenkins is wrong, I
         # don't wanna be right.
         eq_(langs, u'English (US) (default), Deutsch, Espa\xc3\xb1ol')

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -220,7 +220,7 @@ def status(request, addon_id, addon):
                              request.user, form.data['notes'],
                              note_type=comm.RESUBMISSION)
             if addon.vip_app:
-                handle_vip(addon, addon.current_version, request.user)
+                handle_vip(addon, addon.latest_version, request.user)
 
             messages.success(request, _('App successfully resubmitted.'))
             return redirect(addon.get_dev_url('versions'))
@@ -468,8 +468,8 @@ def version_edit(request, addon_id, addon, version_id):
         [f.save() for f in all_forms]
 
         if f.data.get('approvalnotes'):
-            create_comm_note(addon, addon.current_version,
-                             request.user, f.data['approvalnotes'],
+            create_comm_note(addon, version, request.user,
+                             f.data['approvalnotes'],
                              note_type=comm.REVIEWER_COMMENT)
 
         messages.success(request, _('Version successfully edited.'))

--- a/mkt/ratings/tests/test_views.py
+++ b/mkt/ratings/tests/test_views.py
@@ -290,12 +290,13 @@ class TestRatingResource(RestOAuth, amo.tests.AMOPaths):
         assert data['user']['can_rate']
         assert not data['user']['has_rated']
 
-    def _create(self, data=None, anonymous=False):
+    def _create(self, data=None, anonymous=False, version=None):
+        version = version or self.app.current_version
         default_data = {
             'app': self.app.id,
             'body': 'Rocking the free web.',
             'rating': 5,
-            'version': self.app.current_version.id
+            'version': version.id
         }
         if data:
             default_data.update(data)
@@ -356,7 +357,7 @@ class TestRatingResource(RestOAuth, amo.tests.AMOPaths):
 
     def test_create_for_nonpublic(self):
         self.app.update(status=amo.STATUS_PENDING)
-        res, data = self._create()
+        res, data = self._create(version=self.app.latest_version)
         eq_(403, res.status_code)
 
     def test_create_duplicate_rating(self):

--- a/mkt/reviewers/models.py
+++ b/mkt/reviewers/models.py
@@ -8,12 +8,9 @@ import commonware.log
 
 import amo
 import amo.models
-from amo.utils import cache_ns_key
-
 import mkt.constants.comm as comm
-from mkt.access.models import Group
+from amo.utils import cache_ns_key
 from mkt.comm.utils import create_comm_note
-from mkt.developers.models import ActivityLog
 from mkt.translations.fields import save_signal, TranslatedField
 from mkt.users.models import UserProfile
 from mkt.webapps.models import Addon
@@ -83,13 +80,13 @@ class ReviewerScore(amo.models.ModelBase):
 
         """
         if addon.is_packaged:
-            if status == amo.STATUS_PUBLIC:
+            if status in amo.WEBAPPS_APPROVED_STATUSES:
                 return amo.REVIEWED_WEBAPP_UPDATE
             else:  # If it's not PUBLIC, assume it's a new submission.
                 return amo.REVIEWED_WEBAPP_PACKAGED
         else:  # It's a hosted app.
             in_rereview = kwargs.pop('in_rereview', False)
-            if status == amo.STATUS_PUBLIC and in_rereview:
+            if status in amo.WEBAPPS_APPROVED_STATUSES and in_rereview:
                 return amo.REVIEWED_WEBAPP_REREVIEW
             else:
                 return amo.REVIEWED_WEBAPP_HOSTED

--- a/mkt/reviewers/templates/reviewers/includes/macros.html
+++ b/mkt/reviewers/templates/reviewers/includes/macros.html
@@ -86,10 +86,10 @@
     <div class="sprite-reviewer sprite-reviewer-premium" title="{{ _('Premium App') }}"></div>
   {% endif %}
 
-  {% if app.current_version.has_info_request %}
+  {% if app.latest_version.has_info_request %}
     <div class="sprite-reviewer sprite-reviewer-info" title="{{ _('More Information Requested') }}"></div>
   {% endif %}
-  {% if app.current_version.has_editor_comment %}
+  {% if app.latest_version.has_editor_comment %}
     <div class="sprite-reviewer sprite-reviewer-editor" title="{{ _('Contains Editor Comment') }}"></div>
   {% endif %}
 {% endmacro %}

--- a/mkt/reviewers/tests/test_views_api.py
+++ b/mkt/reviewers/tests/test_views_api.py
@@ -248,7 +248,7 @@ class TestApiReviewer(RestOAuth, ESTestCase):
         qs = {'q': 'something', 'pro': feature_profile, 'dev': 'firefoxos'}
 
         # Enable an app feature that doesn't match one in our profile.
-        self.webapp.current_version.features.update(has_pay=True)
+        self.webapp.latest_version.features.update(has_pay=True)
         self.webapp.save()
         self.refresh('webapp')
 
@@ -259,9 +259,7 @@ class TestApiReviewer(RestOAuth, ESTestCase):
         eq_(obj['slug'], self.webapp.app_slug)
 
     def test_no_flash_filtering(self):
-        f = self.webapp.get_latest_file()
-        f.uses_flash = True
-        f.save()
+        self.webapp.latest_version.all_files[0].update(uses_flash=True)
         self.webapp.save()
         self.refresh('webapp')
         res = self.client.get(self.url, {'dev': 'firefoxos'})

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -640,7 +640,7 @@ def device_queue_search(request):
     if sig:
         profile = FeatureProfile.from_signature(sig)
         filters.update(dict(
-            **profile.to_kwargs(prefix='_current_version__features__has_')
+            **profile.to_kwargs(prefix='_latest_version__features__has_')
         ))
     return Webapp.version_and_file_transformer(
         Webapp.objects.filter(**filters))

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -87,7 +87,7 @@ log = commonware.log.getLogger('z.reviewers')
 def log_reviewer_action(addon, user, msg, action):
     create_comm_note(addon, addon.current_version, user, msg,
                      note_type=comm.ACTION_MAP(action.id))
-    amo.log(action, addon, addon.current_version, details={'comments': msg})
+    amo.log(action, addon, addon.latest_version, details={'comments': msg})
 
 
 def reviewer_required(region=None):

--- a/mkt/submit/views.py
+++ b/mkt/submit/views.py
@@ -113,7 +113,7 @@ def manifest(request):
             if form.is_packaged():
                 validation = json.loads(upload.validation)
                 escalate_prerelease_permissions(
-                    addon, validation, addon.current_version)
+                    addon, validation, addon.latest_version)
 
             # Set the device type.
             for device in form.get_devices():
@@ -138,11 +138,11 @@ def manifest(request):
                                                   manifest=True, details=False)
 
             # Create feature profile.
-            addon.current_version.features.update(**features_form.cleaned_data)
+            addon.latest_version.features.update(**features_form.cleaned_data)
 
         # Call task outside of `commit_on_success` to avoid it running before
         # the transaction is committed and not finding the app.
-        tasks.fetch_icon.delay(addon)
+        tasks.fetch_icon.delay(addon, addon.latest_version.all_files[0])
 
         return redirect('submit.app.details', addon.app_slug)
 

--- a/mkt/users/tests/test_models.py
+++ b/mkt/users/tests/test_models.py
@@ -61,7 +61,7 @@ class TestUserProfile(amo.tests.TestCase):
         """
         addon = Webapp.objects.get(id=337141)
         u = UserProfile.objects.get(pk=999)
-        version = addon.get_version()
+        version = addon.current_version
         new_review = Review(version=version, user=u, rating=2, body='hello',
                             addon=addon)
         new_review.save()

--- a/mkt/webapps/tests/test_crons.py
+++ b/mkt/webapps/tests/test_crons.py
@@ -215,7 +215,7 @@ class TestSignApps(amo.tests.TestCase):
     fixtures = fixture('webapp_337141')
 
     def setUp(self):
-        self.app = Addon.objects.get(id=337141)
+        self.app = Webapp.objects.get(id=337141)
         self.app.update(is_packaged=True)
         self.app2 = amo.tests.app_factory(
             name=u'Mozillaball ょ', app_slug='test',
@@ -227,15 +227,15 @@ class TestSignApps(amo.tests.TestCase):
                                           'created': None})
 
     def test_by_webapp(self, sign_mock):
-        v1 = self.app.get_version()
+        v1 = self.app.current_version
         call_command('sign_apps', webapps=str(v1.pk))
         file1 = v1.all_files[0]
         assert sign_mock.called_with(((file1.file_path,
                                        file1.signed_file_path),))
 
     def test_all(self, sign_mock):
-        v1 = self.app.get_version()
-        v2 = self.app2.get_version()
+        v1 = self.app.current_version
+        v2 = self.app2.current_version
         call_command('sign_apps')
         file1 = v1.all_files[0]
         file2 = v2.all_files[0]

--- a/mkt/webapps/tests/test_tasks.py
+++ b/mkt/webapps/tests/test_tasks.py
@@ -100,7 +100,7 @@ class TestUpdateManifest(amo.tests.TestCase):
 
         # Not using app factory since it creates translations with an invalid
         # locale of "en-us".
-        self.addon = Addon.objects.create(type=amo.ADDON_WEBAPP)
+        self.addon = Webapp.objects.create()
         self.version = Version.objects.create(addon=self.addon,
                                               _developer_name='Mozilla')
         self.file = File.objects.create(
@@ -114,6 +114,8 @@ class TestUpdateManifest(amo.tests.TestCase):
         self.addon.status = amo.STATUS_PUBLIC
         self.addon.manifest_url = 'http://nowhere.allizom.org/manifest.webapp'
         self.addon.save()
+
+        self.addon.update_version()
 
         self.addon.addonuser_set.create(user_id=999)
 
@@ -161,7 +163,7 @@ class TestUpdateManifest(amo.tests.TestCase):
         old_file = self.addon.get_latest_file()
         self._run()
 
-        app = Webapp.objects.get(pk=self.addon.pk)
+        app = self.addon.reload()
         version = app.current_version
         file_ = app.get_latest_file()
 
@@ -184,7 +186,7 @@ class TestUpdateManifest(amo.tests.TestCase):
         self._hash = 'foo'
         self._run()
 
-        app = Webapp.objects.get(pk=self.addon.pk)
+        app = self.addon.reload()
         eq_(app.versions.latest().version, '1.1')
 
     def test_not_log(self):

--- a/mkt/webapps/views.py
+++ b/mkt/webapps/views.py
@@ -155,7 +155,7 @@ class AppViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
         # Create app, user and fetch the icon.
         obj = Webapp.from_upload(upload, plats, is_packaged=is_packaged)
         AddonUser(addon=obj, user=request.user).save()
-        tasks.fetch_icon.delay(obj)
+        tasks.fetch_icon.delay(obj, obj.latest_version.all_files[0])
         record_action('app-submitted', request, {'app-id': obj.pk})
 
         log.info('App created: %s' % obj.pk)


### PR DESCRIPTION
This updates the logic so that only apps with a status in
`amo.WEBAPPS_APPROVED_STATUSES` have a `current_version` since a
`current_version` signifies the publicly available version of an app.
