### PR TITLE
Expose inapp active flag through API (bug 1060518)

### DIFF
--- a/mkt/inapp/models.py
+++ b/mkt/inapp/models.py
@@ -42,7 +42,7 @@ class InAppProduct(UUIDModelMixin, ModelBase):
         return json.loads(self.simulate)
 
     def is_purchasable(self):
-        return self.simulate or (self.webapp and self.webapp.is_public())
+        return self.active and (self.simulate or (self.webapp and self.webapp.is_public()))
 
     def delete(self):
         raise models.ProtectedError('Inapp products may not be deleted.', self)

--- a/mkt/inapp/serializers.py
+++ b/mkt/inapp/serializers.py
@@ -18,6 +18,7 @@ log = commonware.log.getLogger('z.inapp')
 
 
 class InAppProductSerializer(serializers.ModelSerializer):
+    active = serializers.BooleanField(required=False)
     guid = serializers.CharField(read_only=True)
     app = serializers.SlugRelatedField(read_only=True, slug_field='app_slug',
                                        source='webapp')
@@ -29,7 +30,7 @@ class InAppProductSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = InAppProduct
-        fields = ['guid', 'app', 'price_id', 'name', 'logo_url']
+        fields = ['active', 'guid', 'app', 'price_id', 'name', 'logo_url']
 
     def validate_logo_url(self, attrs, source):
         logo_url = attrs.get(source)

--- a/mkt/inapp/tests/test_views.py
+++ b/mkt/inapp/tests/test_views.py
@@ -96,11 +96,13 @@ class TestInAppProductViewSetAuthorized(BaseInAppProductViewSetTests):
     def test_update(self):
         product = self.create_product()
         self.valid_in_app_product_data['name'] = 'Orange Gems'
+        self.valid_in_app_product_data['active'] = False
         response = self.put(self.detail_url(product.guid),
                             self.valid_in_app_product_data)
         eq_(response.status_code, status.HTTP_200_OK)
         eq_(response.json['name'], 'Orange Gems')
         eq_(response.json['name'], product.reload().name)
+        eq_(response.json['active'], False)
 
     def test_delete(self):
         product = self.create_product()

--- a/mkt/webpay/tests/test_views.py
+++ b/mkt/webpay/tests/test_views.py
@@ -125,6 +125,11 @@ class TestPrepareInApp(InAppPurchaseTest, RestOAuth):
         res = self._post()
         eq_(res.status_code, 400, res.content)
 
+    def test_inactive_app_fails(self):
+        self.inapp.update(active=False)
+        res = self._post()
+        eq_(res.status_code, 400, res.content)
+
     def test_simulated_app_with_non_public_parent_succeeds(self):
         self.addon.update(status=amo.STATUS_PENDING)
         self.inapp.update(simulate=json.dumps({'result': 'postback'}))


### PR DESCRIPTION
- Add to serializer
- Disable purchases of inactive products
- Add tests
