### PR TITLE
Make API apps search follow docs for dev/device parameters (bug 1060062)

### DIFF
--- a/mkt/reviewers/templates/reviewers/includes/queue_search.html
+++ b/mkt/reviewers/templates/reviewers/includes/queue_search.html
@@ -14,7 +14,7 @@
 
       <div class="advanced-search desktop c hidden">
         <div class="form-elems c">
-          {{ form_row(search_form, ('status', 'app_type', 'device',
+          {{ form_row(search_form, ('status', 'app_type', 'dev', 'device',
                                     'premium_types')) }}
           {# TODO: Add back 'waiting_time_days' when they are in elasticsearch. #}
           {{ form_row(search_form, ('has_editor_comment', 'has_info_request',

--- a/mkt/reviewers/templates/reviewers/includes/queue_search_mobile.html
+++ b/mkt/reviewers/templates/reviewers/includes/queue_search_mobile.html
@@ -32,7 +32,7 @@
         <!-- Value selector fields. -->
         {% for field in ('has_editor_comment', 'has_info_request',
                          'is_escalated', 'is_tarako', 'status', 'app_type',
-                         'device', 'premium_types') %}
+                         'dev', 'device', 'premium_types') %}
           <!-- Differentiate radio and checkbox form elements. -->
           {% set multi = field in ('premium_types',) %}
 

--- a/mkt/reviewers/tests/test_views_api.py
+++ b/mkt/reviewers/tests/test_views_api.py
@@ -250,6 +250,7 @@ class TestApiReviewer(RestOAuth, ESTestCase):
         qs = {'q': 'something', 'pro': feature_profile, 'dev': 'firefoxos'}
 
         # Enable an app feature that doesn't match one in our profile.
+        self.webapp.addondevicetype_set.create(device_type=amo.DEVICE_GAIA.id)
         self.webapp.latest_version.features.update(has_pay=True)
         self.webapp.save()
         self.refresh('webapp')
@@ -261,6 +262,7 @@ class TestApiReviewer(RestOAuth, ESTestCase):
         eq_(obj['slug'], self.webapp.app_slug)
 
     def test_no_flash_filtering(self):
+        self.webapp.addondevicetype_set.create(device_type=amo.DEVICE_GAIA.id)
         self.webapp.latest_version.all_files[0].update(uses_flash=True)
         self.webapp.save()
         self.refresh('webapp')
@@ -269,9 +271,11 @@ class TestApiReviewer(RestOAuth, ESTestCase):
         eq_(len(res.json['objects']), 1)
 
     def test_no_premium_filtering(self):
+        self.webapp.addondevicetype_set.create(
+            device_type=amo.DEVICE_MOBILE.id)
         self.webapp.update(premium_type=amo.ADDON_PREMIUM)
         self.refresh('webapp')
-        res = self.client.get(self.url, {'dev': 'android'})
+        res = self.client.get(self.url, {'dev': 'android', 'device': 'mobile'})
         eq_(res.status_code, 200)
         eq_(len(res.json['objects']), 1)
 

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -114,7 +114,7 @@ class TestSearchFilters(BaseOAuth):
             in qs['query']['filtered']['filter']['bool']['must'])
 
     def test_device(self):
-        qs = self._filter(self.req, {'device': 'desktop'})
+        qs = self._filter(self.req, {'dev': 'desktop'})
         ok_({'term': {'device': DEVICE_CHOICES_IDS['desktop']}}
             in qs['query']['filtered']['filter']['bool']['must'])
 

--- a/mkt/search/tests/test_views.py
+++ b/mkt/search/tests/test_views.py
@@ -511,7 +511,7 @@ class TestApi(RestOAuth, ESTestCase):
             addon=self.webapp, device_type=DEVICE_CHOICES_IDS['desktop'])
         self.webapp.save()
         self.refresh('webapp')
-        res = self.client.get(self.url, data={'device': 'desktop'})
+        res = self.client.get(self.url, data={'dev': 'desktop'})
         eq_(res.status_code, 200)
         obj = res.json['objects'][0]
         eq_(obj['slug'], self.webapp.app_slug)
@@ -729,6 +729,7 @@ class TestApiFeatures(RestOAuth, ESTestCase):
         self.client = RestOAuthClient(None)
         self.url = reverse('search-api')
         self.webapp = Webapp.objects.get(pk=337141)
+        self.webapp.addondevicetype_set.create(device_type=amo.DEVICE_GAIA.id)
         # Pick a few common device features.
         self.profile = FeatureProfile(apps=True, audio=True, fullscreen=True,
                                       geolocation=True, indexeddb=True,


### PR DESCRIPTION
This fixes incoherencies between the API and the docs regarding `dev` and `device` parameters. They are super confusing, but I need them to be coherent for https://bugzilla.mozilla.org/show_bug.cgi?id=1060062

This patch make the API match what fireplace is sending and what the docs are specifying. The rocketfuel and feed APIs were already doing the right thing.
