### PR TITLE
remove mcc from the API and zamboni (bug 1058257)

### DIFF
--- a/docs/api/topics/apps.rst
+++ b/docs/api/topics/apps.rst
@@ -115,13 +115,11 @@ App
             "regions": [
                 {
                     "adolescent": true,
-                    "mcc": 310,
                     "name": "United States",
                     "slug": "us"
                 },
                 {
                     "adolescent": true,
-                    "mcc": null,
                     "name": "Rest of World",
                     "slug": "restofworld"
                 }
@@ -272,9 +270,6 @@ App
         volume of data to calculate ratings and rankings independent of
         worldwide data.
     :type regions.adolescent: boolean
-    :param regions.mcc: represents the region's ITU `mobile
-        country code`_.
-    :type regions.mcc: string|null
     :param regions.name: The region name.
     :type regions.name: string
     :param regions.slug: The region slug.

--- a/docs/api/topics/apps.rst
+++ b/docs/api/topics/apps.rst
@@ -326,6 +326,15 @@ App
          15   Blocked
     =======  ============================
 
+    .. warning:: Version differences.
+
+    The field `regions.mcc` was removed in v2. In v1 it was:
+
+    :param regions.mcc: represents the region's ITU `mobile
+        country code`_.
+    :type regions.mcc: int|null
+
+
 .. http:get:: /api/v2/apps/(int:id)|(string:slug)/privacy/
 
     **Response**
@@ -413,7 +422,8 @@ Versions
         public version of the application.
     :type is_current_version: boolean
     :param features: each item represents a
-        :ref:`device feature <features>` required to run the application.
+        :ref:`feature profile <feature-profile-label>` required to run the
+        application.
     :type features: array
     :param release_notes: the release notes for that version.
     :type release_notes: string|object|null
@@ -440,8 +450,8 @@ Versions
         }
 
     :param features: each item represents a
-        :ref:`device feature <features>` required to run the application.
-        Features not present are assumed not to be required.
+        :ref:`feature profile <feature-profile-label>` required to run the
+        application. Features not present are assumed not to be required.
     :type features: array
 
     **Response**

--- a/mkt/api/base.py
+++ b/mkt/api/base.py
@@ -159,8 +159,8 @@ class MarketplaceView(object):
             except ValueError:
                 pass  # Swallow and ignore invalid input.
 
-        return super(MarketplaceView, self).paginate_queryset(queryset,
-            page_size=page_size)
+        return super(MarketplaceView, self).paginate_queryset(
+            queryset, page_size=page_size)
 
     def get_region_from_request(self, request):
         """
@@ -171,6 +171,16 @@ class MarketplaceView(object):
         RESTOFWORLD.
         """
         return get_region_from_request(request)
+
+    def get_serializer_class(self):
+        """
+        Return a serializer for the requested API version. Versioned
+        serializers are registered on the default serializer with their version
+        number.
+        """
+        api_version = 'V{v_int}'.format(v_int=self.request.API_VERSION)
+        serializer_class = super(MarketplaceView, self).get_serializer_class()
+        return getattr(serializer_class, api_version, serializer_class)
 
 
 class MultiSerializerViewSetMixin(object):

--- a/mkt/api/base.py
+++ b/mkt/api/base.py
@@ -178,7 +178,7 @@ class MarketplaceView(object):
         serializers are registered on the default serializer with their version
         number.
         """
-        api_version = 'V{v_int}'.format(v_int=self.request.API_VERSION)
+        api_version = 'v{v_int}'.format(v_int=self.request.API_VERSION)
         serializer_class = super(MarketplaceView, self).get_serializer_class()
         return getattr(serializer_class, api_version, serializer_class)
 

--- a/mkt/api/tests/test_base.py
+++ b/mkt/api/tests/test_base.py
@@ -138,7 +138,7 @@ class TestSerializer(Serializer):
 class TestSerializerV1(Serializer):
     pass
 
-TestSerializer.V1 = TestSerializerV1
+TestSerializer.v1 = TestSerializerV1
 
 
 class TestView(MarketplaceView, GenericViewSet):

--- a/mkt/api/tests/test_base.py
+++ b/mkt/api/tests/test_base.py
@@ -9,9 +9,10 @@ from nose.tools import eq_
 from rest_framework.decorators import (authentication_classes,
                                        permission_classes)
 from rest_framework.response import Response
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.serializers import Serializer
+from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
-from mkt.api.base import cors_api_view, SubRouterWithFormat
+from mkt.api.base import cors_api_view, MarketplaceView, SubRouterWithFormat
 from mkt.api.tests.test_oauth import RestOAuth
 from mkt.site.tests import TestCase
 from mkt.webapps.views import AppViewSet
@@ -128,3 +129,33 @@ class TestSubRouterWithFormat(TestCase):
         } for url in router.urls]
         for i, _ in enumerate(expected):
             eq_(actual[i], expected[i])
+
+
+class TestSerializer(Serializer):
+    pass
+
+
+class TestSerializerV1(Serializer):
+    pass
+
+TestSerializer.V1 = TestSerializerV1
+
+
+class TestView(MarketplaceView, GenericViewSet):
+    serializer_class = TestSerializer
+
+
+class TestSerializerVersion(TestCase):
+
+    def setUp(self):
+        self.req = RequestFactory().get('/')
+        self.view = TestView()
+        self.view.request = self.req
+
+    def test_get_v1(self):
+        self.view.request.API_VERSION = 1
+        eq_(self.view.get_serializer_class(), TestSerializerV1)
+
+    def test_get_v2(self):
+        self.view.request.API_VERSION = 2
+        eq_(self.view.get_serializer_class(), TestSerializer)

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -684,10 +684,11 @@ class TestAppDetail(RestOAuth):
     def test_region_v1(self):
         res = self.client.get(self.get_url)
         eq_(res.status_code, 200)
-        eq_(res.json['regions'][0]['mcc'], '722')
+        eq_(res.json['regions'][0]['mcc'], 722)
 
     def test_region_v2(self):
-        res = self.client.get(self.get_url.replace('v1', 'v2'))
+        url = reverse('api-v2:app-detail', kwargs={'pk': self.app.app_slug})
+        res = self.client.get(url)
         eq_(res.status_code, 200)
         assert 'mcc' not in res.json['regions'][0]
 

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -678,7 +678,18 @@ class TestAppDetail(RestOAuth):
         eq_(res.status_code, 200)
         data = json.loads(res.content)
         eq_(data['banner_message'], unicode(geodata.banner_message))
-        eq_(data['banner_regions'], [mkt.regions.ARG.slug, mkt.regions.BRA.slug])
+        eq_(data['banner_regions'],
+            [mkt.regions.ARG.slug, mkt.regions.BRA.slug])
+
+    def test_region_v1(self):
+        res = self.client.get(self.get_url)
+        eq_(res.status_code, 200)
+        eq_(res.json['regions'][0]['mcc'], '722')
+
+    def test_region_v2(self):
+        res = self.client.get(self.get_url.replace('v1', 'v2'))
+        eq_(res.status_code, 200)
+        assert 'mcc' not in res.json['regions'][0]
 
 
 class TestCategoryHandler(RestOAuth):

--- a/mkt/constants/regions.py
+++ b/mkt/constants/regions.py
@@ -115,7 +115,7 @@ for k, translation in lookup.items():
         # one and that's included in v1 serialization requests only
         # so we are backwards compatible.
         try:
-            country['mcc'] = str(country['mcc'][0])
+            country['mcc'] = country['mcc'][0]
         except IndexError:
             pass
 

--- a/mkt/constants/regions.py
+++ b/mkt/constants/regions.py
@@ -108,11 +108,21 @@ for k, translation in lookup.items():
     if country.get('ratingsbody'):
         country['ratingsbody'] = getattr(ratingsbodies, country['ratingsbody'])
 
+    # This if check can be removed once marketplace-constants is updated.
+    if isinstance(country['mcc'], list):
+        # Marketplace constants changed the mcc to be a list of integers
+        # which is more accurate. This makes it a string and picks the first
+        # one and that's included in v1 serialization requests only
+        # so we are backwards compatible.
+        try:
+            country['mcc'] = str(country['mcc'][0])
+        except IndexError:
+            pass
+
     globals()[k] = type(k, (REGION,), country)
 
 # Please adhere to the new region checklist when adding a new region:
 # https://mana.mozilla.org/wiki/display/MARKET/How+to+add+a+new+region
-
 
 # Create a list of tuples like so (in alphabetical order):
 #

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -1032,6 +1032,15 @@ REST_FRAMEWORK = {
     'PAGINATE_BY_PARAM': 'limit'
 }
 
+SERIALIZER_BY_VERSION = {
+    'v1': {
+        'mkt.webapps.serializers.RegionSerializer':
+        'mkt.webapps.serializers.RegionSerializerV1',
+        'mkt.webapps.serializers.AppSerializer':
+        'mkt.webapps.serializers.AppSerializerV1',
+    }
+}
+
 RTL_LANGUAGES = ('ar', 'fa', 'fa-IR', 'he')
 
 # Flip this on in your local settings to disable ES tests.

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -58,6 +58,12 @@ class RegionSerializer(serializers.Serializer):
     adolescent = serializers.BooleanField()
 
 
+class RegionSerializerV1(RegionSerializer):
+    mcc = serializers.CharField()
+
+RegionSerializer.V1 = RegionSerializerV1
+
+
 class AppSerializer(serializers.ModelSerializer):
     app_type = serializers.ChoiceField(
         choices=mkt.ADDON_WEBAPP_TYPES_LOOKUP.items(), read_only=True)
@@ -358,6 +364,13 @@ class AppSerializer(serializers.ModelSerializer):
         for f, v in extras:
             f(instance, v)
         return instance
+
+
+class AppSerializerV1(AppSerializer):
+    regions = RegionSerializerV1(read_only=True, source='get_regions')
+
+
+AppSerializer.V1 = AppSerializerV1
 
 
 class ESAppSerializer(BaseESSerializer, AppSerializer):

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -55,7 +55,6 @@ class AppFeaturesSerializer(serializers.ModelSerializer):
 class RegionSerializer(serializers.Serializer):
     name = serializers.CharField()
     slug = serializers.CharField()
-    mcc = serializers.CharField()
     adolescent = serializers.BooleanField()
 
 

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -61,8 +61,6 @@ class RegionSerializer(serializers.Serializer):
 class RegionSerializerV1(RegionSerializer):
     mcc = serializers.CharField()
 
-RegionSerializer.v1 = RegionSerializerV1
-
 
 class AppSerializer(serializers.ModelSerializer):
     app_type = serializers.ChoiceField(
@@ -368,9 +366,6 @@ class AppSerializer(serializers.ModelSerializer):
 
 class AppSerializerV1(AppSerializer):
     regions = RegionSerializerV1(read_only=True, source='get_regions')
-
-
-AppSerializer.v1 = AppSerializerV1
 
 
 class ESAppSerializer(BaseESSerializer, AppSerializer):

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -61,7 +61,7 @@ class RegionSerializer(serializers.Serializer):
 class RegionSerializerV1(RegionSerializer):
     mcc = serializers.CharField()
 
-RegionSerializer.V1 = RegionSerializerV1
+RegionSerializer.v1 = RegionSerializerV1
 
 
 class AppSerializer(serializers.ModelSerializer):
@@ -370,7 +370,7 @@ class AppSerializerV1(AppSerializer):
     regions = RegionSerializerV1(read_only=True, source='get_regions')
 
 
-AppSerializer.V1 = AppSerializerV1
+AppSerializer.v1 = AppSerializerV1
 
 
 class ESAppSerializer(BaseESSerializer, AppSerializer):

--- a/mkt/webapps/tests/test_serializers.py
+++ b/mkt/webapps/tests/test_serializers.py
@@ -325,7 +325,7 @@ class TestAppSerializerPrices(mkt.site.tests.TestCase):
 class TestRegionSerializer(mkt.site.tests.TestCase):
 
     def test_v1(self):
-        eq_(RegionSerializerV1(regions.ARG).data['mcc'], '722')
+        eq_(RegionSerializerV1(regions.ARG).data['mcc'], 722)
 
     def test_v2_later(self):
         ok_('mcc' not in RegionSerializer(regions.ARG).data)

--- a/mkt/webapps/tests/test_serializers.py
+++ b/mkt/webapps/tests/test_serializers.py
@@ -24,6 +24,7 @@ from mkt.versions.models import Version
 from mkt.webapps.indexers import WebappIndexer
 from mkt.webapps.models import AddonDeviceType, Installed, Preview, Webapp
 from mkt.webapps.serializers import (AppSerializer, ESAppSerializer,
+                                     RegionSerializer, RegionSerializerV1,
                                      SimpleESAppSerializer)
 
 
@@ -319,6 +320,15 @@ class TestAppSerializerPrices(mkt.site.tests.TestCase):
         res = self.serialize(self.app)
         eq_(res['price'], None)
         eq_(res['price_locale'], None)
+
+
+class TestRegionSerializer(mkt.site.tests.TestCase):
+
+    def test_v1(self):
+        eq_(RegionSerializerV1(regions.ARG).data['mcc'], '722')
+
+    def test_v2_later(self):
+        ok_('mcc' not in RegionSerializer(regions.ARG).data)
 
 
 @mock.patch('mkt.versions.models.Version.is_privileged', False)


### PR DESCRIPTION
* fireplace maintains its own list of mccs https://github.com/mozilla/fireplace/blob/66a132ecf3e72fafde7c3e096ae0d37ff475d2c2/src/media/js/mobilenetwork.js#L32
* the mcc can be more than one per region, so what zamboni has is incorrect
* this is actually a *backwards incompatible change* for the API, should we do anything different?