### PR TITLE
Remove 32x32 icons to reduce feed endpoint size (bug 1088369)

### DIFF
--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -531,10 +531,8 @@ class BaseESAppFeedSerializer(ESAppSerializer):
     def get_icons(self, obj):
         """
         Only need the 64px icon for Fireplace.
-        Throw in 32px for Transonic.
         """
         return {
-            '32': obj.get_icon_url(32),
             '64': obj.get_icon_url(64)
         }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1088369

Needs mozilla/transonic#80 first.
