### PR TITLE
Allow anonymous users to validate hosted apps (bug 1090341)

### DIFF
--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -625,7 +625,7 @@ def refresh_manifest(request, addon_id, addon):
 def _upload_manifest(request, is_standalone=False):
     form = forms.NewManifestForm(request.POST, is_standalone=is_standalone)
     if (not is_standalone and
-        waffle.switch_is_active('webapps-unique-by-domain')):
+            waffle.switch_is_active('webapps-unique-by-domain')):
         # Helpful error if user already submitted the same manifest.
         dup_msg = trap_duplicate(request, request.POST.get('manifest'))
         if dup_msg:
@@ -633,7 +633,8 @@ def _upload_manifest(request, is_standalone=False):
                     'messages': [{'type': 'error', 'message': dup_msg,
                                   'tier': 1}]}}
     if form.is_valid():
-        upload = FileUpload.objects.create(user=request.user)
+        user = request.user if request.user.is_authenticated() else None
+        upload = FileUpload.objects.create(user=user)
         fetch_manifest.delay(form.cleaned_data['manifest'], upload.pk)
         if is_standalone:
             return redirect('mkt.developers.standalone_upload_detail',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1090341

This already worked for packaged apps, now it works for hosted apps too.
