### PR TITLE
Enable django TransactionMiddleware for everything (bug 1076949)

### DIFF
--- a/mkt/api/middleware.py
+++ b/mkt/api/middleware.py
@@ -10,7 +10,6 @@ from django.contrib.auth.middleware import (AuthenticationMiddleware as
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.middleware.gzip import GZipMiddleware as BaseGZipMiddleware
-from django.middleware.transaction import TransactionMiddleware
 from django.utils.cache import patch_vary_headers
 
 import commonware.log
@@ -196,26 +195,6 @@ class RestSharedSecretMiddleware(object):
         except Exception, e:
             log.info('Bad shared-secret auth data: %s (%s)', auth, e)
             return
-
-
-class APITransactionMiddleware(TransactionMiddleware):
-    """Wrap the transaction middleware so we can use it in the API only."""
-
-    def process_request(self, request):
-        if getattr(request, 'API', False):
-            return (super(APITransactionMiddleware, self)
-                    .process_request(request))
-
-    def process_exception(self, request, exception):
-        if getattr(request, 'API', False):
-            return (super(APITransactionMiddleware, self)
-                    .process_exception(request, exception))
-
-    def process_response(self, request, response):
-        if getattr(request, 'API', False):
-            return (super(APITransactionMiddleware, self)
-                    .process_response(request, response))
-        return response
 
 
 # How long to set the time-to-live on the cache.

--- a/mkt/api/tests/test_middleware.py
+++ b/mkt/api/tests/test_middleware.py
@@ -12,9 +12,8 @@ from test_utils import RequestFactory
 
 import amo.tests
 from mkt.api.middleware import (APIBaseMiddleware, APIFilterMiddleware,
-                                APIPinningMiddleware, APITransactionMiddleware,
-                                AuthenticationMiddleware, CORSMiddleware,
-                                GZipMiddleware)
+                                APIPinningMiddleware, AuthenticationMiddleware,
+                                CORSMiddleware, GZipMiddleware)
 import mkt.regions
 
 fireplace_url = 'http://firepla.ce:1234'
@@ -51,37 +50,6 @@ class TestCORS(amo.tests.TestCase):
         eq_(res['Access-Control-Allow-Origin'], fireplace_url)
         eq_(res['Access-Control-Allow-Methods'], 'GET, OPTIONS')
         eq_(res['Access-Control-Allow-Credentials'], 'true')
-
-
-class TestTransactionMiddleware(amo.tests.TestCase):
-
-    def setUp(self):
-        self.prefix = APIBaseMiddleware()
-        self.transaction = APITransactionMiddleware()
-
-    def test_api(self):
-        req = RequestFactory().get('/api/foo/')
-        self.prefix.process_request(req)
-        ok_(req.API)
-
-    def test_not_api(self):
-        req = RequestFactory().get('/not-api/foo/')
-        self.prefix.process_request(req)
-        ok_(not req.API)
-
-    @mock.patch('django.db.transaction.enter_transaction_management')
-    def test_transactions(self, enter):
-        req = RequestFactory().get('/api/foo/')
-        self.prefix.process_request(req)
-        self.transaction.process_request(req)
-        ok_(enter.called)
-
-    @mock.patch('django.db.transaction.enter_transaction_management')
-    def test_not_transactions(self, enter):
-        req = RequestFactory().get('/not-api/foo/')
-        self.prefix.process_request(req)
-        self.transaction.process_request(req)
-        ok_(not enter.called)
 
 
 class TestPinningMiddleware(amo.tests.TestCase):

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -178,7 +178,7 @@ MIDDLEWARE_CLASSES = (
     'mkt.api.middleware.TimingMiddleware',
     'mkt.api.middleware.CORSMiddleware',
     'mkt.api.middleware.APIPinningMiddleware',
-    'mkt.api.middleware.APITransactionMiddleware',
+    'django.middleware.transaction.TransactionMiddleware',
     'mkt.api.middleware.APIFilterMiddleware',
 )
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1076949

There is little reason to have it only for the API, it's useful everywhere. Nested transactions should work, so we shouldn't need to do any other modifications (hopefully).
