### PR TITLE
Update loop dev URL (bug 1121580)

### DIFF
--- a/mkt/commonplace/tests/test_views.py
+++ b/mkt/commonplace/tests/test_views.py
@@ -190,7 +190,7 @@ class TestIFrames(CommonplaceTestMixin):
              'https://mp.dev',
              'https://hello.firefox.com',
              'https://call.firefox.com',
-             'http://loop-webapp.dev.mozaws.net'])
+             'https://loop-webapp-dev.stage.mozaws.net'])
 
         res = self._test_url(self.potatolytics_url)
         allowed_origins = json.loads(res.context['allowed_origins'])
@@ -223,7 +223,7 @@ class TestIFrames(CommonplaceTestMixin):
              'https://mp.dev',
              'https://hello.firefox.com',
              'https://call.firefox.com',
-             'http://loop-webapp.dev.mozaws.net'])
+             'https://loop-webapp-dev.stage.mozaws.net'])
 
         res = self._test_url(self.potatolytics_url)
         allowed_origins = json.loads(res.context['allowed_origins'])

--- a/mkt/commonplace/views.py
+++ b/mkt/commonplace/views.py
@@ -61,7 +61,7 @@ def get_allowed_origins(request, include_loop=True):
         # On dev, include loop dev origin as well.
         if development_server:
             allowed.extend([
-                'http://loop-webapp.dev.mozaws.net',
+                'https://loop-webapp-dev.stage.mozaws.net',
             ])
 
     return json.dumps(allowed)


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1121580#c10 loop dev URL is now `https://loop-webapp-dev.stage.mozaws.net/`.