### PR TITLE
Fix tests broken in e708c07

### DIFF
--- a/mkt/feed/serializers.py
+++ b/mkt/feed/serializers.py
@@ -274,7 +274,7 @@ class FeedCollectionESHomeSerializer(FeedCollectionESSerializer):
         return app_field.to_native(obj._app_ids)
 
     def get_app_count(self, obj):
-        return len(obj.apps())
+        return len(obj._app_ids)
 
 
 class FeedShelfSerializer(BaseFeedCollectionSerializer):

--- a/mkt/feed/tests/test_serializers.py
+++ b/mkt/feed/tests/test_serializers.py
@@ -192,11 +192,12 @@ class TestFeedCollectionESSerializer(FeedTestMixin, amo.tests.TestCase):
             None, obj=self.collection)
         data = self.test_deserialize()
         for i, app in enumerate(data['apps']):
-            group = app['group']['en-US']
-            if not i == 2:
-                eq_(group, 'first-group')
+            actual = app['group']['en-US']
+            if (i + 1) == len(self.app_ids):
+                expected = 'second-group'
             else:
-                eq_(group, 'second-group')
+                expected = 'first-group'
+            eq_(expected, actual, 'Expected %s, got %s' % (expected, actual))
 
     def test_background_image(self):
         self.collection.update(type=feed.COLLECTION_PROMO, image_hash='LOL')


### PR DESCRIPTION
r? @robhudson @ngokevin

Broken build: https://travis-ci.org/mozilla/zamboni/builds/32461408

I'll let Travis finish before merging even after an r+, but these both pass, so I'm feeling good about it:
- `mkt/feed/tests/test_serializers.py:TestFeedCollectionESSerializer.test_home_serializer_listing_coll`
- `mkt/feed/tests/test_views.py:TestFeedView.test_200`
