### PR TITLE
Modify inapp is_purchaseable logic (bug 1058953)

### DIFF
--- a/mkt/inapp/models.py
+++ b/mkt/inapp/models.py
@@ -41,7 +41,7 @@ class InAppProduct(UUIDModelMixin, ModelBase):
         return json.loads(self.simulate)
 
     def is_purchasable(self):
-        return self.stub or (self.webapp and self.webapp.is_public())
+        return self.simulate or (self.webapp and self.webapp.is_public())
 
     def delete(self):
         raise models.ProtectedError('Inapp products may not be deleted.', self)

--- a/mkt/webpay/tests/test_views.py
+++ b/mkt/webpay/tests/test_views.py
@@ -125,6 +125,18 @@ class TestPrepareInApp(InAppPurchaseTest, RestOAuth):
         res = self._post()
         eq_(res.status_code, 400, res.content)
 
+    def test_simulated_app_with_non_public_parent_succeeds(self):
+        self.addon.update(status=amo.STATUS_PENDING)
+        self.inapp.update(simulate=json.dumps({'result': 'postback'}))
+        res = self._post()
+        eq_(res.status_code, 201, res.content)
+
+    def test_simulated_app_without_parent_succeeds(self):
+        self.inapp.update(simulate=json.dumps({'result': 'postback'}),
+                          webapp=None)
+        res = self._post()
+        eq_(res.status_code, 201, res.content)
+
     def test_get_jwt(self, extra_headers=None):
         res = self._post(extra_headers=extra_headers)
         eq_(res.status_code, 201, res.content)


### PR DESCRIPTION
- Simulated products are always purchasable
- Stub products are always simulated
- Added tests
