### PR TITLE
Replace collection data in /api/v1/search/featured/ by empty arrays (bug 1058292)

### DIFF
--- a/docs/api/topics/fireplace.rst
+++ b/docs/api/topics/fireplace.rst
@@ -74,9 +74,10 @@ Featured Search
 
 .. http:get:: /api/v2/fireplace/search/featured/
 
-    A copy of :ref:`the featured search API <featured-search-api>`. Like the
-    App API above, the response contains the specific subset of fields Fireplace
-    needs.
+    A copy of :ref:`the search API <search-api>`. Like the App API above, the
+    response contains the specific subset of fields Fireplace needs.
+
+    Only kept for backwards-compatibility purposes, don't use in new code.
 
 
 Consumer Information

--- a/docs/api/topics/search.rst
+++ b/docs/api/topics/search.rst
@@ -82,50 +82,6 @@ Search
 
     :status 200: successfully completed.
 
-.. _featured-search-api:
-
-Featured App Listing
-====================
-
-.. http:get::  /api/v2/fireplace/search/featured/
-
-    **Request**
-
-    Accepts the same parameters and returns the same objects as the
-    normal search interface: :ref:`search-api`.  Includes 'featured'
-    list of apps, listing featured apps for the requested category, if
-    any. When no category is specified, frontpage featured apps are
-    listed.
-
-    **Response**:
-
-    :param collections: A list of collections for the requested
-        category/region/carrier set, if any
-    :type collections: array
-    :param featured: A list of :ref:`apps <app-response-label>` featured
-        for the requested category/region/carrier set, if any
-    :type featured: array
-    :param meta: :ref:`meta-response-label`.
-    :type meta: object
-    :param objects: A :ref:`listing <objects-response-label>` of
-        :ref:`apps <app-response-label>` satisfying the search parameters.
-    :type objects: array
-    :param operator: A list of apps in the operator shelf for the requested
-        category/region/carrier set, if any
-    :type operator: array
-    :status 200: successfully completed.
-
-    The different types of collections returned are filtered using the same
-    parameters as :ref:`rocketfuel <rocketfuel>` listing API, using the same
-    :ref:`fallback mechanism <rocketfuel-fallback>` if no results are found
-    with the filters specified.
-
-    However, because there are 3 separate types of collections returned,
-    you can have 3 different fallbacks. Therefore, instead of returning one
-    single `API-Fallback` header, the HTTP response will contain up to 3
-    separate headers: `API-Fallback-collections`, `API-Fallback-featured` and
-    `API-Fallback-operator`. Their content is identical to the `API-Fallback`
-    header returned in rocketfuel listing API.
 
 .. _feature-profile-label:
 

--- a/mkt/api/v2/urls.py
+++ b/mkt/api/v2/urls.py
@@ -34,6 +34,9 @@ subfeedshelf.register('image_landing', views.FeedShelfLandingImageViewSet,
                       base_name='feed-shelf-landing-image')
 
 urlpatterns = patterns('',
+    url(r'^apps/search/featured/.*', endpoint_removed),
+    url(r'^rocketfuel/collections/.*', endpoint_removed),
+
     url(r'^account/operators/$', OperatorPermissionViewSet.as_view(
         {'get': 'list'}), name='operator-permissions'),
     url(r'^apps/recommend/$', RecommendationView.as_view(),
@@ -58,7 +61,6 @@ urlpatterns = patterns('',
         views.FeedElementGetView.as_view(), name='feed.fire_feed_element_get'),
     url(r'^consumer/feed/(?P<item_type>[\w]+)/(?P<slug>[^/.]+)/$',
         views.FeedElementGetView.as_view(), name='feed.feed_element_get'),
-    url(r'^rocketfuel/collections/.*', endpoint_removed),
     url(r'^transonic/feed/(?P<item_type>[\w]+)/$',
         views.FeedElementListView.as_view(), name='feed.feed_element_list'),
 ) + v1_urls

--- a/mkt/fireplace/urls.py
+++ b/mkt/fireplace/urls.py
@@ -3,8 +3,7 @@ from django.conf.urls import include, patterns, url
 from rest_framework.routers import SimpleRouter
 
 from mkt.fireplace.views import (AppViewSet, CollectionViewSet,
-                                 ConsumerInfoView, FeaturedSearchView,
-                                 SearchView)
+                                 ConsumerInfoView, SearchView)
 
 
 apps = SimpleRouter()
@@ -22,8 +21,11 @@ urlpatterns = patterns('',
     url(r'^fireplace/consumer-info/',
         ConsumerInfoView.as_view(),
         name='fireplace-consumer-info'),
+    # /featured/ is not used by fireplace anymore, but still used by yogafire,
+    # so we have to keep it, it's just an alias to the regular search instead
+    # of including extra data about collections.
     url(r'^fireplace/search/featured/',
-        FeaturedSearchView.as_view(),
+        SearchView.as_view(),
         name='fireplace-featured-search-api'),
     url(r'^fireplace/search/',
         SearchView.as_view(),

--- a/mkt/fireplace/views.py
+++ b/mkt/fireplace/views.py
@@ -12,7 +12,6 @@ from mkt.collections.views import CollectionViewSet as BaseCollectionViewSet
 from mkt.fireplace.serializers import (FireplaceAppSerializer,
                                        FireplaceCollectionSerializer,
                                        FireplaceESAppSerializer)
-from mkt.search.views import FeaturedSearchView as BaseFeaturedSearchView
 from mkt.search.views import SearchView as BaseSearchView
 from mkt.webapps.views import AppViewSet as BaseAppViewset
 
@@ -30,12 +29,6 @@ class CollectionViewSet(BaseCollectionViewSet):
 
 class AppViewSet(BaseAppViewset):
     serializer_class = FireplaceAppSerializer
-
-
-class FeaturedSearchView(BaseFeaturedSearchView):
-    serializer_class = FireplaceESAppSerializer
-    collections_serializer_class = FireplaceCollectionSerializer
-    authentication_classes = []
 
 
 class SearchView(BaseSearchView):


### PR DESCRIPTION
Also simplify fireplace version now that yogafire - which doesn't care about collections - is the only client left using it.

https://bugzilla.mozilla.org/show_bug.cgi?id=1058292
