### PR TITLE
Fix gitignore for supervisord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ media/marketplace-stats
 media/transonic
 *.signed.zip
 *.po~
-logs/*.log
+logs/*
+supervisord.pid


### PR DESCRIPTION
r? @andymckay 

To prevent:

\#\# master...upstream/master
?? logs/docker.log.1
?? logs/docker.log.2
?? logs/docker.log.3
?? supervisord.pid