### PR TITLE
add `link` tag for W3C-standardised manifest (bug 1084548)

### DIFF
--- a/mkt/commonplace/templates/commonplace/index.html
+++ b/mkt/commonplace/templates/commonplace/index.html
@@ -15,6 +15,10 @@
     {% endif -%}
     <link rel="stylesheet" href="{{ media(repo + '/css/include.css') }}">
 
+    {% if repo == 'fireplace' %}
+      <link rel="stylesheet" href="/manifests/standard.json">
+    {% endif %}
+
     <link title="Firefox Apps"
           rel="search" type="application/opensearchdescription+xml"
           href="{{ url('opensearch') }}">


### PR DESCRIPTION
dependency: mozilla/fireplace#799

r? @ngokevin 

<hr>

note: the manifest must live at the same origin as the document, so I can't put the manifest in the `media` directory/the CDN.
