### PR TITLE
Set MARKETPLACE_URL envvar in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN npm install
 # Override env vars for setup.
 ENV CLEANCSS_BIN /srv/zamboni-node/node_modules/clean-css/bin/cleancss
 ENV ES_HOST elasticsearch_1:9200
+ENV MARKETPLACE_URL http://mp.dev
 ENV MEMCACHE_URL memcache_1:11211
 ENV SOLITUDE_URL http://solitude_1:2602
 ENV STYLUS_BIN /srv/zamboni-node/node_modules/stylus/bin/stylus


### PR DESCRIPTION
Should fix blocking on localhost urls for things like i18n.js.
