### PR TITLE
[commbadge] include tested with info in reviewer notes (bug 997997)

### DIFF
--- a/mkt/comm/utils.py
+++ b/mkt/comm/utils.py
@@ -235,7 +235,6 @@ def create_comm_note(app, version, author, body, note_type=comm.NO_ACTION,
     perms -- object of groups to grant permission to, will set flags on Thread.
              (e.g. {'developer': False, 'staff': True}).
     attachments -- formset of attachment files
-
     """
     # Perm for reviewer, senior_reviewer, moz_contact, staff True by default.
     # Perm for developer False if is reviewer-only comment by default.

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -3125,6 +3125,18 @@ class TestReviewAppComm(AppReviewerTest, AttachmentManagementMixin):
         note = self._get_note()
         eq_(note.attachments.count(), 2)
 
+    def test_tested_with(self):
+        """Tested 'Tested with' message appended to note body."""
+        data = {'action': 'reject', 'comments': 'rubesh',
+                'device_types': 'iFun', 'browsers': 'FurFocks'}
+        data.update(self._attachment_management_form(num=0))
+        self._post(data)
+
+        # Test notes.
+        note = self._get_note()
+        eq_(note.note_type, comm.REJECTION)
+        eq_(note.body, 'rubesh\n\nTested on iFun with FurFocks')
+
 
 class TestModeratedQueue(AppReviewerTest, AccessMixin):
     fixtures = fixture('group_editor', 'user_editor', 'user_editor_group',


### PR DESCRIPTION
Automatically append the string "Tested on [DEVICE] with [BROWSER]" to the end of the Commbadge notes if it's a reviewer action.

@eviljeff this look okay?
