### PR TITLE
Preverify email 1056338

### DIFF
--- a/docs/api/topics/accounts.rst
+++ b/docs/api/topics/accounts.rst
@@ -24,8 +24,7 @@ lookup the logged in user account id.
 
         {
             "resource_uri": "/api/v2/account/settings/1/",
-            "display_name": "Nice person",
-            "verified": true
+            "display_name": "Nice person"
         }
 
 To update account information:

--- a/mkt/account/serializers.py
+++ b/mkt/account/serializers.py
@@ -9,11 +9,10 @@ from mkt.users.models import UserProfile
 
 
 class AccountSerializer(serializers.ModelSerializer):
-    verified = serializers.BooleanField(source='is_verified', read_only=True)
 
     class Meta:
         model = UserProfile
-        fields = ['display_name', 'verified']
+        fields = ['display_name']
 
     def validate_display_name(self, attrs, source):
         """Validate that display_name is not empty"""
@@ -30,10 +29,11 @@ class AccountSerializer(serializers.ModelSerializer):
 
 class AccountInfoSerializer(serializers.ModelSerializer):
     source = serializers.CharField(read_only=True)
+    verified = serializers.BooleanField(source='is_verified', read_only=True)
 
     class Meta:
         model = UserProfile
-        fields = ['source']
+        fields = ['source', 'verified']
 
     def transform_source(self, obj, value):
         """Return the sources slug instead of the id."""

--- a/mkt/account/tests/test_serializers.py
+++ b/mkt/account/tests/test_serializers.py
@@ -18,14 +18,6 @@ class TestAccountSerializer(amo.tests.TestCase):
         with mock.patch.object(UserProfile, 'name', 'Account name'):
             eq_(self.serializer().data['display_name'], 'Account name')
 
-    def test_not_verified(self):
-        self.account.is_verified = False
-        eq_(self.serializer().data['verified'], False)
-
-    def test_verified(self):
-        self.account.is_verified = True
-        eq_(self.serializer().data['verified'], True)
-
 
 class TestAccountInfoSerializer(amo.tests.TestCase):
     UNKNOWN = amo.LOGIN_SOURCE_LOOKUP[amo.LOGIN_SOURCE_UNKNOWN]
@@ -56,3 +48,11 @@ class TestAccountInfoSerializer(amo.tests.TestCase):
         eq_(serializer.is_valid(), True)
         # This works because the model field is `editable=False`.
         eq_(serializer.save().source, amo.LOGIN_SOURCE_UNKNOWN)
+
+    def test_not_verified(self):
+        self.account.is_verified = False
+        eq_(self.serializer().data['verified'], False)
+
+    def test_verified(self):
+        self.account.is_verified = True
+        eq_(self.serializer().data['verified'], True)

--- a/mkt/account/urls.py
+++ b/mkt/account/urls.py
@@ -3,7 +3,8 @@ from django.conf.urls import include, patterns, url
 from mkt.users import views
 
 from mkt.account.views import (fxa_preverify_view, fxa_preverify_key,
-                               AccountView, AccountInfoView, FeedbackView,
+                               AccountView, AccountInfoView,
+                               ConfirmFxAVerificationView, FeedbackView,
                                FxALoginView, InstalledView, LoginView,
                                LogoutView, NewsletterView, PermissionsView)
 
@@ -14,6 +15,9 @@ drf_patterns = patterns('',
     url('^login/$', LoginView.as_view(), name='account-login'),
     url('^fxa-login/$', FxALoginView.as_view(), name='fxa-account-login'),
     url('^fxa-preverify/$', fxa_preverify_view, name='fxa-preverify'),
+    url('^fxa-preverify/confirm/(?P<email>[^/]+)$',
+        ConfirmFxAVerificationView.as_view(),
+        name='fxa-confirm-preverify'),
     url('^fxa-preverify-key/$', fxa_preverify_key, name='fxa-preverify-key'),
     url('^logout/$', LogoutView.as_view(), name='account-logout'),
     url('^newsletter/$', NewsletterView.as_view(), name='account-newsletter'),

--- a/mkt/users/tasks.py
+++ b/mkt/users/tasks.py
@@ -2,8 +2,20 @@ from celeryutils import task
 
 from django.utils.encoding import force_text
 
+from tower import ugettext_lazy as _
+
 from mkt.site.mail import send_html_mail_jinja
 from mkt.users.models import UserProfile
+
+fxa_email_subjects = {
+    'customers-before': _('Firefox Accounts is coming'),
+    'customers-during': _('Activate your Firefox Account'),
+    'customers-after': _('Activate your Firefox Account'),
+    'developers-before': _('Firefox Accounts is coming'),
+    'developers-during': _('Activate your Firefox Account'),
+    'developers-after': _('Activate your Firefox Account')
+}
+fxa_email_types = fxa_email_subjects.keys()
 
 
 @task
@@ -19,6 +31,17 @@ def send_mail(user_ids, subject, html_template, text_template, link):
             context['link'] = 'https://marketplace.firefox.com'
 
         with user.activate_lang():
-            send_html_mail_jinja(force_text(subject),
+            send_html_mail_jinja(
+                force_text(subject),
                 html_template, text_template,
                 context, recipient_list=[user.email])
+
+
+@task
+def send_fxa_mail(user_ids, mail_type, send_link):
+    return send_mail(
+        user_ids,
+        fxa_email_subjects[mail_type],
+        'users/emails/{0}.html'.format(mail_type),
+        'users/emails/{0}.ltxt'.format(mail_type),
+        send_link)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1056338

API to send preverification emails to verified users on request. I moved `verified` from the user's account API to the unauthenticated one so we can skip this if we know it won't work.
