### PR TITLE
Close popup only if it exists

### DIFF
--- a/media/js/devreg/login.js
+++ b/media/js/devreg/login.js
@@ -72,7 +72,9 @@ define('login', ['notification', 'storage'], function(notification, storage) {
                 dataType: 'json'}).done(finishLogin);
 
             // Close popup on receipt of message.
-            popup.close();
+            if (popup) {
+                popup.close();
+            }
         });
     }
 


### PR DESCRIPTION
Just to be a bit more defensive we should close the popup only if it exists.