### PR TITLE
Pull newsletter language from JSON not LANG

### DIFF
--- a/mkt/account/serializers.py
+++ b/mkt/account/serializers.py
@@ -87,8 +87,11 @@ class NewsletterSerializer(serializers.Serializer):
         'marketplace-android': 'mozilla-and-you'
     }
     email = fields.EmailField()
-    newsletter = fields.ChoiceField(default='marketplace-firefoxos',
-        required=False, choices=NEWSLETTER_CHOICES_API.items())
+    newsletter = fields.ChoiceField(
+        default='marketplace-firefoxos',
+        required=False,
+        choices=NEWSLETTER_CHOICES_API.items())
+    lang = fields.CharField()
 
     def transform_newsletter(self, obj, value):
         # Transform from the string the API receives to the one we need to pass

--- a/mkt/account/tests/test_views.py
+++ b/mkt/account/tests/test_views.py
@@ -767,6 +767,7 @@ class TestNewsletter(RestOAuth):
     @patch('basket.subscribe')
     def test_signup_invalid_newsletter(self, subscribe):
         res = self.client.post(self.url, data={'email': self.VALID_EMAIL,
+                                               'lang': 'en-US',
                                                'newsletter': 'invalid'})
         eq_(res.status_code, 400)
         ok_(not subscribe.called)
@@ -774,16 +775,28 @@ class TestNewsletter(RestOAuth):
     @patch('basket.subscribe')
     def test_signup_anonymous(self, subscribe):
         res = self.anon.post(self.url,
-                               data=json.dumps({'email': self.VALID_EMAIL}))
+                             data=json.dumps({'email': self.VALID_EMAIL,
+                                              'lang': 'en-US'}))
         eq_(res.status_code, 204)
         subscribe.assert_called_with(
             self.VALID_EMAIL, 'marketplace', lang='en-US',
             country='restofworld', trigger_welcome='Y', optin='N', format='H')
 
     @patch('basket.subscribe')
+    def test_signup_lang(self, subscribe):
+        res = self.anon.post(self.url,
+                             data=json.dumps({'email': self.VALID_EMAIL,
+                                              'lang': 'es'}))
+        eq_(res.status_code, 204)
+        subscribe.assert_called_with(
+            self.VALID_EMAIL, 'marketplace', lang='es',
+            country='restofworld', trigger_welcome='Y', optin='N', format='H')
+
+    @patch('basket.subscribe')
     def test_signup(self, subscribe):
         res = self.client.post(self.url,
-                               data=json.dumps({'email': self.VALID_EMAIL}))
+                               data=json.dumps({'email': self.VALID_EMAIL,
+                                                'lang': 'en-US'}))
         eq_(res.status_code, 204)
         subscribe.assert_called_with(
             self.VALID_EMAIL, 'marketplace', lang='en-US',
@@ -793,7 +806,8 @@ class TestNewsletter(RestOAuth):
     def test_signup_plus(self, subscribe):
         res = self.client.post(
             self.url,
-            data=json.dumps({'email': self.VALID_PLUS_EMAIL}))
+            data=json.dumps({'email': self.VALID_PLUS_EMAIL,
+                             'lang': 'en-US'}))
         subscribe.assert_called_with(
             self.VALID_PLUS_EMAIL, 'marketplace', lang='en-US',
             country='restofworld', trigger_welcome='Y', optin='N', format='H')
@@ -803,6 +817,7 @@ class TestNewsletter(RestOAuth):
     def test_signup_about_apps(self, subscribe):
         res = self.client.post(self.url,
                                data=json.dumps({'email': self.VALID_EMAIL,
+                                                'lang': 'en-US',
                                                 'newsletter': 'about:apps'}))
         eq_(res.status_code, 204)
         subscribe.assert_called_with(

--- a/mkt/account/views.py
+++ b/mkt/account/views.py
@@ -427,9 +427,11 @@ class NewsletterView(CORSMixin, CreateAPIViewWithoutModel):
     def create_action(self, request, serializer):
         email = serializer.data['email']
         newsletter = serializer.data['newsletter']
+        lang = serializer.data['lang']
         basket.subscribe(email, newsletter,
                          format='H', country=request.REGION.slug,
-                         lang=request.LANG, optin='N',
+                         lang=lang,
+                         optin='N',
                          trigger_welcome='Y')
 
 


### PR DESCRIPTION
`request.LANG` will prefer `request.GET` over `request.POST`. That isn't ideal but that's a bigger change than I'd like to make right now. This updates the newsletter to pull `lang` from the JSON POST-data instead.
