### PR TITLE
Use Django's RequestFactory in favor of test_utils.

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -18,7 +18,7 @@ from django.core.urlresolvers import reverse
 from django.db.models.signals import post_save
 from django.forms.fields import Field
 from django.http import SimpleCookie
-from django.test.client import Client
+from django.test.client import Client, RequestFactory
 from django.utils import translation
 
 import caching
@@ -32,7 +32,6 @@ from nose.exc import SkipTest
 from nose.tools import eq_
 from pyquery import PyQuery as pq
 from redisutils import mock_redis, reset_redis
-from test_utils import RequestFactory
 from waffle import cache_sample, cache_switch
 from waffle.models import Flag, Sample, Switch
 

--- a/mkt/account/tests/test_utils_.py
+++ b/mkt/account/tests/test_utils_.py
@@ -1,12 +1,13 @@
+from django.test.client import RequestFactory
+
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 import amo.tests
+from mkt.account.utils import purchase_list
 from mkt.constants import apps
-from mkt.webapps.models import Installed, Webapp
 from mkt.site.fixtures import fixture
 from mkt.users.models import UserProfile
-from ..utils import purchase_list
+from mkt.webapps.models import Installed, Webapp
 
 
 class TestUtils(amo.tests.TestCase):

--- a/mkt/api/tests/test_authentication.py
+++ b/mkt/api/tests/test_authentication.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
 
 from mock import Mock, patch
 from multidb.pinning import this_thread_is_pinned, unpin_this_thread
@@ -15,9 +16,8 @@ from mkt.api.middleware import (APIBaseMiddleware, RestOAuthMiddleware,
                                 RestSharedSecretMiddleware)
 from mkt.api.models import Access, generate
 from mkt.api.tests.test_oauth import OAuthClient
-from mkt.site.helpers import absolutify
 from mkt.site.fixtures import fixture
-from test_utils import RequestFactory
+from mkt.site.helpers import absolutify
 from mkt.users.models import UserProfile
 
 

--- a/mkt/api/tests/test_authorization.py
+++ b/mkt/api/tests/test_authorization.py
@@ -1,18 +1,17 @@
 from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
 
-from rest_framework.permissions import AllowAny, BasePermission
 from mock import Mock
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
+from rest_framework.permissions import AllowAny, BasePermission
 
 from amo.tests import TestCase
-from mkt.users.models import UserProfile
-
-from mkt.api.authorization import (AllowAuthor, AllowAppOwner, AllowNone,
-                                   AllowOwner, AllowRelatedAppOwner,
-                                   AllowReadOnlyIfPublic, AllowSelf, AnyOf,
+from mkt.api.authorization import (AllowAppOwner, AllowAuthor, AllowNone,
+                                   AllowOwner, AllowReadOnlyIfPublic,
+                                   AllowRelatedAppOwner, AllowSelf, AnyOf,
                                    ByHttpMethod, flag, GroupPermission, switch)
 from mkt.site.fixtures import fixture
+from mkt.users.models import UserProfile
 from mkt.webapps.models import Webapp
 
 

--- a/mkt/api/tests/test_base.py
+++ b/mkt/api/tests/test_base.py
@@ -2,6 +2,7 @@ import urllib
 
 from django import forms
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 from mock import patch
 from nose.tools import eq_
@@ -9,7 +10,6 @@ from rest_framework.decorators import (authentication_classes,
                                        permission_classes)
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
-from test_utils import RequestFactory
 
 from amo.tests import TestCase
 from mkt.api.base import cors_api_view, SubRouterWithFormat
@@ -82,10 +82,10 @@ class TestSubRouterWithFormat(TestCase):
         router = SubRouterWithFormat()
         router.register('foo', ModelViewSet, base_name='bar')
         expected = [
-            {'name': 'bar-list', 'pattern': '^(?P<pk>[^/]+)/foo/$' },
-            {'name': 'bar-detail', 'pattern': '^(?P<pk>[^/]+)/foo/$' },
+            {'name': 'bar-list', 'pattern': '^(?P<pk>[^/]+)/foo/$'},
+            {'name': 'bar-detail', 'pattern': '^(?P<pk>[^/]+)/foo/$'},
             {'name': 'bar-list',
-             'pattern': '^(?P<pk>[^/.]+)/foo\\.(?P<format>[a-z0-9]+)$' },
+             'pattern': '^(?P<pk>[^/.]+)/foo\\.(?P<format>[a-z0-9]+)$'},
             {'name': 'bar-detail',
              'pattern': '^(?P<pk>[^/.]+)/foo\\.(?P<format>[a-z0-9]+)$'},
         ]
@@ -99,10 +99,10 @@ class TestSubRouterWithFormat(TestCase):
         router = SubRouterWithFormat(trailing_slash=False)
         router.register('foo', ModelViewSet, base_name='bar')
         expected = [
-            {'name': 'bar-list', 'pattern': '^(?P<pk>[^/.]+)/foo$' },
-            {'name': 'bar-detail', 'pattern': '^(?P<pk>[^/.]+)/foo$' },
+            {'name': 'bar-list', 'pattern': '^(?P<pk>[^/.]+)/foo$'},
+            {'name': 'bar-detail', 'pattern': '^(?P<pk>[^/.]+)/foo$'},
             {'name': 'bar-list',
-             'pattern': '^(?P<pk>[^/.]+)/foo\\.(?P<format>[a-z0-9]+)$' },
+             'pattern': '^(?P<pk>[^/.]+)/foo\\.(?P<format>[a-z0-9]+)$'},
             {'name': 'bar-detail',
              'pattern': '^(?P<pk>[^/.]+)/foo\\.(?P<format>[a-z0-9]+)$'},
         ]

--- a/mkt/api/tests/test_exceptions.py
+++ b/mkt/api/tests/test_exceptions.py
@@ -1,15 +1,15 @@
-from mkt.api.exceptions import custom_exception_handler
-
 from nose.tools import raises
 from rest_framework.response import Response
 from test_utils import TestCase
+
+from mkt.api.exceptions import custom_exception_handler
 
 
 class TestExceptionHandler(TestCase):
 
     def test_response(self):
         try:
-            1/0
+            1 / 0
         except Exception as exc:
             assert isinstance(custom_exception_handler(exc), Response)
 
@@ -17,6 +17,6 @@ class TestExceptionHandler(TestCase):
     def test_raised(self):
         with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=True):
             try:
-                1/0
+                1 / 0
             except Exception as exc:
                 custom_exception_handler(exc)

--- a/mkt/api/tests/test_fields.py
+++ b/mkt/api/tests/test_fields.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
+from django.core.exceptions import ValidationError
+from django.test.client import RequestFactory
+
 from mock import Mock
 from nose.tools import eq_, ok_
 from rest_framework.request import Request
 from rest_framework.serializers import CharField, Serializer
 from rest_framework.test import APIRequestFactory
-from test_utils import RequestFactory
-
-from django.core.exceptions import ValidationError
 
 import amo
 from amo.tests import TestCase

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -7,11 +7,11 @@ from decimal import Decimal
 from StringIO import StringIO
 
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 from mock import patch
 from nose.tools import eq_
 from rest_framework.request import Request
-from test_utils import RequestFactory
 
 import amo
 import mkt
@@ -820,7 +820,7 @@ class TestPriceTier(RestOAuth):
             'price': '0.99',
             'method': 'operator+card',
             'resource_uri': self.detail_url
-            })
+        })
 
     def test_detail(self):
         self.grant_permission(self.profile, self.permission)
@@ -832,7 +832,7 @@ class TestPriceTier(RestOAuth):
             'price': '0.99',
             'method': 'operator+card',
             'resource_uri': self.detail_url
-            })
+        })
 
     def test_post_unauthorized(self):
         res = self.client.post(self.list_url, '{}')

--- a/mkt/api/tests/test_middleware.py
+++ b/mkt/api/tests/test_middleware.py
@@ -3,18 +3,19 @@ from urlparse import parse_qs
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseServerError
+from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 import mock
 from multidb import this_thread_is_pinned
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import amo.tests
+import mkt.regions
 from mkt.api.middleware import (APIBaseMiddleware, APIFilterMiddleware,
                                 APIPinningMiddleware, AuthenticationMiddleware,
                                 CORSMiddleware, GZipMiddleware)
-import mkt.regions
+
 
 fireplace_url = 'http://firepla.ce:1234'
 

--- a/mkt/api/tests/test_oauth.py
+++ b/mkt/api/tests/test_oauth.py
@@ -6,7 +6,7 @@ from functools import partial
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
-from django.test.client import FakePayload
+from django.test.client import RequestFactory
 from django.utils.encoding import iri_to_uri, smart_str
 
 from django_browserid.tests import mock_browserid
@@ -14,7 +14,6 @@ from nose.tools import eq_, ok_
 from oauthlib import oauth1
 from pyquery import PyQuery as pq
 from rest_framework.request import Request
-from test_utils import RequestFactory
 
 from amo.helpers import urlparams
 from amo.tests import JSONClient, TestCase

--- a/mkt/api/tests/test_paginator.py
+++ b/mkt/api/tests/test_paginator.py
@@ -2,13 +2,12 @@ from urlparse import urlparse
 
 from django.core.paginator import Paginator
 from django.http import QueryDict
+from django.test.client import RequestFactory
 
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 from amo.tests import ESTestCase, TestCase
-
-from mkt.api.paginator import MetaSerializer, ESPaginator
+from mkt.api.paginator import ESPaginator, MetaSerializer
 from mkt.webapps.indexers import WebappIndexer
 
 

--- a/mkt/api/tests/test_serializer.py
+++ b/mkt/api/tests/test_serializer.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 from django.core.handlers.wsgi import WSGIRequest
 from django.test import TestCase
+from django.test.client import RequestFactory
 
 import mock
 from nose.tools import eq_, ok_
 from rest_framework.serializers import Serializer, ValidationError
-from test_utils import RequestFactory
 
-from mkt.users.models import UserProfile
 from mkt.api.serializers import PotatoCaptchaSerializer, URLSerializerMixin
 from mkt.site.fixtures import fixture
+from mkt.users.models import UserProfile
 
 
 class TestPotatoCaptchaSerializer(TestCase):
@@ -22,7 +22,6 @@ class TestPotatoCaptchaSerializer(TestCase):
         self.context = {'request': self.request}
         self.request.user.is_authenticated = lambda: False
         self.data = {'tuber': '', 'sprout': 'potato'}
-
 
     def test_success_authenticated(self):
         self.request.user = UserProfile.objects.get(id=999)
@@ -67,8 +66,8 @@ class TestURLSerializerMixin(TestCase):
                                          'url_basename': self.url_basename})
         self.request = RequestFactory().get('/')
         self.request.API_VERSION = 1
-        self.serializer = self.SerializerClass(context=
-            {'request': self.request})
+        self.serializer = self.SerializerClass(
+            context={'request': self.request})
         self.obj = self.Struct()
         self.obj.pk = 42
 

--- a/mkt/api/tests/test_views.py
+++ b/mkt/api/tests/test_views.py
@@ -7,16 +7,14 @@ from nose.tools import eq_, ok_
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpRequest
+from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from test_utils import RequestFactory
-
 import amo.tests
-from amo.helpers import urlparams
-
 import mkt
+from amo.helpers import urlparams
 from mkt.api.tests.test_oauth import RestOAuth
-from mkt.api.views import ErrorViewSet, endpoint_removed
+from mkt.api.views import endpoint_removed, ErrorViewSet
 from mkt.site.fixtures import fixture
 
 

--- a/mkt/carriers/tests.py
+++ b/mkt/carriers/tests.py
@@ -1,13 +1,12 @@
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 import mock
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 from amo.tests import TestCase
-
-from . import get_carrier, set_carrier, context_processors
-from .middleware import CarrierURLMiddleware
+from mkt.carriers import context_processors, get_carrier, set_carrier
+from mkt.carriers.middleware import CarrierURLMiddleware
 
 
 class TestCarrierURLs(TestCase):

--- a/mkt/collections/tasks.py
+++ b/mkt/collections/tasks.py
@@ -4,16 +4,17 @@ import os
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
 
 from celeryutils import task
 from rest_framework import serializers
-from test_utils import RequestFactory
 
 from amo.utils import chunked, JSONEncoder
 from mkt.collections.models import Collection
 from mkt.collections.serializers import CollectionSerializer
 from mkt.constants.regions import RESTOFWORLD
 from mkt.webapps.models import Webapp
+
 
 task_log = logging.getLogger('collections.tasks')
 

--- a/mkt/collections/tests/test_authorization.py
+++ b/mkt/collections/tests/test_authorization.py
@@ -1,6 +1,8 @@
 import json
 from urllib import urlencode
 
+from django.test.client import RequestFactory
+
 from nose.tools import ok_
 from rest_framework.generics import GenericAPIView
 from rest_framework.request import Request
@@ -13,7 +15,6 @@ from mkt.collections.authorization import (CanBeHeroAuthorization,
                                            StrictCuratorAuthorization)
 from mkt.collections.tests import CollectionTestMixin
 from mkt.site.fixtures import fixture
-from test_utils import RequestFactory
 from mkt.users.models import UserProfile
 
 

--- a/mkt/collections/tests/test_serializers.py
+++ b/mkt/collections/tests/test_serializers.py
@@ -3,11 +3,11 @@ import hashlib
 import json
 
 from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from nose.tools import eq_, ok_
 from rest_framework import serializers
-from test_utils import RequestFactory
 
 import amo
 import amo.tests
@@ -21,9 +21,9 @@ from mkt.collections.serializers import (CollectionMembershipField,
 from mkt.constants.features import FeatureProfile
 from mkt.search.views import FeaturedSearchView
 from mkt.site.fixtures import fixture
+from mkt.users.models import UserProfile
 from mkt.webapps.models import AddonUser
 from mkt.webapps.serializers import SimpleAppSerializer
-from mkt.users.models import UserProfile
 
 
 class CollectionDataMixin(object):

--- a/mkt/developers/tests/test_api_payments.py
+++ b/mkt/developers/tests/test_api_payments.py
@@ -2,13 +2,13 @@ import json
 
 from django import forms
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from curling.lib import HttpClientError, HttpServerError
 from mock import Mock, patch
 from nose.tools import eq_, ok_
 from rest_framework.request import Request
-from test_utils import RequestFactory
 
 import amo
 from amo.tests import app_factory, TestCase

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -7,10 +7,10 @@ from django import forms as django_forms
 from django.conf import settings
 from django.core.files.storage import default_storage as storage
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test.client import RequestFactory
 
 import mock
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import amo
 import amo.tests

--- a/mkt/developers/tests/test_forms_payments.py
+++ b/mkt/developers/tests/test_forms_payments.py
@@ -1,13 +1,14 @@
+from django.test.client import RequestFactory
+
 import mock
 from curling.lib import HttpClientError
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
-from test_utils import RequestFactory
 
 import amo
 import amo.tests
 from mkt.constants.payments import (PAYMENT_METHOD_ALL, PAYMENT_METHOD_CARD,
-                                PAYMENT_METHOD_OPERATOR)
+                                    PAYMENT_METHOD_OPERATOR)
 from mkt.developers import forms_payments, models
 from mkt.developers.providers import get_provider
 from mkt.developers.tests.test_providers import Patcher

--- a/mkt/developers/tests/test_views_validation.py
+++ b/mkt/developers/tests/test_views_validation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import codecs
-import collections
 import json
 import os
 import tempfile
@@ -8,11 +7,11 @@ import tempfile
 from django import forms
 from django.core.files.storage import default_storage as storage
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
-from mock import Mock, patch
+from mock import patch
 from nose.tools import eq_
 from pyquery import PyQuery as pq
-from test_utils import RequestFactory
 
 import amo
 import amo.tests

--- a/mkt/feed/tests/test_authorization.py
+++ b/mkt/feed/tests/test_authorization.py
@@ -2,12 +2,12 @@ from nose.tools import ok_
 from rest_framework.generics import GenericAPIView
 
 from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
 
 from amo.tests import TestCase
 from mkt.access.middleware import ACLMiddleware
 from mkt.feed.authorization import FeedAuthorization
 from mkt.site.fixtures import fixture
-from test_utils import RequestFactory
 from mkt.users.models import UserProfile
 
 

--- a/mkt/fireplace/tests/test_views.py
+++ b/mkt/fireplace/tests/test_views.py
@@ -3,11 +3,11 @@ from urlparse import urlparse
 
 from django.core.urlresolvers import reverse
 from django.db.models.query import QuerySet
+from django.test.client import RequestFactory
 
 from elasticsearch_dsl.search import Search
 from mock import patch
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import mkt
 from amo.tests import app_factory, ESTestCase, TestCase
@@ -17,8 +17,8 @@ from mkt.collections.constants import COLLECTIONS_TYPE_BASIC
 from mkt.collections.models import Collection
 from mkt.fireplace.serializers import FireplaceAppSerializer
 from mkt.site.fixtures import fixture
-from mkt.webapps.models import AddonUser, Installed, Webapp
 from mkt.users.models import UserProfile
+from mkt.webapps.models import AddonUser, Installed, Webapp
 
 
 # https://bugzilla.mozilla.org/show_bug.cgi?id=958608#c1 and #c2.
@@ -149,9 +149,9 @@ class TestSearchView(RestOAuth, ESTestCase):
         data = objects[0]
         eq_(data['id'], 337141)
         assert_fireplace_app(data)
-        ok_(not 'featured' in res.json)
-        ok_(not 'collections' in res.json)
-        ok_(not 'operator' in res.json)
+        ok_('featured' not in res.json)
+        ok_('collections' not in res.json)
+        ok_('operator' not in res.json)
 
     def test_anonymous_user(self):
         res = self.anon.get(self.url)
@@ -210,7 +210,7 @@ class TestConsumerInfoView(RestOAuth, TestCase):
         res = self.anon.get(self.url)
         data = json.loads(res.content)
         eq_(data['region'], 'uk')
-        ok_(not 'apps' in data)
+        ok_('apps' not in data)
 
     @patch('mkt.regions.middleware.RegionMiddleware.region_from_request')
     def test_with_user_developed(self, region_from_request):

--- a/mkt/operators/tests/test_authorization.py
+++ b/mkt/operators/tests/test_authorization.py
@@ -2,6 +2,7 @@ from nose.tools import ok_
 from rest_framework.generics import GenericAPIView
 
 from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
 
 from amo.tests import TestCase
 from mkt.access.middleware import ACLMiddleware
@@ -14,7 +15,6 @@ from mkt.operators.models import OperatorPermission
 from mkt.regions import REGIONS_DICT as REGIONS
 from mkt.site.fixtures import fixture
 from mkt.users.models import UserProfile
-from test_utils import RequestFactory
 
 
 class BaseTestOperatorAuthorization(FeedTestMixin, TestCase):

--- a/mkt/receipts/tests/test_verify.py
+++ b/mkt/receipts/tests/test_verify.py
@@ -6,6 +6,7 @@ from urllib import urlencode
 
 from django.db import connection
 from django.conf import settings
+from django.test.client import RequestFactory
 
 import jwt
 import M2Crypto
@@ -13,7 +14,6 @@ import mock
 from browserid.errors import ExpiredSignatureError
 from nose.tools import eq_, ok_
 from services import utils, verify
-from test_utils import RequestFactory
 
 import amo
 import amo.tests

--- a/mkt/receipts/tests/test_views.py
+++ b/mkt/receipts/tests/test_views.py
@@ -6,10 +6,10 @@ import uuid
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 import mock
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import amo
 import amo.tests
@@ -20,10 +20,10 @@ from mkt.receipts.utils import create_test_receipt
 from mkt.receipts.views import devhub_verify
 from mkt.site.fixtures import fixture
 from mkt.site.helpers import absolutify
+from mkt.users.models import UserProfile
 from mkt.webapps.models import AddonUser, Webapp
 from services.verify import settings as verify_settings
 from services.verify import decode_receipt
-from mkt.users.models import UserProfile
 
 
 class TestInstall(amo.tests.TestCase):

--- a/mkt/reviewers/tests/test_views_api.py
+++ b/mkt/reviewers/tests/test_views_api.py
@@ -5,11 +5,11 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 import mock
 from cache_nuggets.lib import Token
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import amo
 import mkt.regions
@@ -23,8 +23,8 @@ from mkt.reviewers.models import (AdditionalReview, CannedResponse,
 from mkt.reviewers.utils import AppsReviewing
 from mkt.site.fixtures import fixture
 from mkt.tags.models import Tag
-from mkt.webapps.models import Webapp
 from mkt.users.models import UserProfile
+from mkt.webapps.models import Webapp
 
 
 class TestReviewing(RestOAuth):

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -1,9 +1,9 @@
 import json
 
-import test_utils
 from nose.tools import eq_, ok_
 
 from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
 
 import amo
 from mkt import regions
@@ -11,7 +11,7 @@ from mkt.api.tests.test_oauth import BaseOAuth
 from mkt.constants.applications import DEVICE_CHOICES_IDS
 from mkt.regions import set_region
 from mkt.reviewers.forms import ApiReviewersSearchForm
-from mkt.search.forms import (ApiSearchForm, TARAKO_CATEGORIES_MAPPING)
+from mkt.search.forms import ApiSearchForm, TARAKO_CATEGORIES_MAPPING
 from mkt.search.views import _sort_search, DEFAULT_SORTING
 from mkt.site.fixtures import fixture
 from mkt.webapps.indexers import WebappIndexer
@@ -22,7 +22,7 @@ class TestSearchFilters(BaseOAuth):
 
     def setUp(self):
         super(TestSearchFilters, self).setUp()
-        self.req = test_utils.RequestFactory().get('/')
+        self.req = RequestFactory().get('/')
         self.req.user = AnonymousUser()
 
         # Pick a region that has relatively few filters.

--- a/mkt/search/tests/test_middleware.py
+++ b/mkt/search/tests/test_middleware.py
@@ -1,7 +1,8 @@
+from django.test.client import RequestFactory
+
 import elasticsearch
 import mock
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 import amo.tests
 from mkt.search.middleware import ElasticsearchExceptionMiddleware as ESM

--- a/mkt/site/tests/test_utils_.py
+++ b/mkt/site/tests/test_utils_.py
@@ -1,10 +1,7 @@
-from django import test
 from django.conf import settings
 
 from nose.tools import eq_, assert_not_equal
-import test_utils
 
-import amo.tests
 from mkt.site.utils import get_outgoing_url
 
 
@@ -63,4 +60,3 @@ def test_outgoing_url_query_params():
     url = 'http://xx.com?q=1&amp;v=2" style="123"'
     fixed = get_outgoing_url(url)
     assert fixed.endswith('%3A//xx.com%3Fq=1&v=2%22%20style=%22123%22'), fixed
-

--- a/mkt/submit/tests/test_forms.py
+++ b/mkt/submit/tests/test_forms.py
@@ -1,10 +1,10 @@
 from django.forms.fields import BooleanField
+from django.test.client import RequestFactory
 from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
 import mock
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import amo
 import amo.tests

--- a/mkt/versions/tests/test_serializers.py
+++ b/mkt/versions/tests/test_serializers.py
@@ -1,7 +1,7 @@
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 from amo.tests import app_factory, TestCase
 from mkt.versions.models import Version
@@ -25,7 +25,7 @@ class TestVersionSerializer(TestCase):
         native = self.native()
         removed_keys = self.serializer.Meta.field_rename.keys()
         added_keys = self.serializer.Meta.field_rename.values()
-        ok_(all(not k in native for k in removed_keys))
+        ok_(all(k not in native for k in removed_keys))
         ok_(all(k in native for k in added_keys))
 
     def test_addon(self):

--- a/mkt/versions/tests/test_views.py
+++ b/mkt/versions/tests/test_views.py
@@ -1,12 +1,11 @@
 import json
 
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 from mock import patch
 from nose.tools import eq_, ok_
 from rest_framework.reverse import reverse as rest_reverse
-
-from test_utils import RequestFactory
 
 import amo
 from amo.tests import app_factory, file_factory

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -5,8 +5,8 @@ import json
 import logging
 import os
 import random
-import StringIO
 import shutil
+import StringIO
 import subprocess
 import tempfile
 import time
@@ -16,6 +16,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.files.storage import default_storage as storage
 from django.core.urlresolvers import reverse
 from django.template import Context, loader
+from django.test.client import RequestFactory
 
 import pytz
 import requests
@@ -24,7 +25,6 @@ from celery.exceptions import RetryTaskError
 from celeryutils import task
 from PIL import Image
 from requests.exceptions import RequestException
-from test_utils import RequestFactory
 from tower import ugettext as _
 
 import amo
@@ -43,8 +43,8 @@ from mkt.files.utils import WebAppParser
 from mkt.ratings.models import Review
 from mkt.reviewers.models import EscalationQueue, RereviewQueue
 from mkt.site.decorators import set_task_user, use_master, write
-from mkt.site.mail import send_mail_jinja
 from mkt.site.helpers import absolutify
+from mkt.site.mail import send_mail_jinja
 from mkt.users.models import UserProfile
 from mkt.users.utils import get_task_user
 from mkt.webapps.indexers import WebappIndexer

--- a/mkt/webapps/tests/test_decorators.py
+++ b/mkt/webapps/tests/test_decorators.py
@@ -1,9 +1,9 @@
 from django import http
 from django.core.exceptions import PermissionDenied
+from django.test.client import RequestFactory
 
 import mock
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 import amo.tests
 from mkt.webapps import decorators as dec

--- a/mkt/webapps/tests/test_serializers.py
+++ b/mkt/webapps/tests/test_serializers.py
@@ -3,15 +3,14 @@ from decimal import Decimal
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 import mock
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import amo
 import amo.tests
-
 import mkt
 from mkt.constants import ratingsbodies, regions
 from mkt.developers.models import (AddonPaymentAccount, PaymentAccount,

--- a/mkt/webapps/tests/test_views.py
+++ b/mkt/webapps/tests/test_views.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
 
 from nose.tools import eq_, ok_
-from test_utils import RequestFactory
 
 import amo.tests
 from mkt.api.tests.test_oauth import BaseOAuth, RestOAuth
@@ -14,7 +14,7 @@ from mkt.site.fixtures import fixture
 from mkt.tags.models import Tag
 from mkt.users.models import UserProfile
 from mkt.webapps.models import Webapp
-from mkt.webapps.serializers import (AppSerializer, AppFeaturesSerializer,
+from mkt.webapps.serializers import (AppFeaturesSerializer, AppSerializer,
                                      SimpleAppSerializer)
 
 


### PR DESCRIPTION
The test_utils RequestFactory added 'wsgi.input' but Django has been
doing this since 1.4.
