### PR TITLE
consolidate app filtering for both feed + search

### DIFF
--- a/mkt/api/base.py
+++ b/mkt/api/base.py
@@ -54,6 +54,13 @@ def check_potatocaptcha(data):
             return Response(json.dumps({'sprout': 'Invalid value'}), 400)
 
 
+def get_region_from_request(request):
+    region = request.GET.get('region')
+    if region and region == 'None':
+        return None
+    return getattr(request, 'REGION', mkt.regions.RESTOFWORLD)
+
+
 class SubRouter(SimpleRouter):
     """
     Like SimpleRouter, but with the lookup before the prefix, so that it can be
@@ -156,10 +163,7 @@ class MarketplaceView(object):
         go through the middleware and request.REGION is absent, we fall back to
         RESTOFWORLD.
         """
-        region = request.GET.get('region')
-        if region and region == 'None':
-            return None
-        return getattr(request, 'REGION', mkt.regions.RESTOFWORLD)
+        return get_region_from_request(request)
 
 
 class MultiSerializerViewSetMixin(object):

--- a/mkt/collections/serializers.py
+++ b/mkt/collections/serializers.py
@@ -100,20 +100,15 @@ class CollectionMembershipField(serializers.RelatedField):
         Relies on a FeaturedSearchView instance in self.context['view']
         to properly rehydrate results returned by ES.
         """
-        profile = get_feature_profile(request)
-        region = self.context['view'].get_region_from_request(request)
         device = self._get_device(request)
 
-        _rget = lambda d: getattr(request, d, False)
-        qs = WebappIndexer.from_search(
-            request, region=region, gaia=_rget('GAIA'), mobile=_rget('MOBILE'),
-            tablet=_rget('TABLET'))
-        qs = qs.filter('term', **{'collection.id': obj.pk})
+        app_filters = {'profile': get_feature_profile(request)}
         if device and device != amo.DEVICE_DESKTOP:
-            qs = qs.filter('term', device=device.id)
-        if profile:
-            for k, v in profile.to_kwargs(prefix='features.has_').items():
-                qs = qs.filter('term', **{k: v})
+            app_filters['device'] = device.id
+
+        qs = WebappIndexer.get_app_filter(request, app_filters)
+        qs = qs.filter('term', **{'collection.id': obj.pk})
+
         qs = qs.sort({
             'collection.order': {
                 'order': 'asc',

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -12,7 +12,7 @@ from mkt.constants.applications import DEVICE_CHOICES_IDS
 from mkt.regions import set_region
 from mkt.reviewers.forms import ApiReviewersSearchForm
 from mkt.search.forms import (ApiSearchForm, TARAKO_CATEGORIES_MAPPING)
-from mkt.search.views import _filter_search, DEFAULT_SORTING
+from mkt.search.views import _sort_search, DEFAULT_SORTING
 from mkt.site.fixtures import fixture
 from mkt.webapps.indexers import WebappIndexer
 from mkt.webapps.models import Webapp
@@ -38,9 +38,19 @@ class TestSearchFilters(BaseOAuth):
     def _filter(self, req, filters, **kwargs):
         form = self.form_class(filters)
         if form.is_valid():
-            qs = WebappIndexer.from_search(self.req, **kwargs)
-            return _filter_search(
-                self.req, qs, form.cleaned_data).to_dict()
+            form_data = form.cleaned_data
+            sq = WebappIndexer.get_app_filter(self.req, {
+                'app_type': form_data['app_type'],
+                'category': form_data['cat'],
+                'device': form_data['device'],
+                'is_offline': form_data['offline'],
+                'manifest_url': form_data['manifest_url'],
+                'q': form_data['q'],
+                'premium_type': form_data['premium_types'],
+                'supported_locales': form_data['languages'],
+                'tags': form_data['tag'],
+            })
+            return _sort_search(self.req, sq, form_data).to_dict()
         else:
             return form.errors.copy()
 
@@ -179,7 +189,8 @@ class TestSearchFilters(BaseOAuth):
             in qs['query']['filtered']['filter']['bool']['must'])
 
     def test_region_exclusions(self):
-        qs = self._filter(self.req, {'q': 'search terms'}, region=regions.CO)
+        self.req.REGION = regions.CO
+        qs = self._filter(self.req, {'q': 'search terms'})
         ok_({'term': {'region_exclusions': regions.CO.id}}
             in qs['query']['filtered']['filter']['bool']['must_not'])
 

--- a/mkt/webapps/indexers.py
+++ b/mkt/webapps/indexers.py
@@ -5,15 +5,17 @@ from operator import attrgetter
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db.models import Max, Min
-from elasticsearch_dsl import F, filter as es_filter
+from elasticsearch_dsl import F, filter as es_filter, query
 
 import commonware.log
 
 import amo
-import mkt
 from amo.utils import to_language
+
+import mkt
 from mkt.constants import APP_FEATURES
 from mkt.constants.applications import DEVICE_GAIA
+from mkt.features.utils import get_feature_profile
 from mkt.prices.models import AddonPremium
 from mkt.search.indexers import BaseIndexer
 from mkt.search.utils import Search
@@ -25,19 +27,14 @@ log = commonware.log.getLogger('z.addons')
 
 class WebappIndexer(BaseIndexer):
     """
-    Mapping type for Webapp models.
-
-    By default we will return these objects rather than hit the database so
-    include here all the things we need to avoid hitting the database.
+    Bunch of ES stuff for Webapp include mappings, indexing, search.
     """
-
     @classmethod
     def search(cls, using=None):
         """
         Returns a `Search` object.
 
         We override this to use our patched version which adds statsd timing.
-
         """
         return Search(using=using or cls.get_es(),
                       index=cls.get_index(),
@@ -436,30 +433,79 @@ class WebappIndexer(BaseIndexer):
         WebappIndexer.bulk_index(docs, es=ES, index=index or cls.get_index())
 
     @classmethod
-    def from_search(cls, request, cat=None, region=None, gaia=False,
-                    mobile=False, tablet=False):
+    def get_app_filter(cls, request, additional_data):
         """
-        Base ES filter for Webapp to consumer pages. By default:
+        THE grand, consolidated ES filter for Webapps. By default:
         - Excludes non-public apps.
         - Excludes disabled apps (whether by reviewer or by developer).
         - Excludes based on region exclusions.
         - TODO: Excludes based on device and platform support.
+
+        additional_data -- an object with more data to allow more filtering.
         """
-        filters = [
+        from mkt.api.base import get_region_from_request
+        from mkt.search.views import name_query
+
+        data = {
+            'app_type': [],
+            'category': None,  # Slug.
+            'device': None,  # ID.
+            'gaia': getattr(request, 'GAIA', False),
+            'is_offline': None,
+            'manifest_url': '',
+            'mobile': getattr(request, 'MOBILE', False),
+            'premium_type': [],
+            'profile': get_feature_profile(request),
+            'q': '',
+            'region': get_region_from_request(request).id,
+            'supported_locales': [],
+            'tags': '',
+            'tablet': getattr(request, 'TABLET', False),
+        }
+        data.update(additional_data)
+
+        # Fields that will be filtered with a term query.
+        term_fields = ('device', 'manifest_url', 'tags')
+        # Fields that will be filtered with a terms query.
+        terms_fields = ('category', 'premium_type', 'app_type',
+                        'supported_locales')
+
+        sq = cls.search()
+
+        # QUERY.
+        if data['q']:
+            # Function score for popularity boosting (defaults to multiply).
+            sq = sq.query(
+                'function_score',
+                query=name_query(data['q'].lower()),
+                functions=[query.SF('field_value_factor', field='boost')])
+
+        # MUST.
+        must = [
             F('term', status=amo.STATUS_PUBLIC),
             F('term', is_disabled=False),
         ]
+        for field in term_fields + terms_fields:
+            # Term filters.
+            if data[field]:
+                filter_type = 'term' if field in term_fields else 'terms'
+                must.append(F(filter_type, **{field: data[field]}))
+        if data['profile']:
+            # Feature filters.
+            profile = data['profile']
+            for k, v in profile.to_kwargs(prefix='features.has_').items():
+                must.append(F('term', **{k: v}))
+        if data['mobile'] or data['gaia']:
+            # Uses flash.
+            must.append(F('term', uses_flash=False))
+        if data['is_offline'] is not None:
+            must.append(F('term', is_offline=data['is_offline']))
 
-        if cat:
-            filters.append(F('term', category=cat.slug))
-
-        if mobile or gaia:
-            filters.append(F('term', uses_flash=False))
-
-        sq = cls.search().filter(es_filter.Bool(must=filters))
-
-        if region:
-            sq = sq.filter(~F('term', region_exclusions=region.id))
+        # FILTER.
+        sq = sq.filter(es_filter.Bool(must=must))
+        if data['region']:
+            # Region exclusions.
+            sq = sq.filter(~F('term', region_exclusions=data['region']))
 
         return sq
 


### PR DESCRIPTION
- Combine `mkt.search.views._filter_search` and `mkt.webapps.indexers.from_search` into `mkt.webapps.indexers.get_app_filter`.
- Separate the filtering and sorting code.
- SearchView had a lot of needless helper methods, which made the dataflow confusing. I put most of it into one method.
