### PR TITLE
Edit localized in-app product names (bug 1070120)

### DIFF
--- a/media/css/devreg/in-app-products.styl
+++ b/media/css/devreg/in-app-products.styl
@@ -15,6 +15,18 @@
     width: 125px;
 }
 
+.in-app-product-active {
+    width: 5em;
+}
+
+.in-app-product-locale select {
+    width: 7.5em;
+}
+
+.in-app-product-name input[type="text"] {
+    width: 9em;
+}
+
 .inline-editing {
     .inline-edit {
         display: none;

--- a/mkt/developers/templates/developers/payments/in-app-product-row.html
+++ b/mkt/developers/templates/developers/payments/in-app-product-row.html
@@ -3,6 +3,16 @@
     <img src="{{ product.icon_url }}" width="64" height="64" class="in-app-product-logo-url">
     <div class="field-error error"></div>
   </td>
+  <td class="in-app-product-locale">
+    <div class="in-app-product-error error"></div>
+    {% with widget=form.fields['locale'].widget,
+            initial_locale=lazy_attr(product.name, 'locale', active_lang) %}
+      <span class="inline-view">{{ initial_locale }}</span>
+      {{ widget.render('locale', initial_locale,
+                       attrs={'class': 'inline-edit'}) }}
+    {% endwith %}
+    <div class="field-error error"></div>
+  </td>
   <td class="in-app-product-name">
     <span class="inline-view">{{ product.name }}</span>
     <div class="in-app-product-error error"></div>

--- a/mkt/developers/templates/developers/payments/in-app-products.html
+++ b/mkt/developers/templates/developers/payments/in-app-products.html
@@ -59,6 +59,7 @@
           <thead>
             <tr>
               <th>{{ _('Icon') }}</th>
+              <th>{{ _('Locale') }}</th>
               <th>{{ _('Name') }}</th>
               <th>{{ _('Price Point') }}</th>
               <th>{{ _('Product ID') }}</th>
@@ -77,7 +78,7 @@
         </p>
       </div>
       <script id="in-app-product-row-template" type="x-template">
-        {% with product=new_product %}
+        {% with product=new_product, active_lang=active_lang, lazy_attr=lazy_attr %}
           {% include "developers/payments/in-app-product-row.html" %}
         {% endwith %}
       </script>

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -380,10 +380,11 @@ def in_app_payments(request, addon_id, addon, webapp=True, account=None):
 @dev_required(webapp=True)
 @require_in_app_payments
 def in_app_products(request, addon_id, addon, webapp=True, account=None):
+    active_lang = request.LANG.lower()
     owner = acl.check_addon_ownership(request, addon)
     products = addon.inappproduct_set.all()
     new_product = InAppProduct(webapp=addon)
-    form = InAppProductForm()
+    form = InAppProductForm(initial={'locale': active_lang})
     list_url = None
     detail_url = None
     if addon.origin:
@@ -397,7 +398,7 @@ def in_app_products(request, addon_id, addon, webapp=True, account=None):
                   {'addon': addon, 'form': form, 'new_product': new_product,
                    'owner': owner, 'products': products, 'form': form,
                    'list_url': list_url, 'detail_url': detail_url,
-                   'active_lang': request.LANG.lower()})
+                   'active_lang': active_lang, 'lazy_attr': getattr})
 
 
 def _fix_origin_link(link):

--- a/mkt/inapp/serializers.py
+++ b/mkt/inapp/serializers.py
@@ -1,3 +1,4 @@
+import json
 from cStringIO import StringIO
 
 from django import forms
@@ -112,6 +113,10 @@ class InAppProductSerializer(serializers.ModelSerializer):
 
 
 class InAppProductForm(forms.ModelForm):
+    LOCALES = [(translation.to_locale(k).replace('_', '-').lower(), v)
+               for k, v in do_dictsort(settings.LANGUAGES)]
+
+    locale = forms.TypedChoiceField(required=False, choices=LOCALES)
 
     class Meta:
         model = InAppProduct


### PR DESCRIPTION
W.I.P. - DO NOT MERGE

This allows devs to edit localizations for in-app product names. They can select a language in edit mode and the text field will switch to that language. What's missing is you can't set the default locale for each product. I think we probably need that before landing this patch.

![screen shot 2014-09-29 at 5 30 47 pm](https://cloud.githubusercontent.com/assets/55398/4450772/c5a3f652-4829-11e4-9f27-60c5c7926ede.png)
