### PR TITLE
Remove useless 'weight' field from fireplace API (bug 1064389)

### DIFF
--- a/mkt/fireplace/serializers.py
+++ b/mkt/fireplace/serializers.py
@@ -1,5 +1,3 @@
-from rest_framework.serializers import SerializerMethodField
-
 from mkt.collections.serializers import (CollectionSerializer,
                                          CollectionMembershipField)
 from mkt.webapps.serializers import SimpleAppSerializer, SimpleESAppSerializer
@@ -27,14 +25,10 @@ class FireplaceAppSerializer(BaseFireplaceAppSerializer, SimpleAppSerializer):
 
 class FireplaceESAppSerializer(BaseFireplaceAppSerializer,
                                SimpleESAppSerializer):
-    weight = SerializerMethodField('get_weight')
 
     class Meta(SimpleESAppSerializer.Meta):
-        fields = sorted(FireplaceAppSerializer.Meta.fields + ['weight'])
+        fields = FireplaceAppSerializer.Meta.fields
         exclude = FireplaceAppSerializer.Meta.exclude
-
-    def get_weight(self, obj):
-        return obj.es_data.get('weight', 1)
 
     def get_user_info(self, app):
         # Fireplace search should always be anonymous for extra-cacheability.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1064389

This was only used by our first marketplace prototype for tarako devices, darjeeling, and never used in production.
