### PR TITLE
Use a path relative to MEDIA_URL for FxA CSS (bug 1074235)

### DIFF
--- a/mkt/commonplace/views.py
+++ b/mkt/commonplace/views.py
@@ -76,11 +76,13 @@ def commonplace(request, repo, **kwargs):
         # native fxa already provides navigator.id, and fallback fxa doesn't
         # need it.
         include_persona = False
-        site_settings = {'fxa_css_path': settings.FXA_CSS_URL}
+        site_settings = {}
     else:
         site_settings = {
             'persona_unverified_issuer': settings.BROWSERID_DOMAIN,
         }
+
+    site_settings['fxa_css_path'] = settings.FXA_CSS_PATH
 
     ctx = {
         'BUILD_ID': BUILD_ID,

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -717,7 +717,7 @@ FXA_CLIENT_ID = '7943afb7b9f54089'
 FXA_CLIENT_SECRET = '512d7bcaea26d88cf80934f9b720ab1662066869617fcd33f2b13d97de59636a'
 FXA_OAUTH_URL = 'https://oauth-stable.dev.lcip.org'
 FXA_MIGRATION_URL = '/fxa-migration'
-FXA_CSS_URL = '/media/fireplace/css/fxa.css'
+FXA_CSS_PATH = 'fireplace/css/fxa.css'
 
 if DEBUG:
     # In DEBUG mode, don't require HTTPS for FxA oauth redirects.


### PR DESCRIPTION
Always set fxa_css_path on commonplace views.

See https://github.com/mozilla/fireplace/pull/680 for fireplace changes.
