### PR TITLE
Fix filtering by region in feed elements with fireplace (bug 1061206)

### DIFF
--- a/mkt/feed/fields.py
+++ b/mkt/feed/fields.py
@@ -8,11 +8,11 @@ from rest_framework import exceptions, serializers
 from tower import ugettext as _
 
 from mkt.collections.serializers import DataURLImageField
-from mkt.fireplace.serializers import FireplaceESAppSerializer
-from mkt.webapps.serializers import (AppSerializer, DiscoPlaceESAppSerializer,
-                                     ESAppFeedSerializer,
+from mkt.fireplace.serializers import FeedFireplaceESAppSerializer
+from mkt.webapps.serializers import (AppSerializer, ESAppFeedSerializer,
                                      ESAppFeedCollectionSerializer,
-                                     ESAppSerializer)
+                                     ESAppSerializer,
+                                     FeedDiscoPlaceESAppSerializer)
 
 
 class FeedCollectionMembershipField(serializers.RelatedField):
@@ -38,8 +38,8 @@ class AppESField(serializers.Field):
     self.context['app_map'] -- mapping from app ID to app ES object
     """
     app_serializer_classes = {
-        'fireplace': FireplaceESAppSerializer,
-        'discoplace': DiscoPlaceESAppSerializer
+        'fireplace': FeedFireplaceESAppSerializer,
+        'discoplace': FeedDiscoPlaceESAppSerializer
     }
 
     @property

--- a/mkt/feed/serializers.py
+++ b/mkt/feed/serializers.py
@@ -13,6 +13,7 @@ from mkt.api.fields import (ESTranslationSerializerField, SlugChoiceField,
 from mkt.api.serializers import URLSerializerMixin
 from mkt.carriers import CARRIER_CHOICE_DICT
 from mkt.constants.categories import CATEGORY_CHOICES
+from mkt.fireplace.serializers import FireplaceESAppSerializer
 from mkt.regions import REGIONS_CHOICES_ID_DICT
 from mkt.search.serializers import BaseESSerializer
 from mkt.submit.serializers import FeedPreviewESSerializer

--- a/mkt/feed/tests/test_views.py
+++ b/mkt/feed/tests/test_views.py
@@ -1698,9 +1698,12 @@ class TestFeedElementGetView(BaseTestFeedESView, BaseTestFeedItemViewSet):
 
         url = reverse('api-v2:feed.feed_element_get',
                       args=['apps', app.slug])
-        res, data = self._get(url, app_serializer='fireplace')
+        res, data = self._get(url, app_serializer='fireplace',
+                                   region='restofworld')
         self._assert(app, data)
         assert_fireplace_app(data['app'])
+
+        self._assert(app, data)
 
     def test_app_limit(self):
         app = self.feed_app_factory()

--- a/mkt/fireplace/serializers.py
+++ b/mkt/fireplace/serializers.py
@@ -30,8 +30,7 @@ class FireplaceESAppSerializer(BaseFireplaceAppSerializer,
     weight = SerializerMethodField('get_weight')
 
     class Meta(SimpleESAppSerializer.Meta):
-        fields = sorted(FireplaceAppSerializer.Meta.fields + ['is_disabled',
-                                                              'weight'])
+        fields = sorted(FireplaceAppSerializer.Meta.fields + ['weight'])
         exclude = FireplaceAppSerializer.Meta.exclude
 
     def get_weight(self, obj):
@@ -40,6 +39,15 @@ class FireplaceESAppSerializer(BaseFireplaceAppSerializer,
     def get_user_info(self, app):
         # Fireplace search should always be anonymous for extra-cacheability.
         return None
+
+
+class FeedFireplaceESAppSerializer(FireplaceESAppSerializer):
+    class Meta(FireplaceESAppSerializer.Meta):
+        # Feed needs status, is_disabled and regions in the serializer in
+        # order to do some filtering in the view.
+        fields = sorted(FireplaceESAppSerializer.Meta.fields + ['is_disabled',
+                                                                'regions'])
+        exclude = FireplaceESAppSerializer.Meta.exclude
 
 
 class FireplaceCollectionMembershipField(CollectionMembershipField):

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -597,9 +597,13 @@ class SuggestionsESAppSerializer(ESAppSerializer):
         return app.get_icon_url(64)
 
 
-class DiscoPlaceESAppSerializer(SuggestionsESAppSerializer):
+class FeedDiscoPlaceESAppSerializer(SuggestionsESAppSerializer):
     class Meta(ESAppSerializer.Meta):
-        fields = ['name', 'absolute_url', 'icon', 'status', 'is_disabled']
+        # Feed needs status, is_disabled and regions in the serializer in
+        # order to do some filtering in the view. The view will drop regions
+        # and is_disabled from the serialization.
+        fields = ['name', 'absolute_url', 'icon',
+                  'regions', 'status', 'is_disabled']
 
     def get_icon(self, app):
         return app.get_icon_url(128)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1061206
Fix for http://sentry.dmz.phx1.mozilla.com/marketplace-dev/marketplace-dev/group/20970/

```
mkt.feed.views in _do_app_filter
KeyError: 'regions'

  File "rest_framework/views.py", line 396, in dispatch
    response = handler(request, *args, **kwargs)
  File "mkt/feed/views.py", line 788, in get
    data = (self.filter_apps_feed_element(request, dict(data)) or
  File "mkt/feed/views.py", line 485, in filter_apps_feed_element
    map_field='slug')
  File "mkt/feed/views.py", line 533, in _filter
    app for app in feed_element['apps'] if _do_app_filter(app)]
  File "mkt/feed/views.py", line 518, in _do_app_filter
    app[field] = map(lambda x: x[map_field], app[field])
```
