### PR TITLE
Improve stats-po.sh script

### DIFF
--- a/locale/stats-po.sh
+++ b/locale/stats-po.sh
@@ -1,15 +1,21 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 # syntax:
 # stats-po.sh
 
 echo "Printing number of untranslated strings found in locales:"
 
-for lang in `find $1 -type f -name "messages.po" | sort`; do
-    dir=`dirname $lang`
-    stem=`basename $lang .po`
+for lang in $(find $1 -type f -name "messages.po" | sort); do
+    dir=$(dirname $lang)
+    stem=$(basename $lang .po)
     js="$dir/javascript.po"
-    count=$(msgattrib --untranslated $lang | grep -c "msgid")
-    count2=$(msgattrib --untranslated $js | grep -c "msgid")
+    count=$(msgattrib $lang --untranslated --no-obsolete --no-fuzzy | grep -c 'msgid ')
+    if [ $count -gt 0 ]; then
+        count=$(($count-1))
+    fi
+    count2=$(msgattrib $js --untranslated --no-obsolete --no-fuzzy | grep -c 'msgid ')
+    if [ $count2 -gt 0 ]; then
+        count2=$(($count2-1))
+    fi
     echo -e "$(dirname $dir)\t\tmain=$count\tjs=$count2"
 done


### PR DESCRIPTION
Besides style changes (use consistently `$(expression)` instead of ``expression``, the current script suffers from a series of issues: it counts `msgid`, but that means that it always increases the real number by 1 when it's not 0 (there's an empty msgid), and counts plural forms as missing strings (`msgid_plurals`)

Current script

```
./sr_Latn       main=304    js=5
```

New script

```
./sr_Latn       main=297    js=4
```

Which is correct compared to msgfmt

$ msgfmt --statistics sr_Latn/LC_MESSAGES/javascript.po -o /dev/null
128 translated messages, 4 untranslated messages.

$ msgfmt --statistics sr_Latn/LC_MESSAGES/messages.po -o /dev/null
1543 translated messages, 297 untranslated messages.
