### PR TITLE
Expand privacy policy help text (bug 1055790)

### DIFF
--- a/mkt/submit/forms.py
+++ b/mkt/submit/forms.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from django import forms
 from django.conf import settings
+from django.utils.safestring import mark_safe
 
 import basket
 import happyforms
@@ -277,6 +278,10 @@ class NewWebappForm(DeviceTypeForm, NewWebappVersionForm):
 
 class AppDetailsBasicForm(TranslationFormMixin, happyforms.ModelForm):
     """Form for "Details" submission step."""
+    PRIVACY_MDN_URL = (
+        'https://developer.mozilla.org/Marketplace/'
+        'Publishing/Policies_and_Guidelines/Privacy_policies')
+
 
     PUBLISH_CHOICES = (
         (amo.PUBLISH_IMMEDIATE,
@@ -297,8 +302,15 @@ class AppDetailsBasicForm(TranslationFormMixin, happyforms.ModelForm):
         label=_lazy(u'Privacy Policy:'),
         widget=TransTextarea(attrs={'rows': 6}),
         help_text=_lazy(
-            u"A privacy policy that explains what data is transmitted from a "
-            u"user's computer and how it is used is required."))
+            u'A privacy policy explains how you handle data received '
+            u'through your app.  For example: what data do you receive? '
+            u'How do you use it? Who do you share it with? Do you '
+            u'receive personal information? Do you take steps to make '
+            u'it anonymous? What choices do users have to control what '
+            u'data you and others receive? Enter your privacy policy '
+            u'link or text above.  If you don\'t have a privacy '
+            u'policy, <a href="{url}" target="_blank">learn more on how to '
+            u'write one.</a>'))
     homepage = TransField.adapt(forms.URLField)(
         label=_lazy(u'Homepage:'), required=False,
         widget=TransInput(attrs={'class': 'full'}),
@@ -342,6 +354,13 @@ class AppDetailsBasicForm(TranslationFormMixin, happyforms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop('request')
+
+        # TODO: remove this and put it in the field definition above.
+        # See https://bugzilla.mozilla.org/show_bug.cgi?id=1072513
+        privacy_field = self.base_fields['privacy_policy']
+        privacy_field.help_text = mark_safe(privacy_field.help_text.format(
+            url=self.PRIVACY_MDN_URL))
+
         super(AppDetailsBasicForm, self).__init__(*args, **kwargs)
 
     def clean_app_slug(self):

--- a/mkt/submit/tests/test_forms.py
+++ b/mkt/submit/tests/test_forms.py
@@ -1,4 +1,5 @@
 from django.forms.fields import BooleanField
+from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
 import mock
@@ -236,6 +237,17 @@ class TestAppDetailsBasicForm(amo.tests.TestCase):
         assert form.is_valid(), form.errors
         form.save()
         eq_(app.publish_type, amo.PUBLISH_PRIVATE)
+
+    def test_help_text_uses_safetext_and_includes_url(self):
+        app = self.get_app()
+        form = forms.AppDetailsBasicForm(
+            self.get_data(publish_type=amo.PUBLISH_PRIVATE),
+            request=self.request, instance=app)
+
+        help_text = form.base_fields['privacy_policy'].help_text
+        eq_(type(help_text), SafeText)
+        ok_('{url}' not in help_text)
+        ok_(form.PRIVACY_MDN_URL in help_text)
 
 
 class TestAppFeaturesForm(amo.tests.TestCase):


### PR DESCRIPTION
This turned out to be pretty tricky.  We want to embed some HTML with a link inside a lazily translated string in the help text of a form field.  Ideally we'd want to use mark_safe_lazy as seen here:

https://docs.djangoproject.com/en/1.6/topics/i18n/translation/#other-uses-of-lazy-in-delayed-translations

However this didn't seem to want to work for me.  I performed some experiments like:

```
In [7]: type(force_text(mark_safe_lazy(_lazy(u'hello'))))
Out[7]: django.utils.safestring.SafeText
```

which seem to indicate that mark_safe_lazy is behaving as expected, however if I use it like so:

help_text=mark_safe_lazy(_lazy(u'Expanded help text'))

then it would not correctly render the HTML like so:

![screenshot 2014-09-24 14 38 11](https://cloud.githubusercontent.com/assets/119884/4394184/f22a2426-441e-11e4-967d-5df421fe8a51.png)

I tried using the django built in ugettext_lazy rather than the one provided by tower but that didn't make a difference, if I change mark_safe_lazy to mark_safe then it does render correctly like so:

![screenshot 2014-09-24 15 08 19](https://cloud.githubusercontent.com/assets/119884/4394200/20e19ac4-441f-11e4-98bd-86007be80104.png)

However this will be evaluated at code init time, not at request time, so it won't correctly find the translation. so I had to push the mark_safe invocation into form init time (which happens within the request flow) so that it will be translated correctly.  

Another separate issue is that using a format string will also force a lazy string to become evaluated so if we were to use the format option to embed the URL, we would also have to do that lazily so that it's not applied until evaluation time during the request path.  Altogether this presented a few bizarre edge case challenges, and this solution is not ideal but it functions in the mean time, I have filed a ticket to clean this up if someone knows the correct solution.
