### PR TITLE
    Add bug link to in app products (bug 1052143)

### DIFF
--- a/mkt/developers/templates/developers/payments/in-app-products.html
+++ b/mkt/developers/templates/developers/payments/in-app-products.html
@@ -25,18 +25,23 @@
 
   <section class="primary manage" role="main">
     {% if not addon.is_packaged %}
-      <div class="island notification-box">
+      <div id="origin-notification" class="island notification-box">
         {% trans origin='https://developer.mozilla.org/en-US/Apps/Build/Manifest#origin' %}
           Your app must be packaged and specify an <a href="{{ origin }}">origin</a> to use this in-app payment system.
         {% endtrans %}
       </div>
     {% elif not addon.origin %}
-      <div class="island notification-box">
+      <div id="origin-notification" class="island notification-box">
         {% trans origin='https://developer.mozilla.org/en-US/Apps/Build/Manifest#origin' %}
           Your app must define an <a href="{{ origin }}">origin</a> in your manifest so that receipts can be verified properly.
         {% endtrans %}
       </div>
     {% else %}
+      <div id="buglink-notification" class="island notification-box">
+        {% trans  link='https://bugzilla.mozilla.org/enter_bug.cgi?product=Marketplace&component=Payments/Refunds' %}
+          This feature is under active development. <a target="_blank" href="{{ link }}">Click here</a> to report a bug.
+        {% endtrans %}
+      </div>
       <div id="in-app-products" class="devhub-form island" data-list-url="{{ url('in-app-products-list', origin=addon.origin) }}"
            data-detail-url-format="{{ url('in-app-products-detail', origin=addon.origin, guid="{guid}") }}">
         <table id="version-list">

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -192,17 +192,18 @@ class TestInAppProductsView(InappTest):
     def test_origin(self):
         self.app.update(is_packaged=True, app_domain='http://f.c')
         doc = pq(self.get().content)
-        ok_(not doc('section.primary div.notification-box'))
+        ok_(not doc('section.primary div#origin-notification'))
+        ok_(doc('section.primary div#buglink-notification'))
 
     def test_no_origin(self):
         self.app.update(is_packaged=True, app_domain=None)
         doc = pq(self.get().content)
-        ok_(doc('section.primary div.notification-box'))
+        ok_(doc('section.primary div#origin-notification'))
 
     def test_not_packaged(self):
         self.app.update(is_packaged=False)
         doc = pq(self.get().content)
-        ok_(doc('section.primary div.notification-box'))
+        ok_(doc('section.primary div#origin-notification'))
 
 
 class TestInappSecret(InappTest):


### PR DESCRIPTION
Revert "Revert "Add a file a bug link to new inapp products pages (bug 1052143)""

This reverts commit 5081c39f24e3f27029ec5661bab6d3cee85a9598.
- Add div ids to disambiguate notifications
- Update tests
- Add new test
