### PR TITLE
Remove the unnessecary queue check (only one type of review exists).

### DIFF
--- a/mkt/reviewers/models.py
+++ b/mkt/reviewers/models.py
@@ -157,8 +157,6 @@ class ReviewerScore(ModelBase):
     def award_additional_review_points(cls, user, addon, queue):
         """Awards points to user based on additional (Tarako) review."""
         # TODO: generalize with other additional reviews queues
-        if queue is not QUEUE_TARAKO:
-            return
         event = amo.REVIEWED_WEBAPP_TARAKO
         score = amo.REVIEWED_SCORES.get(event)
 


### PR DESCRIPTION
Feels icky to be removing a test, but its only used one place anyway, and will need generalising if its actually be useful outside of Tarako reviews.
