### PR TITLE
Adds API endpoint listing all operator shelves upon which the current user has permission to operate (bug 1074368).

### DIFF
--- a/docs/api/topics/feed.rst
+++ b/docs/api/topics/feed.rst
@@ -1095,6 +1095,20 @@ List
     :type objects: array
 
 
+List User's
+===========
+
+.. http:get:: /api/v2/account/shelves/
+
+    A listing of operator shelves upon which the authenticating user has
+    permission to administer.
+
+    **Response**
+
+    A :ref:`listing <objects-response-label>` of :ref:`operator shelves
+        <feed-shelves>`.
+
+
 Detail
 ======
 

--- a/mkt/account/urls.py
+++ b/mkt/account/urls.py
@@ -1,12 +1,12 @@
 from django.conf.urls import include, patterns, url
 
-from mkt.users import views
-
 from mkt.account.views import (fxa_preverify_view, fxa_preverify_key,
                                AccountView, AccountInfoView,
                                ConfirmFxAVerificationView, FeedbackView,
                                FxALoginView, InstalledView, LoginView,
                                LogoutView, NewsletterView, PermissionsView)
+from mkt.feed.views import FeedShelfViewSet
+from mkt.users import views
 
 
 drf_patterns = patterns('',
@@ -27,6 +27,8 @@ drf_patterns = patterns('',
         name='account-settings'),
     url('^info/(?P<email>[^/]+)$', AccountInfoView.as_view(),
         name='account-info'),
+    url(r'^shelves/$', FeedShelfViewSet.as_view(
+        {'get': 'mine'}), name='feedshelves-mine'),
 )
 
 api_patterns = patterns('',

--- a/mkt/feed/tests/test_models.py
+++ b/mkt/feed/tests/test_models.py
@@ -13,6 +13,7 @@ import amo.tests
 import mkt.feed.constants as feed
 from mkt.feed.models import (FeedApp, FeedBrand, FeedCollection, FeedItem,
                              FeedShelf)
+from mkt.operators.models import OperatorPermission
 from mkt.site.fixtures import fixture
 from mkt.webapps.models import Webapp
 
@@ -62,6 +63,10 @@ class FeedTestMixin(object):
             region=region, **kwargs)
         shelf.set_apps(app_ids or [337141])
         return shelf
+
+    def feed_shelf_permission_factory(self, user, carrier=1, region=1):
+        return OperatorPermission.objects.create(user=user, carrier=carrier,
+                                                 region=region)
 
     def feed_item_factory(self, carrier=1, region=1,
                           item_type=feed.FEED_TYPE_APP, **kw):

--- a/mkt/operators/tests/test_views.py
+++ b/mkt/operators/tests/test_views.py
@@ -23,7 +23,7 @@ class TestPreloadCandidates(amo.tests.TestCase):
     def setUp(self):
         self.create_switch('preload-apps')
         self.url = reverse('operators.preloads')
-        self.user = UserProfile.objects.get()
+        self.user = UserProfile.objects.get(pk=322)
         self.app = app_factory()
 
     def _preload_factory(self):


### PR DESCRIPTION
![Mine.](https://cloud.githubusercontent.com/assets/23885/4565352/25abe82e-4f1f-11e4-866f-e56ec9b14b8a.gif)

r? @ngokevin @robhudson @diox 
