### PR TITLE
Hide devhub FxA migration banner when waffle is off (bug 1078352)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -116,7 +116,8 @@
         </div>
       </div>
     {% endif %}
-    {% if not user.is_authenticated() or user.can_migrate_to_fxa() %}
+    {% if waffle.switch('fx-accounts-migration') and
+          (not logged or user.can_migrate_to_fxa()) %}
       <mkt-banner class="mkt-cloak" success dismiss="off">
         <span>
           {{ _('Firefox Accounts has arrived') }}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1078352
