### PR TITLE
Limit pending reviews (bug 1063172)

### DIFF
--- a/media/js/devreg/tarako.js
+++ b/media/js/devreg/tarako.js
@@ -9,7 +9,7 @@ jQuery(function ($) {
             app: $form.find('[name="app"]').val(),
             queue: $form.find('[name="queue"]').val(),
         }).done(function (review) {
-            window.location = window.location;
+            location.reload();
         }).fail(function (response) {
             var errors = response.responseJSON;
             if (errors.app) {
@@ -28,7 +28,7 @@ jQuery(function ($) {
             url: $removeTarakoTag.data('action'),
             method: 'delete',
         }).done(function () {
-            window.location = window.location;
+            location.reload();
         }).fail(function () {
             console.error('Error removing tarako tag');
             $removeTarakoModal.find('.error').text(

--- a/mkt/reviewers/models.py
+++ b/mkt/reviewers/models.py
@@ -395,11 +395,14 @@ def tarako_failed(review):
 
 
 class AdditionalReviewManager(amo.models.ManagerBase):
-    def unreviewed(self, queue):
-        return self.get_queryset().filter(
-            passed=None,
-            queue=queue,
-            app__status__in=amo.WEBAPPS_APPROVED_STATUSES)
+    def unreviewed(self, queue, and_approved=False):
+        query = {
+            'passed': None,
+            'queue': queue,
+        }
+        if and_approved:
+            query['app__status__in'] = amo.WEBAPPS_APPROVED_STATUSES
+        return self.get_queryset().filter(**query)
 
     def latest_for_queue(self, queue):
         try:

--- a/mkt/reviewers/tests/test_models.py
+++ b/mkt/reviewers/tests/test_models.py
@@ -311,8 +311,13 @@ class TestAdditionalReviewManager(amo.tests.TestCase):
         self.other_queue = AdditionalReview.objects.create(
             app=Webapp.objects.create(), queue='queue-two')
 
-    def test_unreviewed_none_approved(self):
-        eq_([], list(AdditionalReview.objects.unreviewed(queue='queue-one')))
+    def test_unreviewed_none_approved_allow_unapproved(self):
+        eq_([self.unreviewed, self.unreviewed_too],
+            list(AdditionalReview.objects.unreviewed(queue='queue-one')))
+
+    def test_unreviewed_none_approved_only_approved(self):
+        eq_([], list(AdditionalReview.objects.unreviewed(
+            queue='queue-one', and_approved=True)))
 
     def test_unreviewed_and_approved_all_approved(self):
         self.unreviewed.app.update(status=amo.STATUS_PUBLIC)
@@ -320,11 +325,18 @@ class TestAdditionalReviewManager(amo.tests.TestCase):
         eq_([self.unreviewed, self.unreviewed_too],
             list(AdditionalReview.objects.unreviewed(queue='queue-one')))
 
-    def test_unreviewed_and_approved_one_approved(self):
+    def test_unreviewed_and_approved_one_approved_allow_unapproved(self):
+        self.unreviewed.app.update(status=amo.STATUS_PUBLIC)
+        self.unreviewed_too.app.update(status=amo.STATUS_REJECTED)
+        eq_([self.unreviewed, self.unreviewed_too],
+            list(AdditionalReview.objects.unreviewed(queue='queue-one')))
+
+    def test_unreviewed_and_approved_one_approved_only_approved(self):
         self.unreviewed.app.update(status=amo.STATUS_PUBLIC)
         self.unreviewed_too.app.update(status=amo.STATUS_REJECTED)
         eq_([self.unreviewed],
-            list(AdditionalReview.objects.unreviewed(queue='queue-one')))
+            list(AdditionalReview.objects.unreviewed(
+                queue='queue-one', and_approved=True)))
 
 
 class BaseTarakoFunctionsTestCase(amo.tests.TestCase):

--- a/mkt/reviewers/tests/test_views_api.py
+++ b/mkt/reviewers/tests/test_views_api.py
@@ -530,6 +530,7 @@ class TestCreateAdditionalReview(RestOAuth):
 
     def test_only_one_pending_review(self):
         AdditionalReview.objects.create(queue=QUEUE_TARAKO, app=self.app)
+        self.app.update(status=amo.STATUS_PENDING)
         eq_(AdditionalReview.objects.filter(app=self.app).count(), 1)
         response = self.post({'queue': QUEUE_TARAKO, 'app': self.app.pk})
         eq_(response.status_code, 400)

--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -180,7 +180,7 @@ def queue_counts(request):
         'region_cn': Webapp.objects.pending_in_region(mkt.regions.CN).count(),
         'additional_tarako': (
             AdditionalReview.objects
-                            .unreviewed(queue=QUEUE_TARAKO)
+                            .unreviewed(queue=QUEUE_TARAKO, and_approved=True)
                             .count()),
     }
 
@@ -629,8 +629,9 @@ def additional_review(request, queue):
     if request.GET.get('order') == 'desc':
         order_by = '-' + order_by
     # TODO: Add `.select_related('app')`. Currently it won't load the name.
-    additional_reviews = (AdditionalReview.objects.unreviewed(queue=queue)
-                                                  .order_by(order_by))
+    additional_reviews = (
+        AdditionalReview.objects.unreviewed(queue=queue, and_approved=True)
+                                .order_by(order_by))
     apps = [ActionableQueuedApp(additional_review.app,
                                 additional_review.created,
                                 reverse('additionalreview-detail',

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -44,7 +44,7 @@ from mkt.files.models import File
 from mkt.files.tests.test_models import UploadTest as BaseUploadTest
 from mkt.files.utils import WebAppParser
 from mkt.prices.models import AddonPremium, Price
-from mkt.reviewers.models import EscalationQueue, RereviewQueue
+from mkt.reviewers.models import EscalationQueue, QUEUE_TARAKO, RereviewQueue
 from mkt.site.fixtures import fixture
 from mkt.site.helpers import absolutify
 from mkt.site.tests import DynamicBoolFieldsTestMixin
@@ -696,6 +696,28 @@ class TestWebapp(amo.tests.WebappTestCase):
         # This returns the class definitions for the *included* regions.
         eq_(sorted(self.get_app().get_regions()),
             sorted(mkt.regions.REGIONS_CHOICES_ID_DICT.values()))
+
+    def test_in_tarako_queue_pending_in_queue(self):
+        app = self.get_app()
+        app.update(status=amo.STATUS_PENDING)
+        app.additionalreview_set.create(queue=QUEUE_TARAKO)
+        ok_(app.in_tarako_queue())
+
+    def test_in_tarako_queue_approved_in_queue(self):
+        app = self.get_app()
+        app.update(status=amo.STATUS_APPROVED)
+        app.additionalreview_set.create(queue=QUEUE_TARAKO)
+        ok_(app.in_tarako_queue())
+
+    def test_in_tarako_queue_pending_not_in_queue(self):
+        app = self.get_app()
+        app.update(status=amo.STATUS_PENDING)
+        ok_(not app.in_tarako_queue())
+
+    def test_in_tarako_queue_approved_not_in_queue(self):
+        app = self.get_app()
+        app.update(status=amo.STATUS_APPROVED)
+        ok_(not app.in_tarako_queue())
 
 
 class TestWebappLight(amo.tests.TestCase):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1063172
1. The pending review check was filtering on approved statuses so you could add your app to the review queue multiple times due to bug number two.
2. When you go to the status page and it sets the anchor to drop you at low-memory devices `window.location = window.location` doesn't refresh the page.
