### PR TITLE
Add check-for-update and apply-update to iframe-install API (bug 1097430)

### DIFF
--- a/mkt/commonplace/templates/commonplace/iframe-install.html
+++ b/mkt/commonplace/templates/commonplace/iframe-install.html
@@ -29,6 +29,14 @@
     }
     getInstallers();
 
+    function postErrorMessage(consoleMessage, manifestURL, functionName, errorName) {
+        console.log('[iframe-install] ' + consoleMessage + ' for ' + manifestURL);
+        window.top.postMessage({
+            'manifestURL': manifestURL,
+            'error': {error: errorName},
+            'name': functionName
+        }, '*');
+    }
 
     // Message handler.
     {# Whitelist origin is generated in the view and already a json array #}
@@ -41,12 +49,19 @@
             console.log('[iframe-install] message from ' + e.origin + ' not allowed');
             return;
         }
+
         if (!e.data) {
             console.log('[iframe-install] no data');
             return;
         }
 
         switch (e.data.name) {
+            case 'apply-update':
+                applyUpdate(e);
+                break;
+            case 'check-for-update':
+                checkForUpdate(e);
+                break;
             case 'getInstalled':
                 getInstalled(e);
                 break;
@@ -99,14 +114,14 @@
         var opt = e.data.data.opt || {};
         opt.data = opt.data || {};
 
-        var manifest_url;
+        var manifestURL;
         if (product.manifest_url) {
-            manifest_url = product.manifest_url;
+            manifestURL = product.manifest_url;
         }
 
         var mozApps = (opt.navigator || window.navigator).mozApps;
         var installer = product.is_packaged ? 'installPackage' : 'install';
-        var installRequest = mozApps[installer](manifest_url, opt.data);
+        var installRequest = mozApps[installer](manifestURL, opt.data);
 
         installRequest.onsuccess = function() {
             console.log('[iframe-install] App install request for ' + product.name);
@@ -128,6 +143,7 @@
                 console.log('[iframe-install] App download error: ' + e.application.downloadError.name);
                 window.top.postMessage({
                     'appId': product.id,
+                    'product': product,
                     'error': {error: e.application.downloadError.name},
                     'name': 'install-package'
                 }, '*');
@@ -139,12 +155,102 @@
             var error = this.error.name || this.error;
             window.top.postMessage({
                 'appId': product.id,
+                'product': product,
                 'error': {error: error},
                 'name': 'install-package'
             }, '*');
         };
     }
 
+    function applyUpdate(e) {
+        /* Download app update (app need to be installed first), send a message
+           back to the caller then it's done.
+           {
+               name: 'apply-update',
+               manifestURL: <MANIFEST_URL>
+           }
+        */
+        getInstallers(function() {
+            var manifestURL = e.data.manifestURL;
+            var app = installed[manifestURL];
+            if (app === undefined) {
+                postErrorMessage('Applying app update failed', manifestURL, 'apply-update', 'NOT_INSTALLED');
+                return;
+            }
+            app.ondownloadsuccess = function(e) {
+                console.log('[iframe-install] Applying app update succeeded (downloadsuccess) for ' + manifestURL);
+                window.top.postMessage({
+                    'manifestURL': manifestURL,
+                    'name': 'apply-update'
+                }, '*');
+            };
+            if (app.downloadAvailable) {
+                app.download();
+            }
+        }
+
+    }
+
+    function checkForUpdate(e) {
+        /* Check for an app update (app need to be installed first) and send a
+           message back to the caller with the result (boolean indicating
+           whether an app is available or not).
+           {
+               name: 'check-for-update',
+               manifestURL: <MANIFEST_URL>
+           }
+        */
+
+        getInstallers(function() {
+            var manifestURL = e.data.manifestURL;
+            var app = installed[manifestURL];
+            if (app === undefined) {
+                postErrorMessage('Checking for app update failed', manifestURL, 'check-for-update', 'NOT_INSTALLED');
+                return;
+            }
+            if (app.downloading) {
+                postErrorMessage('Checking for app update failed', manifestURL, 'check-for-update', 'APP_IS_DOWNLOADING');
+                return;
+            }
+            if (app.downloadAvailable) {
+                // If we already know an app has a download available, we can
+                // return right away.
+                console.log('[iframe-install] Checking for app update succeeded immediately (downloadavailable) for ' + manifestURL);
+                window.top.postMessage({
+                    'manifestURL': manifestURL,
+                    'result': app.downloadAvailable,
+                    'type': 'downloadavailable',
+                    'name': 'check-for-update'
+                }, '*');
+                return;
+            }
+            // app.checkForUpdate() appears not to be sending success event,
+            // only errors. It does fire 'downloadavailable'/'downloadapplied'
+            // events and update the corresponding app instance, though.
+            app.ondownloadavailable = function(e) {
+                console.log('[iframe-install] Checking for app update succeeded (downloadavailable) for ' + manifestURL);
+                window.top.postMessage({
+                    'manifestURL': manifestURL,
+                    'result': app.downloadAvailable,
+                    'type': e.type,
+                    'name': 'check-for-update'
+                }, '*');
+            };
+            app.ondownloadapplied = function(e) {
+                console.log('[iframe-install] Checking for app update succeeded (downloadapplied) for ' + manifestURL);
+                window.top.postMessage({
+                    'manifestURL': manifestURL,
+                    'result': app.downloadAvailable,
+                    'type': e.type,
+                    'name': 'check-for-update'
+                }, '*');
+            };
+            var request = installed[manifestURL].checkForUpdate();
+            request.onerror = function() {
+                postErrorMessage('Checking for app update failed', manifestURL, 'check-for-update', this.error.name || this.error);
+            }
+        })
+    }
 
     function launchApp(e) {
         /* Find installer from getInstalled and launch an app.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1097430

Needed to be able to tell whether a Marketplace update is available (and then download it) from Marketplace itself.

Added (temporary, need a better place to live, like marketplace-frontend) docs here: https://github.com/mozilla/commonplace/wiki/iframe-install-messaging-API
