### PR TITLE
    Improve initial inapp page (bug 1059959)

### DIFF
--- a/media/css/devreg/in-app-products.styl
+++ b/media/css/devreg/in-app-products.styl
@@ -1,3 +1,16 @@
+#in-app-products.empty {
+    .listing-footer {
+        background: #FFFFFF;
+        text-align: center;
+        border-top: none;
+        margin: 0px;
+    }
+
+    table {
+        display: none;
+    }
+}
+
 .inline-editing {
     .inline-edit {
         display: none;

--- a/media/js/devreg/in_app_products.js
+++ b/media/js/devreg/in_app_products.js
@@ -310,4 +310,7 @@
         component: InAppProductComponent,
         componentAttrs: {startEditing: true},
     });
+    $('#add-in-app-product').on('click', function () {
+        $('#in-app-products').removeClass('empty');
+    })
 })();

--- a/mkt/developers/templates/developers/payments/in-app-products.html
+++ b/mkt/developers/templates/developers/payments/in-app-products.html
@@ -38,11 +38,20 @@
       </div>
     {% else %}
       <div id="buglink-notification" class="island notification-box">
-        {% trans  link='https://bugzilla.mozilla.org/enter_bug.cgi?product=Marketplace&component=Payments/Refunds' %}
-          This feature is under active development. <a target="_blank" href="{{ link }}">Click here</a> to report a bug.
-        {% endtrans %}
+        <p>
+          {% trans doc_link='https://developer.mozilla.org/en-US/Marketplace/Monetization/In-app_payments_section/Introduction_In-app_Payments' %}
+            This feature is under active development. Please refer to the <a target="_blank" href="{{ doc_link }}">documentation</a> for more information.
+          {% endtrans %}
+        </p>
+        <p>
+          {% trans bug_link='https://bugzilla.mozilla.org/enter_bug.cgi?product=Marketplace&component=Payments/Refunds' %}
+            If you find a problem please <a target="_blank" href="{{ bug_link }}">report a bug</a>.
+          {% endtrans %}
+        </p>
       </div>
-      <div id="in-app-products" class="devhub-form island" data-list-url="{{ url('in-app-products-list', origin=addon.origin) }}"
+      <div id="in-app-products"
+           class="devhub-form island{% if not products %} empty{% endif %}"
+           data-list-url="{{ url('in-app-products-list', origin=addon.origin) }}"
            data-detail-url-format="{{ url('in-app-products-detail', origin=addon.origin, guid="{guid}") }}">
         <table id="version-list">
           <thead>


### PR DESCRIPTION
- Hide table until user clicks 'Add a product'
- Add documentation link

![screenshot 2014-09-04 16 35 54](https://cloud.githubusercontent.com/assets/119884/4156324/1ddae378-3473-11e4-84ac-2530ceac8d4f.png)
![screenshot 2014-09-04 16 36 01](https://cloud.githubusercontent.com/assets/119884/4156325/213d0cc6-3473-11e4-8160-f50398881dfb.png)
