### PR TITLE
Fix requirements for dev.txt

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
--r prod.txt
--r compiled.txt
+# test.txt also includes prod.txt and compiled.txt
 -r test.txt
 
 translate-toolkit==1.12.0


### PR DESCRIPTION
pip was throwing an error about duplicate packages b/c we were including
prod and compiled twice when using dev.txt