### PR TITLE
Send a strong signal to delete feed item memberships when deleting a Webapp instance to prevent them from getting garbage collected (bug 1124319).

### DIFF
--- a/mkt/feed/models.py
+++ b/mkt/feed/models.py
@@ -474,13 +474,11 @@ models.signals.pre_save.connect(
 
 
 # Delete membership instances when their apps are deleted.
-def remove_deleted_app_on(cls):
-    def inner(*args, **kwargs):
-        instance = kwargs.get('instance')
+def remove_memberships(*args, **kwargs):
+    instance = kwargs.get('instance')
+    for cls in [FeedBrandMembership, FeedCollectionMembership,
+                FeedShelfMembership]:
         cls.objects.filter(app_id=instance.pk).delete()
-    return inner
 
-for cls in [FeedBrandMembership, FeedCollectionMembership,
-            FeedShelfMembership]:
-    post_delete.connect(remove_deleted_app_on(cls), sender=Webapp,
-                        dispatch_uid='apps_collections_cleanup')
+post_delete.connect(remove_memberships, sender=Webapp, weak=False,
+                    dispatch_uid='cleanup_feed_membership')

--- a/mkt/feed/models.py
+++ b/mkt/feed/models.py
@@ -246,8 +246,8 @@ class FeedBrand(BaseFeedCollection):
 
 class FeedCollectionMembership(BaseFeedCollectionMembership):
     """
-    An app's membership to a `FeedCollection` class, used as the through model for
-    `FeedBrand._apps`.
+    An app's membership to a `FeedCollection` class, used as the through model
+    for `FeedBrand._apps`.
     """
     obj = models.ForeignKey('FeedCollection')
     group = PurifiedField(blank=True, null=True)
@@ -361,8 +361,8 @@ class FeedApp(BaseFeedImage, ModelBase):
     # Optionally linked to a pull quote.
     pullquote_attribution = models.CharField(max_length=50, null=True,
                                              blank=True)
-    pullquote_rating = models.PositiveSmallIntegerField(null=True, blank=True,
-        validators=[validate_rating])
+    pullquote_rating = models.PositiveSmallIntegerField(
+        null=True, blank=True, validators=[validate_rating])
     pullquote_text = PurifiedField(null=True)
 
     # Deprecated.

--- a/mkt/feed/views.py
+++ b/mkt/feed/views.py
@@ -375,7 +375,6 @@ class FeedShelfViewSet(GroupedAppsViewSetMixin, FeedShelfPermissionMixin,
         Return all shelves a user can administer. Anonymous users will always
         receive an empty list.
         """
-        data = self.req_data()
         qs = self.queryset.no_cache()
         if request.user.is_anonymous():
             qs = self.queryset.none()
@@ -423,7 +422,6 @@ class FeedShelfViewSet(GroupedAppsViewSetMixin, FeedShelfPermissionMixin,
         """
         self.require_object_permission(request.user, self.get_object())
         return super(FeedShelfViewSet, self).destroy(request, *args, **kwargs)
-
 
 
 class FeedShelfPublishView(FeedShelfPermissionMixin, CORSMixin, APIView):
@@ -552,7 +550,8 @@ class FeedShelfImageViewSet(FeedShelfPermissionMixin, CollectionImageViewSet):
     queryset = FeedShelf.objects.all()
 
 
-class FeedShelfLandingImageViewSet(FeedShelfPermissionMixin, CollectionImageViewSet):
+class FeedShelfLandingImageViewSet(FeedShelfPermissionMixin,
+                                   CollectionImageViewSet):
     queryset = FeedShelf.objects.all()
     hash_field = 'image_landing_hash'
     image_suffix = '_landing'
@@ -750,9 +749,9 @@ class FeedView(MarketplaceView, BaseFeedESView, generics.GenericAPIView):
         shelf_filter = es_filter.Term(item_type=feed.FEED_TYPE_SHELF)
 
         ordering_fn = es_function.FieldValueFactor(
-             field='order', modifier='reciprocal',
-             filter=es_filter.Bool(must=[region_filter],
-                                   must_not=[shelf_filter]))
+            field='order', modifier='reciprocal',
+            filter=es_filter.Bool(must=[region_filter],
+                                  must_not=[shelf_filter]))
         boost_fn = es_function.BoostFactor(value=10000.0,
                                            filter=shelf_filter)
 


### PR DESCRIPTION
This was a fun one.