### PR TITLE
Bump sphinx version to fix readthedocs issues (bug 1050811)

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,5 +2,5 @@
 sphinxcontrib-httpdomain==1.1.9
 docutils==0.11
 Pygments==1.6
-Sphinx==1.1.3
+Sphinx==1.2.2
 sphinx_rtd_theme==0.1.6


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1050811

Not sure we still need `sphinx_rtd_theme` in there btw, but one thing at a time.
