### PR TITLE
Set source in settings on FxA login (bug 1070008)

### DIFF
--- a/mkt/account/tests/test_views.py
+++ b/mkt/account/tests/test_views.py
@@ -524,6 +524,11 @@ class TestFxaLoginHandler(TestCase):
         assert 'auth_response' in data
         assert 'apps' not in data
 
+    def test_login_settings(self):
+        data = self._test_login()
+        eq_(data['settings']['source'], 'firefox-accounts')
+
+
     def test_logout(self):
         UserProfile.objects.create(email='cvan@mozilla.com')
         data = self._test_login()

--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -173,6 +173,7 @@ class FxaLoginView(CORSMixin, CreateAPIViewWithoutModel):
             'settings': {
                 'display_name': request.user.display_name,
                 'email': request.user.email,
+                'source': 'firefox-accounts',
             }
         }
         # Serializers give up if they aren't passed an instance, so we


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1070008

This sets the source in the user's setting so fireplace (https://github.com/mozilla/fireplace/pull/668) knows that the user just signed in with FxA.
