### PR TITLE
allow disable search app filter for curator (bug 1066755)

### DIFF
--- a/mkt/reviewers/views.py
+++ b/mkt/reviewers/views.py
@@ -1130,7 +1130,7 @@ class ReviewersSearchView(SearchView):
         # Do filter.
         sq = apply_reviewer_filters(request, WebappIndexer.search(),
                                     data=form_data)
-        sq = WebappIndexer.get_app_filter(request, data, sq=sq, reviewers=True)
+        sq = WebappIndexer.get_app_filter(request, data, sq=sq, no_filter=True)
 
         page = self.paginate_queryset(sq)
         return self.get_pagination_serializer(page), request.GET.get('q', '')

--- a/mkt/search/views.py
+++ b/mkt/search/views.py
@@ -176,8 +176,11 @@ class SearchView(CORSMixin, MarketplaceView, GenericAPIView):
         form_data = form.cleaned_data
 
         # Query and filter.
-        sq = WebappIndexer.get_app_filter(request,
-                                          search_form_to_es_fields(form_data))
+        no_filter = (
+            request.GET.get('filtering', '1') == '0' and
+            request.user.groups.filter(rules__contains='Feed:Curate').exists())
+        sq = WebappIndexer.get_app_filter(
+            request, search_form_to_es_fields(form_data), no_filter=no_filter)
 
         # Sort.
         sq = _sort_search(request, sq, form_data)


### PR DESCRIPTION
Pass in `filtering=0` as a GET and if you're a feed curator, you can see non-region-excluded and non-status-excluded apps.

Re-use existing filter-disabling that the reviewers search uses.
