### PR TITLE
Update FxA email link and give results for verified account info

### DIFF
--- a/mkt/account/serializers.py
+++ b/mkt/account/serializers.py
@@ -28,6 +28,8 @@ class AccountSerializer(serializers.ModelSerializer):
 
 
 class AccountInfoSerializer(serializers.ModelSerializer):
+    ALLOWED_SOURCES = [amo.LOGIN_SOURCE_UNKNOWN, amo.LOGIN_SOURCE_FXA]
+
     source = serializers.CharField(read_only=True)
     verified = serializers.BooleanField(source='is_verified', read_only=True)
 
@@ -37,8 +39,10 @@ class AccountInfoSerializer(serializers.ModelSerializer):
 
     def transform_source(self, obj, value):
         """Return the sources slug instead of the id."""
-        return amo.LOGIN_SOURCE_LOOKUP.get(
-            value, amo.LOGIN_SOURCE_LOOKUP[amo.LOGIN_SOURCE_UNKNOWN])
+        if obj.source in self.ALLOWED_SOURCES:
+            return amo.LOGIN_SOURCE_LOOKUP[value]
+        else:
+            return amo.LOGIN_SOURCE_LOOKUP[amo.LOGIN_SOURCE_UNKNOWN]
 
 
 class FeedbackSerializer(PotatoCaptchaSerializer):

--- a/mkt/account/tests/test_serializers.py
+++ b/mkt/account/tests/test_serializers.py
@@ -40,6 +40,10 @@ class TestAccountInfoSerializer(amo.tests.TestCase):
         self.account.source = -1
         eq_(self.serializer().data['source'], self.UNKNOWN)
 
+    def test_source_is_unrelated(self):
+        self.account.source = amo.LOGIN_SOURCE_BROWSERID
+        eq_(self.serializer().data['source'], self.UNKNOWN)
+
     def test_source_is_read_only(self):
         serializer = AccountInfoSerializer(
             instance=None,

--- a/mkt/account/tests/test_views.py
+++ b/mkt/account/tests/test_views.py
@@ -822,7 +822,7 @@ class TestPreverify(RestOAuth):
     def test_preverify(self):
         res = self.client.post(reverse('fxa-preverify'))
         eq_(res.status_code, 200)
-        eq_(res.content, 'eyJhbGciOiJSUzI1NiIsImtpZCI6MSwiY3R5IjoiSldUIiwiamt1IjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXBpL3YxL2FjY291bnQvZnhhLXByZXZlcmlmeS1rZXkvIn0.eyJ0eXAiOiJtb3ppbGxhL2Z4YS9wcmVWZXJpZnlUb2tlbi92MSIsImF1ZCI6Imh0dHBzOi8vc3RhYmxlLmRldi5sY2lwLm9yZy8iLCJleHAiOjE0MDAwMDAwMDAsInN1YiI6ImNmaW5rZUBtLmNvbSJ9.Y4rpzDJIAVy7QjPra8f7gsMKFSLLT0QLiM8ayyIYSU0nOKSQezDTNr4_8KeWuUJaGiMJDuTVIayNWw6CNb_FmUwa1AyViNR86s4KwMVvCYhI12GpJNEQ98y0teFtNMpAY6Ox5DsddxcgLzFZYhzlPtVYPQJF4EmM2bBO-EXZusE')
+        eq_(res.content, 'eyJhbGciOiJSUzI1NiIsImtpZCI6MSwiY3R5IjoiSldUIiwiamt1IjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXBpL3YxL2FjY291bnQvZnhhLXByZXZlcmlmeS1rZXkvIn0.eyJ0eXAiOiJtb3ppbGxhL2Z4YS9wcmVWZXJpZnlUb2tlbi92MSIsImF1ZCI6InN0YWJsZS5kZXYubGNpcC5vcmciLCJleHAiOjE0MDAwMDAwMDAsInN1YiI6ImNmaW5rZUBtLmNvbSJ9.UCGxqgVNbFnS6Kr0mj75o-qcixgCH1rb0ZSJHo2fsrru_9d1QKenUFtB46T1i-LFc5L4-c8645tvB3iBYMk1jwur043wOPQFmTHWInJ-q1LBsc8Low7PHdTx7EXyfZ1F3nT2NZPB78KyaOlQOnDgV_68GKDDWTswLnDRMMJedkk')
 
     def test_reject_unverified(self):
         self.user.is_verified = False

--- a/mkt/account/utils.py
+++ b/mkt/account/utils.py
@@ -38,7 +38,7 @@ def fxa_preverify_token(user, expiry):
     """
     msg = {
         'exp': get_token_expiry(expiry),
-        'aud': settings.FXA_AUTH_SERVER,
+        'aud': settings.FXA_AUTH_DOMAIN,
         'sub': user.email,
         'typ': 'mozilla/fxa/preVerifyToken/v1',
     }
@@ -50,8 +50,10 @@ def fxa_preverify_token(user, expiry):
 
 def fxa_preverify_url(user, expiry):
     return urlparams('{0}/v1/authorization'.format(settings.FXA_OAUTH_URL),
-                     clientId=settings.FXA_CLIENT_ID,
-                     preVerifiedToken=fxa_preverify_token(user, expiry),
+                     action='signup',
+                     client_id=settings.FXA_CLIENT_ID,
+                     email=user.email,
+                     preVerifyToken=fxa_preverify_token(user, expiry),
                      scope='profile:email',
                      state=Signer().sign(user.pk)
                      )

--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -134,7 +134,7 @@ class AccountInfoView(AnonymousUserMixin, CORSMixin, RetrieveAPIView):
     permission_classes = []
     cors_allowed_methods = ['get']
     # Only select users with an FxA source, everything else will be unkown.
-    queryset = UserProfile.objects.filter(source=amo.LOGIN_SOURCE_FXA)
+    queryset = UserProfile.objects.all()
     serializer_class = AccountInfoSerializer
     lookup_field = 'email'
 

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -708,7 +708,7 @@ FIREPLACE_URL = ''
 # Where to find ffmpeg and totem if it's not in the PATH.
 FFMPEG_BINARY = 'ffmpeg'
 
-FXA_AUTH_SERVER = 'https://stable.dev.lcip.org/'
+FXA_AUTH_DOMAIN = 'stable.dev.lcip.org'  # Domain only, no protocol.
 FXA_CLIENT_ID = '7943afb7b9f54089'
 FXA_CLIENT_SECRET = '512d7bcaea26d88cf80934f9b720ab1662066869617fcd33f2b13d97de59636a'
 FXA_OAUTH_URL = 'https://oauth-stable.dev.lcip.org'

--- a/sites/altdev/settings_mkt.py
+++ b/sites/altdev/settings_mkt.py
@@ -170,6 +170,7 @@ PAYMENT_PROVIDERS = ['reference']
 PRE_GENERATE_APK_URL = 'http://dapk.net/application.apk'
 
 PREVERIFIED_ACCOUNT_KEY = private_mkt.PREVERIFIED_ACCOUNT_KEY
+FXA_AUTH_DOMAIN = getattr(private_mkt, 'FXA_AUTH_DOMAIN', '')
 FXA_OAUTH_URL = getattr(private_mkt, 'FXA_OAUTH_URL', '')
 FXA_CLIENT_ID = getattr(private_mkt, 'FXA_CLIENT_ID', '')
 FXA_CLIENT_SECRET = getattr(private_mkt, 'FXA_CLIENT_SECRET', '')

--- a/sites/dev/settings_mkt.py
+++ b/sites/dev/settings_mkt.py
@@ -174,6 +174,7 @@ PRE_GENERATE_APKS = True
 PRE_GENERATE_APK_URL = 'https://apk-controller.dev.mozaws.net/application.apk'
 
 PREVERIFIED_ACCOUNT_KEY = private_mkt.PREVERIFIED_ACCOUNT_KEY
+FXA_AUTH_DOMAIN = getattr(private_mkt, 'FXA_AUTH_DOMAIN', '')
 FXA_OAUTH_URL = getattr(private_mkt, 'FXA_OAUTH_URL', '')
 FXA_CLIENT_ID = getattr(private_mkt, 'FXA_CLIENT_ID', '')
 FXA_CLIENT_SECRET = getattr(private_mkt, 'FXA_CLIENT_SECRET', '')

--- a/sites/identitystage/settings_mkt.py
+++ b/sites/identitystage/settings_mkt.py
@@ -131,6 +131,7 @@ ES_DEFAULT_NUM_REPLICAS = 2
 ES_USE_PLUGINS = True
 
 PREVERIFIED_ACCOUNT_KEY = private_mkt.PREVERIFIED_ACCOUNT_KEY
+FXA_AUTH_DOMAIN = getattr(private_mkt, 'FXA_AUTH_DOMAIN', '')
 FXA_OAUTH_URL = getattr(private_mkt, 'FXA_OAUTH_URL', '')
 FXA_CLIENT_ID = getattr(private_mkt, 'FXA_CLIENT_ID', '')
 FXA_CLIENT_SECRET = getattr(private_mkt, 'FXA_CLIENT_SECRET', '')

--- a/sites/paymentsalt/settings_mkt.py
+++ b/sites/paymentsalt/settings_mkt.py
@@ -146,6 +146,7 @@ PAYMENT_PROVIDERS = ['bango', 'boku', 'reference']
 DEFAULT_PAYMENT_PROVIDER = 'bango'
 
 PREVERIFIED_ACCOUNT_KEY = private_mkt.PREVERIFIED_ACCOUNT_KEY
+FXA_AUTH_DOMAIN = getattr(private_mkt, 'FXA_AUTH_DOMAIN', '')
 FXA_OAUTH_URL = getattr(private_mkt, 'FXA_OAUTH_URL', '')
 FXA_CLIENT_ID = getattr(private_mkt, 'FXA_CLIENT_ID', '')
 FXA_CLIENT_SECRET = getattr(private_mkt, 'FXA_CLIENT_SECRET', '')

--- a/sites/prod/settings_mkt.py
+++ b/sites/prod/settings_mkt.py
@@ -151,6 +151,7 @@ PRE_GENERATE_APK_URL = 'https://controller.apk.firefox.com/application.apk'
 VALIDATOR_TIMEOUT = 110
 
 PREVERIFIED_ACCOUNT_KEY = private_mkt.PREVERIFIED_ACCOUNT_KEY
+FXA_AUTH_DOMAIN = getattr(private_mkt, 'FXA_AUTH_DOMAIN', '')
 FXA_OAUTH_URL = getattr(private_mkt, 'FXA_OAUTH_URL', '')
 FXA_CLIENT_ID = getattr(private_mkt, 'FXA_CLIENT_ID', '')
 FXA_CLIENT_SECRET = getattr(private_mkt, 'FXA_CLIENT_SECRET', '')

--- a/sites/stage/settings_mkt.py
+++ b/sites/stage/settings_mkt.py
@@ -148,6 +148,7 @@ PRE_GENERATE_APK_URL = \
 BOKU_SIGNUP_URL = 'https://merchants.boku.com/signup/signup_business?params=jEHWaTM7zm5cbPpheT2iS4xB1mkzO85uxVAo7rs7LVgy5JYGMWnUYDvxyEk8lxalP1pJZFv5d9oI%0A9bcXqxv0MQ%3D%3D'
 
 PREVERIFIED_ACCOUNT_KEY = private_mkt.PREVERIFIED_ACCOUNT_KEY
+FXA_AUTH_DOMAIN = getattr(private_mkt, 'FXA_AUTH_DOMAIN', '')
 FXA_OAUTH_URL = getattr(private_mkt, 'FXA_OAUTH_URL', '')
 FXA_CLIENT_ID = getattr(private_mkt, 'FXA_CLIENT_ID', '')
 FXA_CLIENT_SECRET = getattr(private_mkt, 'FXA_CLIENT_SECRET', '')


### PR DESCRIPTION
Retrieve all accounts in the account info view but only list `'firefox-accounts'` or `'unknown'` as the source.

Update the FxA preverified email to send the user to sign up and prefill the email address.
