### PR TITLE
add command to fix developer version notes (bug 1090615)

### DIFF
--- a/mkt/comm/management/commands/fix_developer_version_notes.py
+++ b/mkt/comm/management/commands/fix_developer_version_notes.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+
+import commonware.log
+
+from amo.utils import chunked
+from mkt.comm.tasks import _fix_developer_version_notes
+from mkt.comm.models import CommunicationNote
+from mkt.constants import comm
+
+
+log = commonware.log.getLogger('comm')
+
+
+class Command(BaseCommand):
+    help = ('Fix developer version notes that were accidentally logged as '
+            'reviewer comments due to "approvalnotes" being a confusing '
+            'variable name')
+
+    def handle(self, *args, **options):
+        ids = (CommunicationNote.objects
+                                .filter(note_type=comm.REVIEWER_COMMENT)
+                                .values_list('id', flat=True))
+
+        for log_chunk in chunked(ids, 100):
+            _fix_developer_version_notes.delay(ids)


### PR DESCRIPTION
"Fix developer version notes that were logged as reviewer comments.
The strategy is to find all reviewer comments that were authored the
developer of the app and changed them to be developer version notes for
reviewers. And check that they are the first note of the thread, to be
sure."
