### PR TITLE
fix feed view serializing promo collections with bg images (bug 1061647)

### DIFF
--- a/mkt/feed/serializers.py
+++ b/mkt/feed/serializers.py
@@ -266,13 +266,8 @@ class FeedCollectionESHomeSerializer(FeedCollectionESSerializer):
 
     def get_apps(self, obj):
         if obj.type == feed.COLLECTION_PROMO:
-            if obj.image_hash:
-                # Don't need any apps if background image.
-                return []
-            else:
-                # Need app icons if not background image.
-                app_field = AppESHomePromoCollectionField(
-                    many=True)
+            # Need app icons if not background image.
+            app_field = AppESHomePromoCollectionField(many=True)
 
         elif obj.type == feed.COLLECTION_LISTING:
             # Needs minimal app serialization like FeedBrand.

--- a/mkt/feed/tests/test_serializers.py
+++ b/mkt/feed/tests/test_serializers.py
@@ -264,19 +264,6 @@ class TestFeedCollectionESSerializer(FeedTestMixin, amo.tests.TestCase):
         assert 'ratings' not in data['apps'][0]
         assert data['apps'][0]['icons']
 
-    def test_home_serializer_promo_coll_bg_image(self):
-        """
-        Test the listing collection does not return apps if background image.
-        """
-        self.collection.update(type=feed.COLLECTION_PROMO, image_hash='#swag')
-        self.data_es = self.collection.get_indexer().extract_document(
-            None, obj=self.collection)
-        data = serializers.FeedCollectionESHomeSerializer(self.data_es,
-            context={'app_map': self.app_map,
-                     'request': amo.tests.req_factory_factory('')}
-        ).data
-        assert not data['apps']
-
 
 class TestFeedShelfSerializer(FeedTestMixin, amo.tests.TestCase):
 

--- a/mkt/feed/tests/test_views.py
+++ b/mkt/feed/tests/test_views.py
@@ -1373,6 +1373,22 @@ class TestFeedView(BaseTestFeedESView, BaseTestFeedItemViewSet):
         eq_(res.status_code, 200)
         ok_(data['objects'])
 
+    def test_collection_promo_background_image(self):
+        # Create the feed collection, a promo with a background image.
+        app_ids = [app_factory().id for i in range(3)]
+        coll = self.feed_collection_factory(app_ids=app_ids,
+                                            coll_type=feed.COLLECTION_PROMO,
+                                            image_hash='abcdefgh')
+        item = FeedItem.objects.create(collection=coll,
+                                       item_type=feed.FEED_TYPE_COLL, region=1)
+
+        # Get the feed for which the feed item should be a member.
+        res, data = self._get(filtering=0)
+        eq_(res.status_code, 200)
+        eq_(data['objects'][0]['id'], item.id)
+        ok_(len(data['objects'][0]['collection']['apps']))
+
+
 class TestFeedViewDeviceFiltering(BaseTestFeedESView, BaseTestFeedItemViewSet):
     fixtures = BaseTestFeedItemViewSet.fixtures + FeedTestMixin.fixtures
 

--- a/mkt/feed/views.py
+++ b/mkt/feed/views.py
@@ -464,7 +464,7 @@ class BaseFeedESView(CORSMixin, APIView):
         # Don't filter device/regions if filtering == 0.
         filtering = request.QUERY_PARAMS.get('filtering', '1') != '0'
 
-        if feed_element.get('apps') == []:
+        if 'app_count' in feed_element and feed_element['app_count'] == 0:
             # No empty collections.
             return
 


### PR DESCRIPTION
We had some leftover app-limiting logic in the serializers.
