### PR TITLE
add command to migrate Version.approvalnotes to comm (bug 1091160)

### DIFF
--- a/mkt/comm/management/commands/migrate_approval_notes.py
+++ b/mkt/comm/management/commands/migrate_approval_notes.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+
+from amo.utils import chunked
+from mkt.comm.tasks import _migrate_approval_notes
+from mkt.versions.models import Version
+
+
+class Command(BaseCommand):
+    help = ('Port version approvalnotes to notes with type '
+            'DEVELOPER_VERSION_NOTE_FOR_REVIEWER.')
+
+    def handle(self, *args, **options):
+        ids = Version.objects.filter(approvalnotes__isnull=False)
+
+        for log_chunk in chunked(ids, 100):
+            _migrate_approval_notes.delay(ids)


### PR DESCRIPTION
To be run after https://github.com/mozilla/zamboni/pull/2689

"When developers submit a new version of their app, they leave "Comments for Reviewers", which is Version.approvalnotes in the code. These "Comments for Reviewers" now makes more sense as a CommunicationNote rather than a field attached to the Version.

Adding it as a CommunicationNote allows the Comments for Reviewers to be visible within the Communication Dashboard."

Not stripping out Version.approvalnotes yet, a lot to do before then.
