### PR TITLE
note-type-specific commbadge emails (bug 1043541)

### DIFF
--- a/mkt/comm/templates/comm/emails/approval.html
+++ b/mkt/comm/templates/comm/emails/approval.html
@@ -1,0 +1,16 @@
+{% extends 'comm/emails/base.html' %}
+
+{% block content %}
+Congratulations! {{ name }} has been approved and is now published on the Firefox Marketplace.
+
+Check it out: {{ detail_url }}
+
+{% if app.status == amo.STATUS_UNLISTED %}
+Your app is now approved but not published on category listing pages nor in search results. Only those with the URL can find and install your app.
+
+If you would like your app included in search results and listing pages visit its Manage Status page: {{ status_url }}
+{% endif %}
+
+{% include 'comm/emails/includes/details.html' %}
+{% include 'comm/emails/includes/questions.html' %}
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/approval_private.html
+++ b/mkt/comm/templates/comm/emails/approval_private.html
@@ -1,0 +1,16 @@
+{% extends 'comm/emails/base.html' %}
+
+{% block content %}
+
+App: {{ name }}
+URL: {{ detail_url }}
+
+Congratulations! Your app has been approved for the Firefox Marketplace.
+
+Your app is now in a private state, because you either requested that the app not be automatically published after approval, or we noticed something during review that we didn't think was serious enough to warrant rejecting your app, but wanted to give you the option to fix it if you'd like.
+
+To publish your app, visit its Manage Status page: {{ status_url }}.
+
+{% include 'comm/emails/includes/details.html' %}
+{% include 'comm/emails/includes/questions.html' %}
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/base.html
+++ b/mkt/comm/templates/comm/emails/base.html
@@ -1,0 +1,10 @@
+{% block content %}{% endblock %}
+
+You may reply to this email or post to {{ url('commonplace.commbadge.show_thread', thread_id)|absolutify }}
+
+--
+{% block footer %}
+{{ reviewer }}
+Firefox Marketplace Reviewer
+{{ SITE_URL }}
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/disabled.html
+++ b/mkt/comm/templates/comm/emails/disabled.html
@@ -1,0 +1,8 @@
+{% extends 'comm/emails/base.html' -%}
+
+{% block content %}
+Your App, {{ name }}, has been banned by an admin or senior reviewer.
+
+{% include 'comm/emails/includes/details.html' %}
+{% include 'comm/emails/includes/questions.html' %}
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/escalation.html
+++ b/mkt/comm/templates/comm/emails/escalation.html
@@ -1,0 +1,9 @@
+{% extends 'comm/emails/base.html' -%}
+
+{% block content %}
+Your App, {{ name }}, has been escalated for an admin review by a reviewer.
+
+Your App is now in our escalated review queue, and it will need to be checked by one of our senior comm. This means that your review will probably take longer than usual. You don't need to take any further action - we will contact you if any more information is required from you.  Thanks for your understanding.
+
+{% include 'comm/emails/includes/questions.html' %}
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/escalation_prerelease_app.html
+++ b/mkt/comm/templates/comm/emails/escalation_prerelease_app.html
@@ -1,0 +1,14 @@
+Dear Superheroes,
+
+A developer has uploaded/resubmitted an app that uses prerelease permissions
+(the ones that used to be certified but are now privileged).
+
+Please ensure that this app is on the approved list for use of these APIs:
+
+App: {{ name }}
+URL: {{ review_url }}
+
+Love,
+
+Firefox Marketplace
+{{ SITE_URL }}

--- a/mkt/comm/templates/comm/emails/escalation_vip.html
+++ b/mkt/comm/templates/comm/emails/escalation_vip.html
@@ -1,0 +1,13 @@
+Dear Superheroes,
+
+A developer has uploaded/resubmitted an app we've designated to be super important and/or a massive PITA.
+
+Please roll out the red carpet, don your white/rubber gloves and give the following app your attention in due time:
+
+App: {{ name }}
+URL: {{ review_url }}
+
+Love,
+
+Firefox Marketplace
+{{ SITE_URL }}

--- a/mkt/comm/templates/comm/emails/generic.html
+++ b/mkt/comm/templates/comm/emails/generic.html
@@ -1,0 +1,13 @@
+{% extends 'comm/emails/base.html' %}
+
+{% block content %}
+A user posted on a discussion of {{ name }}.
+
+{{ sender }} wrote:
+{{ comments }}
+{% endblock %}
+
+{% block footer %}
+Firefox Marketplace
+{{ SITE_URL }}
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/includes/details.html
+++ b/mkt/comm/templates/comm/emails/includes/details.html
@@ -1,0 +1,5 @@
+{% if comments %}
+Reviewer comments:
+
+{{ comments }}
+{% endif %}

--- a/mkt/comm/templates/comm/emails/includes/questions.html
+++ b/mkt/comm/templates/comm/emails/includes/questions.html
@@ -1,0 +1,2 @@
+
+If you have any questions about this review, you can contact the review team by replying to this email or join us in #app-comm on irc.mozilla.org. You can also follow the Apps Blog (http://blog.mozilla.com/apps) to stay updated on Marketplace news.

--- a/mkt/comm/templates/comm/emails/more_info_required.html
+++ b/mkt/comm/templates/comm/emails/more_info_required.html
@@ -1,0 +1,11 @@
+{% extends 'comm/emails/base.html' -%}
+
+{% block content %}
+We need additional information to complete review of your application.
+
+App: {{ name }}
+URL: {{ detail_url }}
+
+Please reply to this email with the following information:
+{{ comments }}
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/rejection.html
+++ b/mkt/comm/templates/comm/emails/rejection.html
@@ -1,0 +1,13 @@
+{% extends 'comm/emails/base.html' %}
+
+{% block content %}
+After reviewing your submission for {{ name }}, we have determined that it does not currently meet our requirements for approval.
+
+URL: {{ detail_url }}
+
+{% include 'comm/emails/includes/details.html' %}
+
+If you have any questions about this review, you can contact the review team by replying to this email or join us in #app-comm on irc.mozilla.org.  Technical support is available on http://stackoverflow.com/r/mozilla.
+
+Once the concerns above have been addressed, you may resubmit your app from the My Submissions page at {{ status_url }}.
+{% endblock %}

--- a/mkt/comm/templates/comm/emails/tarako.html
+++ b/mkt/comm/templates/comm/emails/tarako.html
@@ -1,0 +1,13 @@
+{%- if note.note_type == comm.ADDITIONAL_REVIEW_PASSED -%}
+Your app "{{ name }}" has passed the low-memory device review. It will now
+be shown to low-memory devices.
+{% else %}
+Your app "{{ name }}" has not passed the low-memory device review. It will
+not be shown to low-memory devices.
+{% endif %}
+
+{% if comments %}
+Your reviewer left these comments:
+
+    {{ comments }}
+{%- endif -%}

--- a/mkt/constants/comm.py
+++ b/mkt/constants/comm.py
@@ -5,9 +5,9 @@ from tower import ugettext_lazy as _
 # - assign it a incremented number (MY_NOTE_TYPE = 42)
 # - give it a translation in NOTE_TYPES
 # - if adding from amo/log.py, add it to ACTION_MAP
+# - add it to REVIEWERS_NOTE_TYPE if it should only be visible to reviewers
 # - add the translation to Commbadge settings
 
-# Faith of the seven.
 NO_ACTION = 0
 APPROVAL = 1
 REJECTION = 2
@@ -34,7 +34,8 @@ REREVIEW_CONTENT_RATING_ADULT = 22
 ESCALATION_VIP_APP = 22
 ESCALATION_PRERELEASE_APP = 23
 PRIORITY_REVIEW_REQUESTED = 24
-ADDITIONAL_REVIEW = 25
+ADDITIONAL_REVIEW_PASSED = 25
+ADDITIONAL_REVIEW_FAILED = 26
 
 NOTE_TYPES = {
     NO_ACTION: _('No action'),
@@ -43,7 +44,7 @@ NOTE_TYPES = {
     DISABLED: _('Banned'),
     MORE_INFO_REQUIRED: _('More information requested'),
     ESCALATION: _('Escalated'),
-    REVIEWER_COMMENT: _('Comment'),
+    REVIEWER_COMMENT: _('Reviewer comment'),
     RESUBMISSION: _('App resubmission'),
     APPROVE_VERSION_PRIVATE: _('Approved but private'),
     ESCALATION_CLEARED: _('Escalation cleared'),
@@ -63,7 +64,8 @@ NOTE_TYPES = {
     ESCALATION_VIP_APP: _('Escalation due to VIP App'),
     ESCALATION_PRERELEASE_APP: _('Escalation due to Prelease App'),
     PRIORITY_REVIEW_REQUESTED: _('Priority review requested'),
-    ADDITIONAL_REVIEW: _('Additional review completed'),
+    ADDITIONAL_REVIEW_PASSED: _('Additional review passed'),
+    ADDITIONAL_REVIEW_FAILED: _('Additional review failed')
 }
 
 # Note types only visible by reviewers and not developers.
@@ -90,6 +92,21 @@ API_NOTE_TYPE_WHITELIST = (
     REVIEWER_COMMENT,
     DEVELOPER_COMMENT,
 )
+
+# Maps from note type to email template names.
+# Note types not listed will default to the 'generic' email.
+COMM_MAIL_MAP = {
+    APPROVAL: 'approval',
+    REJECTION: 'rejection',
+    DISABLED: 'disabled',
+    MORE_INFO_REQUIRED: 'more_info_required',
+    ESCALATION: 'escalation',
+    APPROVE_VERSION_PRIVATE: 'approval_private',
+    ESCALATION_VIP_APP: 'escalation_vip',
+    ESCALATION_PRERELEASE_APP: 'escalation_prerelease',
+    ADDITIONAL_REVIEW_PASSED: 'tarako',
+    ADDITIONAL_REVIEW_FAILED: 'tarako',
+}
 
 
 def U_NOTE_TYPES():
@@ -131,8 +148,8 @@ def ACTION_MAP(activity_action):
         amo.LOG.ESCALATION_VIP_APP.id: ESCALATION_VIP_APP,
         amo.LOG.ESCALATION_PRERELEASE_APP.id: ESCALATION_PRERELEASE_APP,
         amo.LOG.PRIORITY_REVIEW_REQUESTED.id: PRIORITY_REVIEW_REQUESTED,
-        amo.LOG.PASS_ADDITIONAL_REVIEW.id: ADDITIONAL_REVIEW,
-        amo.LOG.FAIL_ADDITIONAL_REVIEW.id: ADDITIONAL_REVIEW,
+        amo.LOG.PASS_ADDITIONAL_REVIEW.id: ADDITIONAL_REVIEW_PASSED,
+        amo.LOG.FAIL_ADDITIONAL_REVIEW.id: ADDITIONAL_REVIEW_FAILED,
     }.get(activity_action, NO_ACTION)
 
 

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -29,8 +29,8 @@ from mkt.webapps.tasks import set_storefront_data
 log = commonware.log.getLogger('z.mailer')
 
 
-def send_reviewer_mail(subject, template, context, emails, perm_setting=None, cc=None,
-              attachments=None, reply_to=None):
+def send_reviewer_mail(subject, template, context, emails, perm_setting=None,
+                       cc=None, attachments=None, reply_to=None):
     if not reply_to:
         reply_to = settings.MKT_REVIEWERS_EMAIL
 


### PR DESCRIPTION
- Create a mapping from `note_type` -> email template name.
- Change email titles to be relevant to the note type (e.g., `Rejected: Facebook`).
