### PR TITLE
Fix CORS in devhub test receipts (bug 1104371)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -501,11 +501,14 @@ class TestCase(MockEsMixin, RedisTest, MockBrowserIdMixin, test.TestCase):
         return self.assertSetEqual(qs1.values_list('id', flat=True),
                                    qs2.values_list('id', flat=True))
 
-    def assertCORS(self, res, *verbs):
+    def assertCORS(self, res, *verbs, **kw):
         """
         Determines if a response has suitable CORS headers. Appends 'OPTIONS'
         on to the list of verbs.
         """
+        headers = kw.pop('headers', None)
+        if not headers:
+            headers = ['X-HTTP-Method-Override', 'Content-Type']
         eq_(res['Access-Control-Allow-Origin'], '*')
         assert 'API-Status' in res['Access-Control-Expose-Headers']
         assert 'API-Version' in res['Access-Control-Expose-Headers']
@@ -513,8 +516,7 @@ class TestCase(MockEsMixin, RedisTest, MockBrowserIdMixin, test.TestCase):
         verbs = map(str.upper, verbs) + ['OPTIONS']
         actual = res['Access-Control-Allow-Methods'].split(', ')
         self.assertSetEqual(verbs, actual)
-        eq_(res['Access-Control-Allow-Headers'],
-            'X-HTTP-Method-Override, Content-Type')
+        eq_(res['Access-Control-Allow-Headers'], ', '.join(headers))
 
     def assertApiUrlEqual(self, *args, **kwargs):
         """

--- a/mkt/api/tests/test_base.py
+++ b/mkt/api/tests/test_base.py
@@ -61,15 +61,32 @@ class TestEncoding(RestOAuth):
 
 
 class TestCORSWrapper(TestCase):
+    urls = 'mkt.api.tests.test_base_urls'
+
     def test_cors(self):
         @cors_api_view(['GET', 'PATCH'])
         @authentication_classes([])
         @permission_classes([])
         def foo(request):
             return Response()
-        request = RequestFactory().get('/')
+        request = RequestFactory().options('/')
         foo(request)
         eq_(request.CORS, ['GET', 'PATCH'])
+
+    def test_cors_with_headers(self):
+        @cors_api_view(['POST'], headers=('x-barfoo',))
+        @authentication_classes([])
+        @permission_classes([])
+        def foo(request):
+            return Response()
+        request = RequestFactory().options('/')
+        foo(request)
+        eq_(request.CORS_HEADERS, ('x-barfoo',))
+
+    def test_cors_options(self):
+        res = self.client.options(reverse('test-cors-api-view'))
+        eq_(res['Access-Control-Allow-Origin'], '*')
+        eq_(res['Access-Control-Allow-Headers'], 'x-barfoo, x-foobar')
 
 
 class Form(forms.Form):

--- a/mkt/api/tests/test_base_urls.py
+++ b/mkt/api/tests/test_base_urls.py
@@ -1,0 +1,23 @@
+"""Some URLs for test_base.py"""
+
+from django.conf.urls import patterns, url
+
+from rest_framework.decorators import (authentication_classes,
+                                       permission_classes)
+from rest_framework.response import Response
+
+from mkt.api.base import cors_api_view
+
+
+@cors_api_view(['POST'], headers=('x-barfoo', 'x-foobar'))
+@authentication_classes([])
+@permission_classes([])
+def _test_cors_api_view(request):
+    return Response()
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^test-cors-api-view/', _test_cors_api_view,
+        name='test-cors-api-view'),
+)

--- a/mkt/receipts/tests/test_views_api.py
+++ b/mkt/receipts/tests/test_views_api.py
@@ -28,7 +28,8 @@ class TestAPI(RestOAuth):
         self.profile = self.user
 
     def test_has_cors(self):
-        self.assertCORS(self.client.post(self.url), 'post')
+        self.assertCORS(self.client.post(self.url), 'post',
+                        headers=['content-type', 'accept', 'x-fxpay-version'])
 
     def post(self, anon=False):
         client = self.client if not anon else self.anon
@@ -92,7 +93,8 @@ class TestDevhubAPI(RestOAuth):
         self.url = reverse('receipt.test')
 
     def test_has_cors(self):
-        self.assertCORS(self.client.post(self.url), 'post')
+        self.assertCORS(self.client.post(self.url), 'post',
+                        headers=['content-type', 'accept', 'x-fxpay-version'])
 
     def test_decode(self):
         res = self.anon.post(self.url, data=self.data)

--- a/mkt/receipts/views.py
+++ b/mkt/receipts/views.py
@@ -222,15 +222,18 @@ def devhub_details(request):
     return render(request, 'receipts/test_details.html')
 
 
-@csrf_exempt
-@require_POST
+@cors_api_view(['POST'],
+               headers=('content-type', 'accept', 'x-fxpay-version'))
+@authentication_classes([])
+@permission_classes((AllowAny,))
 def devhub_verify(request, status):
     receipt = request.read()
     verify = Verify(receipt, request.META)
-    return response(json.dumps(verify.check_without_db(status)))
+    return Response(verify.check_without_db(status))
 
 
-@cors_api_view(['POST'])
+@cors_api_view(['POST'],
+               headers=('content-type', 'accept', 'x-fxpay-version'))
 @authentication_classes([RestOAuthAuthentication,
                          RestSharedSecretAuthentication])
 @permission_classes([IsAuthenticated])
@@ -287,7 +290,8 @@ def install_record(obj, request, install_type):
     return create_receipt(installed.addon, installed.user, uuid)
 
 
-@cors_api_view(['POST'])
+@cors_api_view(['POST'],
+               headers=('content-type', 'accept', 'x-fxpay-version'))
 @permission_classes((AllowAny,))
 def test_receipt(request):
     form = forms.TestInstall(request.DATA)
@@ -302,7 +306,8 @@ def test_receipt(request):
     return Response(data, status=201)
 
 
-@cors_api_view(['POST'])
+@cors_api_view(['POST'],
+               headers=('content-type', 'accept', 'x-fxpay-version'))
 @permission_classes((AllowAny,))
 def reissue(request):
     """


### PR DESCRIPTION
This also fixes the CORS decorator which was
previously broken for OPTIONS requests.

@mstriemer r?
