### PR TITLE
add device filtering to apps of the feed (bug 1054381)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -781,7 +781,7 @@ def file_factory(**kw):
     return f
 
 
-def req_factory_factory(url, user=None, post=False, data=None, **kwargs):
+def req_factory_factory(url='', user=None, post=False, data=None, **kwargs):
     """Creates a request factory, logged in with the user."""
     req = RequestFactory()
     if post:


### PR DESCRIPTION
I elected to implemented it all on the view level.

For FeedView
- If a Featured App has an incompatible app, nix it from the view.
- If a collection has all incompatible apps, nix it from the view.
- If a collection has some incompatible apps, filter out the incompatible apps from the collection.

For FeedElementGetView
- If feed element has all incompatible apps, just show everything. Since it wouldn't have shown up on the Feed, it must mean the user navigated there manually.
- If a feed element has some incompatible apps, filter them out.

Special flag added for Desktop to show all.
