### PR TITLE
Account source in user detail 1052625

### DIFF
--- a/docs/api/topics/accounts.rst
+++ b/docs/api/topics/accounts.rst
@@ -25,6 +25,7 @@ lookup the logged in user account id.
         {
             "resource_uri": "/api/v2/account/settings/1/",
             "display_name": "Nice person",
+            "verified": true
         }
 
 To update account information:

--- a/mkt/account/tests/test_serializers.py
+++ b/mkt/account/tests/test_serializers.py
@@ -1,0 +1,58 @@
+import mock
+from nose.tools import eq_
+
+import amo
+import amo.tests
+from mkt.account.serializers import AccountSerializer, AccountInfoSerializer
+from mkt.users.models import UserProfile
+
+
+class TestAccountSerializer(amo.tests.TestCase):
+    def setUp(self):
+        self.account = UserProfile()
+
+    def serializer(self):
+        return AccountSerializer(instance=self.account)
+
+    def test_display_name_returns_name(self):
+        with mock.patch.object(UserProfile, 'name', 'Account name'):
+            eq_(self.serializer().data['display_name'], 'Account name')
+
+    def test_not_verified(self):
+        self.account.is_verified = False
+        eq_(self.serializer().data['verified'], False)
+
+    def test_verified(self):
+        self.account.is_verified = True
+        eq_(self.serializer().data['verified'], True)
+
+
+class TestAccountInfoSerializer(amo.tests.TestCase):
+    UNKNOWN = amo.LOGIN_SOURCE_LOOKUP[amo.LOGIN_SOURCE_UNKNOWN]
+    FIREFOX_ACCOUNTS = amo.LOGIN_SOURCE_LOOKUP[amo.LOGIN_SOURCE_FXA]
+
+    def setUp(self):
+        self.account = UserProfile()
+
+    def serializer(self):
+        return AccountInfoSerializer(instance=self.account)
+
+    def test_source_is_a_slug_default(self):
+        eq_(self.serializer().data['source'], self.UNKNOWN)
+
+    def test_source_is_fxa(self):
+        self.account.source = amo.LOGIN_SOURCE_FXA
+        eq_(self.serializer().data['source'], self.FIREFOX_ACCOUNTS)
+
+    def test_source_is_invalid(self):
+        self.account.source = -1
+        eq_(self.serializer().data['source'], self.UNKNOWN)
+
+    def test_source_is_read_only(self):
+        serializer = AccountInfoSerializer(
+            instance=None,
+            data={'source': amo.LOGIN_SOURCE_FXA, 'display_name': 'Hey!'},
+            partial=True)
+        eq_(serializer.is_valid(), True)
+        # This works because the model field is `editable=False`.
+        eq_(serializer.save().source, amo.LOGIN_SOURCE_UNKNOWN)

--- a/mkt/account/urls.py
+++ b/mkt/account/urls.py
@@ -2,9 +2,9 @@ from django.conf.urls import include, patterns, url
 
 from mkt.users import views
 
-from mkt.account.views import (AccountView, FeedbackView, FxaLoginView,
-                               InstalledView, LoginView, LogoutView,
-                               NewsletterView, PermissionsView)
+from mkt.account.views import (AccountView, AccountInfoView, FeedbackView,
+                               FxaLoginView, InstalledView, LoginView,
+                               LogoutView, NewsletterView, PermissionsView)
 
 
 drf_patterns = patterns('',
@@ -18,6 +18,8 @@ drf_patterns = patterns('',
         name='account-permissions'),
     url('^settings/(?P<pk>[^/]+)/$', AccountView.as_view(),
         name='account-settings'),
+    url('^info/(?P<email>[^/]+)$', AccountInfoView.as_view(),
+        name='account-info'),
 )
 
 api_patterns = patterns('',

--- a/mkt/constants/base.py
+++ b/mkt/constants/base.py
@@ -235,6 +235,18 @@ LOGIN_SOURCE_FXA = 4
 # Signups via Webpay Purchases
 LOGIN_SOURCE_WEBPAY = 5
 
+LOGIN_SOURCE_LOOKUP = {
+    LOGIN_SOURCE_UNKNOWN: 'unknown',
+    LOGIN_SOURCE_BROWSERID: 'browserid',
+    LOGIN_SOURCE_MMO_BROWSERID: 'mmo-browserid',
+    LOGIN_SOURCE_AMO_BROWSERID: 'amo-browserid',
+    LOGIN_SOURCE_FXA: 'firefox-accounts',
+    LOGIN_SOURCE_WEBPAY: 'webpay',
+}
+# Add slug ~> id to the dict so lookups can be done with id or slug.
+for source_id, source_slug in LOGIN_SOURCE_LOOKUP.items():
+    LOGIN_SOURCE_LOOKUP[source_slug] = source_id
+
 # These are logins that use BrowserID.
 LOGIN_SOURCE_BROWSERIDS = [LOGIN_SOURCE_BROWSERID, LOGIN_SOURCE_AMO_BROWSERID,
                            LOGIN_SOURCE_MMO_BROWSERID, LOGIN_SOURCE_WEBPAY]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1052625

Add an anonymous API endpoints to check the account source for an email address. This will either return `{"source":"firefox-accounts"}` or `{"source":"unknown"}` and will not 404. This is used in https://github.com/mozilla/fireplace/pull/670.

Add `verified` to the account settings endpoint so the FxA migration can start a pre-verified FxA registration flow. No PR for fireplace yet.
