### PR TITLE
Display GUID in developper pages (bug 1119851)

### DIFF
--- a/mkt/developers/templates/developers/apps/edit/technical.html
+++ b/mkt/developers/templates/developers/apps/edit/technical.html
@@ -78,6 +78,18 @@
             </td>
           </tr>
         {% endif %}
+        <tr>
+          <th>
+            <label for="id_guid">
+              {{ _('GUID') }}
+              {{ tip(None,
+                     _('Internal identifier for this app on the Firefox Marketplace.')) }}
+            </label>
+          </th>
+          <td>
+            {{ addon.guid }}
+          </td>
+        </tr>
       </tbody>
     </table>
     {% if editable %}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1119851