### PR TITLE
use ES for feed filtering (bug 1067492)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ settings_local.py*
 settings_local_*.py
 shellng_local.py
 *.py[co]
-*.sw[pon]
+*.sw[lmnop]
 .coverage
 .vagrant
 pip-log.txt

--- a/mkt/fireplace/serializers.py
+++ b/mkt/fireplace/serializers.py
@@ -41,13 +41,15 @@ class FireplaceESAppSerializer(BaseFireplaceAppSerializer,
         return None
 
 
-class FeedFireplaceESAppSerializer(FireplaceESAppSerializer):
-    class Meta(FireplaceESAppSerializer.Meta):
-        # Feed needs status, is_disabled and regions in the serializer in
-        # order to do some filtering in the view.
-        fields = sorted(FireplaceESAppSerializer.Meta.fields + ['is_disabled',
-                                                                'regions'])
-        exclude = FireplaceESAppSerializer.Meta.exclude
+class FeedFireplaceESAppSerializer(BaseFireplaceAppSerializer,
+                                   SimpleESAppSerializer):
+    """
+    Serializer for Fireplace Feed pages (mostly detail pages). Needs
+    collection groups.
+    """
+    class Meta(SimpleESAppSerializer.Meta):
+        fields = sorted(FireplaceAppSerializer.Meta.fields + ['group'])
+        exclude = FireplaceAppSerializer.Meta.exclude
 
 
 class FireplaceCollectionMembershipField(CollectionMembershipField):

--- a/mkt/webapps/indexers.py
+++ b/mkt/webapps/indexers.py
@@ -433,8 +433,8 @@ class WebappIndexer(BaseIndexer):
         WebappIndexer.bulk_index(docs, es=ES, index=index or cls.get_index())
 
     @classmethod
-    def get_app_filter(cls, request, additional_data, sq=None,
-                       reviewers=False):
+    def get_app_filter(cls, request, additional_data=None, sq=None,
+                       app_ids=None, reviewers=False):
         """
         THE grand, consolidated ES filter for Webapps. By default:
         - Excludes non-public apps.
@@ -444,12 +444,15 @@ class WebappIndexer(BaseIndexer):
 
         additional_data -- an object with more data to allow more filtering.
         sq -- if you have an existing search object to filter off of.
+        app_ids -- if you want to filter by a list of app IDs.
         reviewers -- doesn't apply the consumer-side excludes (public/region).
         """
         from mkt.api.base import get_region_from_request
         from mkt.search.views import name_query
 
         sq = sq or cls.search()
+        additional_data = additional_data or {}
+        app_ids = app_ids or []
 
         data = {
             'app_type': [],
@@ -462,7 +465,7 @@ class WebappIndexer(BaseIndexer):
             'premium_type': [],
             'profile': get_feature_profile(request),
             'q': '',
-            'region': get_region_from_request(request).id,
+            'region': getattr(get_region_from_request(request), 'id', None),
             'status': None,
             'supported_locales': [],
             'tags': '',
@@ -508,10 +511,13 @@ class WebappIndexer(BaseIndexer):
             if data['is_offline'] is not None:
                 must.append(F('term', is_offline=data['is_offline']))
 
-        if must:
-            sq = sq.filter(es_filter.Bool(must=must))
+        # SHOULD.
+        should = [es_filter.Terms(id=app_ids)]
 
         # FILTER.
+        if must or should:
+            sq = sq.filter(es_filter.Bool(must=must, should=should))
+
         if data['region'] and not reviewers:
             # Region exclusions.
             sq = sq.filter(~F('term', region_exclusions=data['region']))

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -549,10 +549,9 @@ class ESAppFeedSerializer(BaseESAppFeedSerializer):
     """
     class Meta(ESAppSerializer.Meta):
         fields = [
-            'author', 'device_types', 'icons', 'id', 'is_disabled',
+            'author', 'device_types', 'icons', 'id',
             'is_packaged', 'manifest_url', 'name', 'payment_required',
-            'premium_type', 'price', 'price_locale', 'ratings', 'regions',
-            'status', 'slug', 'user'
+            'premium_type', 'price', 'price_locale', 'ratings', 'slug', 'user'
         ]
 
 
@@ -563,8 +562,7 @@ class ESAppFeedCollectionSerializer(BaseESAppFeedSerializer):
     """
     class Meta(ESAppSerializer.Meta):
         fields = [
-            'device_types', 'icons', 'id', 'is_disabled', 'slug', 'regions',
-            'status'
+            'device_types', 'icons', 'id', 'slug',
         ]
 
 
@@ -599,11 +597,7 @@ class SuggestionsESAppSerializer(ESAppSerializer):
 
 class FeedDiscoPlaceESAppSerializer(SuggestionsESAppSerializer):
     class Meta(ESAppSerializer.Meta):
-        # Feed needs status, is_disabled and regions in the serializer in
-        # order to do some filtering in the view. The view will drop regions
-        # and is_disabled from the serialization.
-        fields = ['name', 'absolute_url', 'icon',
-                  'regions', 'status', 'is_disabled']
+        fields = ['name', 'absolute_url', 'icon']
 
     def get_icon(self, app):
         return app.get_icon_url(128)

--- a/mkt/webapps/tests/test_serializers.py
+++ b/mkt/webapps/tests/test_serializers.py
@@ -667,6 +667,13 @@ class TestESAppSerializer(amo.tests.ESTestCase):
         res = self.serialize()
         eq_(res['author'], '')
 
+    def test_feed_collection_group(self):
+        app = WebappIndexer.search().filter(
+            'term', id=self.app.pk).execute().hits[0]
+        app['group_translations'] = [{'lang': 'en-US', 'string': 'My Group'}]
+        res = ESAppSerializer(app, context={'request': self.request})
+        eq_(res.data['group'], {'en-US': 'My Group'})
+
 
 class TestSimpleESAppSerializer(amo.tests.ESTestCase):
     fixtures = fixture('webapp_337141')


### PR DESCRIPTION
We got a new fancy filter in WebappIndexer.get_app_filter, let's use that.
- Removes any in-view filtering we did and any fields we added to the serializers for that.
- Allows us to do app limiting in the serializers again.
- Uses a common ES filter that's shared with regular and reviewer search.
