### PR TITLE
Filter on `lang` in ratings API with `match_lang` (bug 875455)

### DIFF
--- a/docs/api/topics/ratings.rst
+++ b/docs/api/topics/ratings.rst
@@ -21,6 +21,11 @@ _`List`
 
     :query app: the ID or slug of the app whose ratings are to be returned.
     :query user: the ID of the user or `mine` whose ratings are to be returned.
+    :query lang: a language to filter ratings by if `match_lang` is set.
+    :query match_lang: a boolean to specify to match langauge or not. If unset
+                       all results are returned, if 1 only results matching
+                       `lang` are returned if 0 only results not matching
+                       `lang` are returned. All other values are ignored.
 
     The value `mine` can be used to filter ratings belonging to the currently
     logged in user.
@@ -41,7 +46,8 @@ _`List`
             },
             "info": {
                 "average": "3.4",
-                "slug": "marble-run"
+                "slug": "marble-run",
+                "total_reviews": 391
             },
             "objects": [
                 {
@@ -49,6 +55,7 @@ _`List`
                     "body": "This app is top notch. Aces in my book!",
                     "created": "2013-04-17T15:25:16",
                     "is_author": true,
+                    "lang": "en-US",
                     "modified": "2013-04-17T15:34:19",
                     "rating": 5,
                     "resource_uri": "/api/v2/apps/rating/19/",

--- a/migrations/880-lang-on-reviews.sql
+++ b/migrations/880-lang-on-reviews.sql
@@ -1,0 +1,5 @@
+ALTER TABLE reviews
+    ADD COLUMN lang VARCHAR(5);
+
+CREATE INDEX app_reviews_with_lang
+    ON reviews (addon_id, reply_to, lang);

--- a/mkt/ratings/models.py
+++ b/mkt/ratings/models.py
@@ -35,6 +35,8 @@ class Review(ModelBase):
     rating = models.PositiveSmallIntegerField(null=True)
     title = TranslatedField(require_locale=False)
     body = TranslatedField(require_locale=False)
+    lang = models.CharField(max_length=5, null=True, blank=True,
+                            editable=False)
     ip_address = models.CharField(max_length=255, default='0.0.0.0')
 
     editorreview = models.BooleanField(default=False)
@@ -79,10 +81,6 @@ class Review(ModelBase):
         if kwargs.get('raw'):
             return
         instance.refresh(update_denorm=True)
-
-    @property
-    def lang(self):
-        return self.user.lang
 
     def refresh(self, update_denorm=False):
         from . import tasks

--- a/mkt/ratings/models.py
+++ b/mkt/ratings/models.py
@@ -80,6 +80,10 @@ class Review(ModelBase):
             return
         instance.refresh(update_denorm=True)
 
+    @property
+    def lang(self):
+        return self.user.lang
+
     def refresh(self, update_denorm=False):
         from . import tasks
 

--- a/mkt/ratings/serializers.py
+++ b/mkt/ratings/serializers.py
@@ -61,7 +61,10 @@ class RatingSerializer(serializers.ModelSerializer):
                 obj.reviewflag_set.filter(user=self.request.user).exists())
 
     def get_lang(self, obj):
-        return obj.user.lang
+        if obj.pk is None:
+            return self.request.LANG
+        else:
+            return obj.lang
 
     def validate(self, attrs):
         if not getattr(self, 'object'):

--- a/mkt/ratings/serializers.py
+++ b/mkt/ratings/serializers.py
@@ -27,10 +27,11 @@ class RatingSerializer(serializers.ModelSerializer):
     is_author = serializers.SerializerMethodField('get_is_author')
     has_flagged = serializers.SerializerMethodField('get_has_flagged')
     version = SimpleVersionSerializer(read_only=True)
+    lang = serializers.SerializerMethodField('get_lang')
 
     class Meta:
         model = Review
-        fields = ('app', 'body', 'created', 'has_flagged', 'is_author',
+        fields = ('app', 'body', 'created', 'has_flagged', 'is_author', 'lang',
                   'modified', 'rating', 'report_spam', 'resource_uri', 'user',
                   'version')
 
@@ -58,6 +59,9 @@ class RatingSerializer(serializers.ModelSerializer):
     def get_has_flagged(self, obj):
         return (not self.get_is_author(obj) and
                 obj.reviewflag_set.filter(user=self.request.user).exists())
+
+    def get_lang(self, obj):
+        return obj.user.lang
 
     def validate(self, attrs):
         if not getattr(self, 'object'):

--- a/mkt/ratings/views.py
+++ b/mkt/ratings/views.py
@@ -79,7 +79,7 @@ class RatingViewSet(CORSMixin, MarketplaceView, ModelViewSet):
         if user:
             filters &= Q(user=self.get_user(user))
         elif lang and match_lang == '1':
-            filters &= Q(user__lang=lang)
+            filters &= Q(lang=lang)
 
         if filters:
             queryset = queryset.filter(filters)


### PR DESCRIPTION
This is going to need a migration on the reviews table to store the user's lang, but getting the PR in.

- [x] Create migration for lang on reviews.
- [x] Set lang from user's lang on create.
- [x] Use the lang column in API.
- [ ] Populate the lang from user's lang in task.
- [ ] Update docs/tests to no longer support `match_lang=0`.