### PR TITLE
Hide FxA migration banner once dev uses FxA (bug 1080039)

### DIFF
--- a/media/js/devreg/devhub.js
+++ b/media/js/devreg/devhub.js
@@ -8,6 +8,11 @@
     });
 })(require);
 
+// Do this right away so it doesn't appear and get removed.
+if (require('storage').getItem('fxa-migrated')) {
+    $('#fxa-migration-banner').remove();
+}
+
 $(document).ready(function() {
 
     // Show daily message if it hasn't been seen yet

--- a/media/js/devreg/login.js
+++ b/media/js/devreg/login.js
@@ -1,30 +1,4 @@
-define('login', ['notification'], function(notification) {
-
-    function Storage() {
-        function _prefix(storageKey) {
-            var version = localStorage.getItem('latestStorageVersion') || '0';
-            return version + '::' + storageKey;
-        }
-
-        this.setItem = function (key, value) {
-            return localStorage.setItem(_prefix(key), JSON.stringify(value));
-        };
-
-        this.getItem = function (key) {
-            value = localStorage.getItem(_prefix(key));
-            try {
-                return JSON.parse(value);
-            } catch(e) {
-                return value;
-            }
-        };
-
-        this.removeItem = function (key) {
-            return localStorage.removeItem(_prefix(key));
-        };
-    }
-
-    var storage = new Storage();
+define('login', ['notification', 'storage'], function(notification, storage) {
     var requestedLogin = false;
     var readyForReload = false;
 
@@ -202,6 +176,9 @@ define('login', ['notification'], function(notification) {
         storage.setItem('settings', data.settings);
         storage.setItem('permissions', data.permissions);
         storage.setItem('user_apps', data.apps);
+        if (storage.getItem('settings').source === 'firefox-accounts') {
+            storage.setItem('fxa-migrated', true);
+        }
     }
 
     function clearToken() {

--- a/media/js/devreg/storage.js
+++ b/media/js/devreg/storage.js
@@ -1,0 +1,27 @@
+define('storage', [], function() {
+    function Storage() {
+        function _prefix(storageKey) {
+            var version = localStorage.getItem('latestStorageVersion') || '0';
+            return version + '::' + storageKey;
+        }
+
+        this.setItem = function (key, value) {
+            return localStorage.setItem(_prefix(key), JSON.stringify(value));
+        };
+
+        this.getItem = function (key) {
+            value = localStorage.getItem(_prefix(key));
+            try {
+                return JSON.parse(value);
+            } catch(e) {
+                return value;
+            }
+        };
+
+        this.removeItem = function (key) {
+            return localStorage.removeItem(_prefix(key));
+        };
+    }
+
+    return new Storage();
+});

--- a/mkt/asset_bundles.py
+++ b/mkt/asset_bundles.py
@@ -175,6 +175,7 @@ JS = {
         'js/devreg/login.js',
         'js/devreg/notification.js',
         'js/devreg/outgoing_links.js',
+        'js/devreg/storage.js',
         'js/devreg/tarako.js',
         'js/devreg/utils.js',
         'js/lib/csrf.js',
@@ -243,6 +244,7 @@ JS = {
         'js/lib/csrf.js',
         'js/impala/serializers.js',
         'js/devreg/login.js',
+        'js/devreg/storage.js',
     ),
     'mkt/in-app-products': (
         'js/lib/es5-shim.min.js', # We might already assume these work.

--- a/templates/base.html
+++ b/templates/base.html
@@ -118,7 +118,7 @@
     {% endif %}
     {% if waffle.switch('fx-accounts-migration') and
           (not logged or user.can_migrate_to_fxa()) %}
-      <mkt-banner class="mkt-cloak" success dismiss="off">
+      <mkt-banner id="fxa-migration-banner" class="mkt-cloak" success dismiss="off">
         <span>
           {{ _('Firefox Accounts has arrived') }}
         </span>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1080039

Hide the FxA migration banner once the user signs in with FxA on the devhub.
