### PR TITLE
Fix fxpay API views, fix CORS (bug 1104371)

### DIFF
--- a/mkt/webpay/serializers.py
+++ b/mkt/webpay/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
 
+from mkt.purchase.models import Contribution
 from mkt.webpay.models import ProductIcon
+
 
 class ProductIconSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField('get_url')
@@ -13,3 +15,16 @@ class ProductIconSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductIcon
         exclude = ('format',)
+
+
+class ContributionSerializer(serializers.ModelSerializer):
+    """
+    Dummy Contribution serializer.
+
+    This doesn't expose anything because the views that use it
+    do not return any data. However, DRF will raise an AssertionError
+    if a view does not declare a serializer.
+    """
+
+    class Meta:
+        model = Contribution

--- a/mkt/webpay/tests/test_views.py
+++ b/mkt/webpay/tests/test_views.py
@@ -153,6 +153,8 @@ class TestPrepareInApp(InAppPurchaseTest, RestOAuth):
         eq_(res.json['contribStatusURL'],
             reverse('webpay-status', kwargs={'uuid': contribution.uuid}))
         ok_(res.json['webpayJWT'])
+        eq_(res['Access-Control-Allow-Headers'],
+            'content-type, accept, x-fxpay-version')
 
     def test_get_simulated_jwt(self):
         self.inapp.webapp = None

--- a/mkt/webpay/views.py
+++ b/mkt/webpay/views.py
@@ -29,7 +29,8 @@ from mkt.site.mail import send_mail_jinja
 from mkt.site.helpers import absolutify
 from mkt.webpay.forms import FailureForm, PrepareInAppForm, PrepareWebAppForm
 from mkt.webpay.models import ProductIcon
-from mkt.webpay.serializers import ProductIconSerializer
+from mkt.webpay.serializers import (ContributionSerializer,
+                                    ProductIconSerializer)
 from mkt.webpay.webpay_jwt import (get_product_jwt, InAppProduct,
                                    sign_webpay_jwt, SimulatedInAppProduct,
                                    WebAppProduct)
@@ -46,6 +47,7 @@ class PreparePayWebAppView(CORSMixin, MarketplaceView, GenericAPIView):
     permission_classes = [IsAuthenticated]
     cors_allowed_methods = ['post']
     cors_allowed_headers = ('content-type', 'accept', 'x-fxpay-version')
+    serializer_class = ContributionSerializer
 
     def post(self, request, *args, **kwargs):
         form = PrepareWebAppForm(request.DATA)
@@ -95,6 +97,8 @@ class PreparePayInAppView(CORSMixin, MarketplaceView, GenericAPIView):
     authentication_classes = []
     permission_classes = []
     cors_allowed_methods = ['post']
+    cors_allowed_headers = ('content-type', 'accept', 'x-fxpay-version')
+    serializer_class = ContributionSerializer
 
     def post(self, request, *args, **kwargs):
         form = PrepareInAppForm(request.DATA)


### PR DESCRIPTION
The missing serializer_class causes a 500 and
I'm not sure how long that has been broken.

http://sentry.dmz.phx1.mozilla.com/marketplace-payments-alt/payments-altallizomorg/group/21620/
