### PR TITLE
Cache index.html for commonplace projects for a few minutes (bug 1071468)

### DIFF
--- a/mkt/commonplace/tests/test_views.py
+++ b/mkt/commonplace/tests/test_views.py
@@ -47,6 +47,7 @@ class TestCommonplace(BaseCommonPlaceTests):
         self.assertEquals(res.context['repo'], 'fireplace')
         self.assertContains(res, 'splash.css')
         self.assertContains(res, 'login.persona.org/include.js')
+        eq_(res['Cache-Control'], 'max-age=180')
 
     def test_commbadge(self):
         res = self._test_url('/comm/')
@@ -54,6 +55,7 @@ class TestCommonplace(BaseCommonPlaceTests):
         self.assertEquals(res.context['repo'], 'commbadge')
         self.assertNotContains(res, 'splash.css')
         self.assertContains(res, 'login.persona.org/include.js')
+        eq_(res['Cache-Control'], 'max-age=180')
 
     def test_rocketfuel(self):
         res = self._test_url('/curation/')
@@ -61,6 +63,7 @@ class TestCommonplace(BaseCommonPlaceTests):
         self.assertEquals(res.context['repo'], 'rocketfuel')
         self.assertNotContains(res, 'splash.css')
         self.assertContains(res, 'login.persona.org/include.js')
+        eq_(res['Cache-Control'], 'max-age=180')
 
     def test_transonic(self):
         res = self._test_url('/curate/')
@@ -68,6 +71,7 @@ class TestCommonplace(BaseCommonPlaceTests):
         self.assertEquals(res.context['repo'], 'transonic')
         self.assertNotContains(res, 'splash.css')
         self.assertContains(res, 'login.persona.org/include.js')
+        eq_(res['Cache-Control'], 'max-age=180')
 
     def test_discoplace(self):
         res = self._test_url('/discovery/')
@@ -75,6 +79,7 @@ class TestCommonplace(BaseCommonPlaceTests):
         self.assertEquals(res.context['repo'], 'discoplace')
         self.assertContains(res, 'splash.css')
         self.assertNotContains(res, 'login.persona.org/include.js')
+        eq_(res['Cache-Control'], 'max-age=180')
 
     def test_fireplace_persona_js_not_included_on_firefox_os(self):
         for url in ('/server.html?mccs=blah',

--- a/mkt/commonplace/views.py
+++ b/mkt/commonplace/views.py
@@ -9,6 +9,7 @@ from django.core.files.storage import default_storage as storage
 from django.core.urlresolvers import resolve
 from django.http import HttpResponse, Http404
 from django.shortcuts import render
+from django.views.decorators.cache import cache_control
 from django.views.decorators.gzip import gzip_page
 
 import jingo
@@ -93,6 +94,7 @@ def get_imgurls(repo):
 
 
 @gzip_page
+@cache_control(max_age=settings.CACHE_MIDDLEWARE_SECONDS)
 def commonplace(request, repo, **kwargs):
     if repo not in settings.COMMONPLACE_REPOS:
         raise Http404


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1071468

Those pages are served by us, not the CDN, so we can afford to cache them for a few minutes to help repeat views. If a client wants to bypass the cache (for instance when we push to production) they can hit reload, their browser will send a `If-Modified-Since` or `If-None-Match` and we'll give them the new content.
