### PR TITLE
feed region exclusions (bug 1055962)

### DIFF
--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1930,8 +1930,7 @@ class Webapp(UUIDModelMixin, Addon):
         else:
             all_ids = mkt.regions.REGION_IDS
         if excluded is None:
-            excluded = list(self.addonexcludedregion
-                                .values_list('region', flat=True))
+            excluded = self.get_excluded_region_ids()
 
         return sorted(set(all_ids) - set(excluded or []))
 

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -548,7 +548,8 @@ class ESAppFeedSerializer(BaseESAppFeedSerializer):
         fields = [
             'author', 'device_types', 'icons', 'id', 'is_packaged',
             'manifest_url', 'name', 'payment_required', 'premium_type',
-            'price', 'price_locale', 'ratings', 'status', 'slug', 'user'
+            'price', 'price_locale', 'ratings', 'regions', 'status', 'slug',
+            'user'
         ]
 
 
@@ -559,7 +560,7 @@ class ESAppFeedCollectionSerializer(BaseESAppFeedSerializer):
     """
     class Meta(ESAppSerializer.Meta):
         fields = [
-            'icons', 'id', 'slug', 'status'
+            'device_types', 'icons', 'id', 'slug', 'regions', 'status'
         ]
 
 

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -688,6 +688,15 @@ class TestWebapp(amo.tests.WebappTestCase):
         pay_mock.return_value = True
         assert app.payments_complete()
 
+    def test_get_region_ids_no_exclusions(self):
+        # This returns IDs for the *included* regions.
+        eq_(self.get_app().get_region_ids(), mkt.regions.REGION_IDS)
+
+    def test_get_regions_no_exclusions(self):
+        # This returns the class definitions for the *included* regions.
+        eq_(sorted(self.get_app().get_regions()),
+            sorted(mkt.regions.REGIONS_CHOICES_ID_DICT.values()))
+
 
 class TestWebappLight(amo.tests.TestCase):
     """
@@ -857,10 +866,6 @@ class TestWebappLight(amo.tests.TestCase):
     def test_not_premium(self):
         eq_(Webapp().has_premium(), False)
 
-    def test_get_region_ids_no_exclusions(self):
-        # This returns IDs for the *included* regions.
-        eq_(Webapp().get_region_ids(), mkt.regions.REGION_IDS)
-
     def test_get_region_ids_with_exclusions(self):
         w1 = Webapp.objects.create()
         w2 = Webapp.objects.create()
@@ -880,11 +885,6 @@ class TestWebappLight(amo.tests.TestCase):
             sorted(w1_regions))
         eq_(sorted(Webapp.objects.get(id=w2.id).get_region_ids()),
             sorted(w2_regions))
-
-    def test_get_regions_no_exclusions(self):
-        # This returns the class definitions for the *included* regions.
-        eq_(sorted(Webapp().get_regions()),
-            sorted(mkt.regions.REGIONS_CHOICES_ID_DICT.values()))
 
     def test_get_regions_with_exclusions(self):
         w1 = Webapp.objects.create()


### PR DESCRIPTION
Just like devices/statuses.
- Need to refactor later to DRY.
- Changed `Webapp.get_regions` to include Geodata stuff by calling `Webapp.get_excluded_region_ids`
- Pop all of the filter fields so we don't send them down the wire
