### PR TITLE
filter out delisted apps from feed (bug 1058139)

### DIFF
--- a/docs/api/topics/apps.rst
+++ b/docs/api/topics/apps.rst
@@ -84,6 +84,7 @@ App
                 "128": "/tmp/uploads/addon_icons/0/24-128.png?modified=1362762723"
             },
             "id": "24",
+            "is_disabled": false,
             "is_packaged": false,
             "manifest_url": "http://zrnktefoptje.test-manifest.herokuapp.com/manifest.webapp",
             "name": {
@@ -206,6 +207,8 @@ App
     :type icons: object
     :param id: The app ID.
     :type id: int
+    :param is_disabled: Boolean indicating whether the app is disabled or not.
+    :type is_disabled: boolean
     :param is_packaged: Boolean indicating whether the app is packaged or not.
     :type is_packaged: boolean
     :param manifest_url: URL for the app manifest. If the app is not an hosted

--- a/mkt/feed/tests/test_views.py
+++ b/mkt/feed/tests/test_views.py
@@ -1555,6 +1555,13 @@ class TestFeedViewStatusFiltering(BaseTestFeedESView, BaseTestFeedItemViewSet):
         eq_(len(data['objects']), 1)
         eq_(data['objects'][0]['collection']['apps'][0]['id'], app_public.id)
 
+    def test_is_disabled(self):
+        feed_item = self.feed_item_factory(item_type=feed.FEED_TYPE_APP)
+        app = feed_item.app.app
+        app.update(disabled_by_user=True)
+        res, data = self._get()
+        ok_(not data['objects'])
+
 
 class TestFeedViewQueries(BaseTestFeedItemViewSet, amo.tests.TestCase):
     fixtures = BaseTestFeedItemViewSet.fixtures + FeedTestMixin.fixtures

--- a/mkt/feed/views.py
+++ b/mkt/feed/views.py
@@ -477,6 +477,9 @@ class BaseFeedESView(CORSMixin, APIView):
                                         feed_element)
 
         if feed_element:
+            feed_element = self._filter(False, 'is_disabled', feed_element)
+
+        if feed_element:
             feed_element = self._pop_filter_fields(feed_element)
 
         return feed_element
@@ -523,7 +526,7 @@ class BaseFeedESView(CORSMixin, APIView):
         """
         apps = feed_element.get('apps') or [feed_element['app']]
         for app in apps:
-            for field in ('regions', 'status'):
+            for field in ('is_disabled', 'regions', 'status'):
                 if field in app:
                     del app[field]
         return feed_element

--- a/mkt/webapps/tests/test_serializers.py
+++ b/mkt/webapps/tests/test_serializers.py
@@ -373,6 +373,7 @@ class TestESAppSerializer(amo.tests.ESTestCase):
             'icons': dict((size, self.app.get_icon_url(size))
                           for size in (32, 48, 64, 128)),
             'id': 337141,
+            'is_disabled': False,
             'is_offline': False,
             'is_packaged': False,
             'manifest_url': 'http://micropipes.com/temp/steamcube.webapp',


### PR DESCRIPTION
I'm planning on moving the filters to ES and patching up the serializers to expected their apps being filtered out. But for launch, just gonna go with the current implementation.
