### PR TITLE
convert from $0.99 to 0.99 USD (bug 1028361-two)

### DIFF
--- a/mkt/prices/models.py
+++ b/mkt/prices/models.py
@@ -87,11 +87,12 @@ class Price(amo.models.ModelBase):
         return _('Tier %s' % self.name)
 
     def tier_locale(self, currency='USD'):
-        # A way to display the price of the tier.
+        # Display the price of the tier in locale relevant way eg: $0.99
         return price_locale(self.price, currency)
 
     def __unicode__(self):
-        return u'$%s' % self.price
+        # Display the price in unamiguous USD, eg: 0.99 USD
+        return '{0} USD'.format(self.price)
 
     @staticmethod
     def transformer(prices):


### PR DESCRIPTION
For in-app product page and payment pages
![screenshot 2014-08-27 09 14 04](https://cloud.githubusercontent.com/assets/74699/4063146/6de55110-2e05-11e4-9eba-8f33692bfb7e.png)

![screenshot 2014-08-27 09 13 37](https://cloud.githubusercontent.com/assets/74699/4063147/703ef272-2e05-11e4-98e6-d91a9f40de59.png)

Prevents awkward switch from $0.99 (which is ambiguous anyway, multiple countries use $ as their symbol) to 0.99 USD and displays it consistently in the UI.
