### PR TITLE
improve refund page with payment provider specific information (bug 1123470)

### DIFF
--- a/media/css/devreg/lookup-tool.styl
+++ b/media/css/devreg/lookup-tool.styl
@@ -422,3 +422,9 @@ dd {
 a:not([href]) {
     cursor: pointer;
 }
+
+#transaction-lookup {
+    dt {
+        margin: 10px 0px 5px;
+    }
+}

--- a/media/css/devreg/manage.styl
+++ b/media/css/devreg/manage.styl
@@ -364,3 +364,7 @@ td .checkbox-choices:not(.regions) {
 .island-error {
     margin-bottom: 10px;
 }
+
+#transaction-lookup dd {
+    margin-top: 5px;
+}

--- a/mkt/constants/payments.py
+++ b/mkt/constants/payments.py
@@ -96,7 +96,8 @@ PROVIDER_CHOICES = (
     (PROVIDER_BOKU, 'boku')
 )
 
-PROVIDER_LOOKUP = dict([(v, k) for k, v in PROVIDER_CHOICES])
+PROVIDER_LOOKUP = dict(PROVIDER_CHOICES)
+PROVIDER_LOOKUP_INVERTED = dict([(v, k) for k, v in PROVIDER_CHOICES])
 CARRIER_CHOICES = ()
 
 # Payment methods accepted by the PriceCurrency..

--- a/mkt/lookup/templates/lookup/app_summary.html
+++ b/mkt/lookup/templates/lookup/app_summary.html
@@ -9,7 +9,7 @@
                       ('last_7_days', _('last 7 days')),
                       ('alltime', _('all time'))) %}
 
-  <section class="island c">
+  <section class="island c transaction-lookup">
     {{ app_header(app, 'summary') }}
 
     <section class="column-b">

--- a/mkt/lookup/templates/lookup/transaction_summary.html
+++ b/mkt/lookup/templates/lookup/transaction_summary.html
@@ -6,15 +6,16 @@
 {% block content %}
   {% include 'lookup/includes/transaction_search.html' %}
 
-  <section class="island c">
+  <section class="island c" id="transaction-lookup">
     <h1>
       {% trans tx_url = url('lookup.transaction_summary', uuid) %}
-        Transaction Lookup results for <a href="{{ tx_url }}">Transaction {{ uuid }}</a>
+        Transaction Lookup
       {% endtrans %}
     </h1>
 
     {% if contrib %}
       <section id="prose">
+        <h2>{{ _('Marketplace information') }}</h2>
         <dl>
           <dt>{{ _('Transaction ID') }}</dt><dd>{{ contrib.uuid }}</dd>
           <dt>{{ _('Date') }}</dt><dd>{{ contrib.created|datetime('%B %e, %Y %H:%M:%S') }}</dd>
@@ -37,12 +38,51 @@
             </dd>
           {% endif %}
         </dl>
+
+        <h2>{{ _('Payment provider information') }}</h2>
+        {% if not lookup['transaction'] %}
+          <p>{{ _('Currently unable to retrieve transaction status.') }}</p>
+        {% endif %}
+
+        {% if provider == 'bango' %}
+          <p>
+            {% trans bango_support='support@bango.com' %}
+              This payment was made through Bango. To get more information
+              contact <a href="mailto:{{ bango_support }}">Bango support</a>
+              with the following information.
+            {% endtrans %}
+          </p>
+        {% endif %}
+
+        {% if provider == 'reference' %}
+          <p>
+            {% trans %}
+              This payment was made through the <b>reference implementation</b>.
+              It wasn't a real transaction.
+            {% endtrans %}
+          </p>
+        {% endif %}
+
+        {% if lookup['transaction'] %}
+          <dl>
+            <dt>{{ _('Amount paid') }}</dt>
+            <dd>{{ amount }} {{ currency }}</dd>
+            <dt>{{ _('Lookup id') }}</dt>
+            <dd>{{ support }}</dd>
+            <dt>{{ _('Timestamp') }}</dt>
+            <dd>{{ timestamp }} PST</dd>
+          </dl>
+        {% endif %}
       </section>
     {% else %}
       {{ no_results() }}
     {% endif %}
 
     <div class="refund-transaction c">
+      <h2>{{ _('Refund information') }}</h2>
+      {% if not lookup['status'] %}
+        <p>{{ _('Currently unable to retrieve refund status.') }}</p>
+      {% endif %}
       <dl>
         <dt>{{ _('Refund Status') }}</dt>
         <dd>{{ refund_status or _('Unrequested') }}</dd>

--- a/mkt/prices/models.py
+++ b/mkt/prices/models.py
@@ -17,8 +17,8 @@ import mkt
 from lib.constants import ALL_CURRENCIES
 from mkt.constants import apps
 from mkt.constants.payments import (CARRIER_CHOICES, PAYMENT_METHOD_ALL,
-                                PAYMENT_METHOD_CHOICES, PROVIDER_BANGO,
-                                PROVIDER_CHOICES, PROVIDER_LOOKUP)
+                                    PAYMENT_METHOD_CHOICES, PROVIDER_BANGO,
+                                    PROVIDER_CHOICES, PROVIDER_LOOKUP_INVERTED)
 from mkt.constants.regions import RESTOFWORLD, REGIONS_CHOICES_ID_DICT as RID
 from mkt.purchase.models import Contribution
 from mkt.regions.utils import remove_accents
@@ -35,7 +35,7 @@ def default_providers():
     Returns a list of the default providers from the settings as the
     appropriate constants.
     """
-    return [PROVIDER_LOOKUP[p] for p in settings.PAYMENT_PROVIDERS]
+    return [PROVIDER_LOOKUP_INVERTED[p] for p in settings.PAYMENT_PROVIDERS]
 
 
 def price_locale(price, currency):

--- a/mkt/prices/serializers.py
+++ b/mkt/prices/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from mkt.constants.payments import PROVIDER_LOOKUP
+from mkt.constants.payments import PROVIDER_LOOKUP_INVERTED
 from mkt.prices.models import Price, price_locale
 
 
@@ -16,7 +16,7 @@ class PriceSerializer(serializers.ModelSerializer):
     def get_prices(self, obj):
         provider = self.context['request'].GET.get('provider', None)
         if provider:
-            provider = PROVIDER_LOOKUP[provider]
+            provider = PROVIDER_LOOKUP_INVERTED[provider]
         return obj.prices(provider=provider)
 
     def get_localized_prices(self, obj):


### PR DESCRIPTION
Lessons learned from the first refund, we need a bit more information on the refund page. This adds in information that Bango would like to know in terminology that Bango understands.

I'll do another PR with the package details to add to this.

![screenshot 2015-01-19 16 28 04](https://cloud.githubusercontent.com/assets/74699/5810241/2dd906a6-9ff8-11e4-8a1f-3c25d88a9f91.png)
