### PR TITLE
reference terms not pulled correctly

### DIFF
--- a/media/js/devreg/payments-manage.js
+++ b/media/js/devreg/payments-manage.js
@@ -104,7 +104,7 @@ define('payments-manage', ['payments'], function(payments) {
             }));
 
             // Plop in text of agreement.
-            $('.agreement-text').html(response.text);
+            $('.agreement-text').html(response.reference.text);
 
             if (response.accepted) {
                 $overlay.find('form').trigger('submit');


### PR DESCRIPTION
before
![screenshot 2014-10-10 14 22 58](https://cloud.githubusercontent.com/assets/74699/4599249/b32044fc-50c3-11e4-9027-95e5538cba30.png)
after
![screenshot 2014-10-10 14 22 05](https://cloud.githubusercontent.com/assets/74699/4599254/bb315c1c-50c3-11e4-9c2a-a2b337e265cd.png)
