### PR TITLE
Move langpack name to its own property, expose it to the API (bug 1122256)

### DIFF
--- a/mkt/langpacks/models.py
+++ b/mkt/langpacks/models.py
@@ -71,6 +71,14 @@ class LangPack(ModelBase):
         return self.active
 
     @property
+    def name(self):
+        with translation.override(self.language):
+            return _('%(lang)s language pack for Firefox OS %(version)s' % {
+                'lang': self.get_language_display(),
+                'version': self.fxos_version
+            })
+
+    @property
     def path_prefix(self):
         return os.path.join(settings.ADDONS_PATH, 'langpacks', str(self.pk))
 
@@ -100,13 +108,9 @@ class LangPack(ModelBase):
         # in the zip file. When we do, we'll need to add caching and refactor
         # to avoid code duplication with mkt.detail.manifest() and
         # mkt.webapps.Webapp.get_cached_manifest().
-        with translation.override(self.language):
-            name = _('%(lang)s language pack for Firefox OS %(version)s' % {
-                'lang': self.get_language_display(),
-                'version': self.fxos_version
-            })
+
         manifest = {
-            'name': name,
+            'name': self.name,
             'developer': {
                 'name': 'Mozilla'
             },

--- a/mkt/langpacks/serializers.py
+++ b/mkt/langpacks/serializers.py
@@ -53,12 +53,18 @@ class LangPackSerializer(serializers.ModelSerializer):
     # want to be stricter and throw 400 errors if we encounter any of the
     # read-only fields.
     write_allowed_fields = ('active',)
-    # manifest_url is a @property so we need to manually choose a field for it.
-    manifest_url = serializers.CharField(source='manifest_url')
+
+    # Special fields (properties/methods).
+    language_display = serializers.CharField(read_only=True,
+                                             source='get_language_display')
+    manifest_url = serializers.CharField(read_only=True)
+    name = serializers.CharField(read_only=True)
+
     class Meta:
         model = LangPack
         fields = ('active', 'created', 'fxos_version', 'hash', 'language',
-                  'manifest_url', 'modified', 'size', 'uuid', 'version')
+                  'language_display', 'manifest_url', 'modified', 'name',
+                  'size', 'uuid', 'version')
 
     def validate(self, attrs):
         errors = {}

--- a/mkt/langpacks/tests/test_models.py
+++ b/mkt/langpacks/tests/test_models.py
@@ -2,6 +2,7 @@
 import json
 import os
 
+from django.conf import settings
 from django.core.files.storage import default_storage as storage
 from django.forms import ValidationError
 
@@ -43,6 +44,16 @@ class TestLangPackBasic(TestCase):
              'name': u'English (US) language pack for Firefox OS 2.2',
              'package_path': langpack.download_url,
              'developer': {'name': 'Mozilla'}})
+
+    def test_name(self):
+        langpack = LangPack(fxos_version='2.5.1')
+        eq_(langpack.name, u'English (US) language pack for Firefox OS 2.5.1')
+
+    def test_language_choices_and_display(self):
+        field = LangPack._meta.get_field('language')
+        eq_(len(field.choices), len(settings.LANGUAGES))
+        eq_(LangPack(language='fr').get_language_display(), u'Français')
+        eq_(LangPack(language='en-US').get_language_display(), u'English (US)')
 
 
 class UploadCreationMixin(object):

--- a/mkt/langpacks/tests/test_views.py
+++ b/mkt/langpacks/tests/test_views.py
@@ -6,7 +6,6 @@ from django.core.files.storage import default_storage as storage
 from django.core.urlresolvers import reverse
 from django.forms import ValidationError
 from django.test.utils import override_settings
-from django.utils.http import parse_http_date
 
 from mock import patch
 from nose.tools import eq_, ok_
@@ -53,6 +52,8 @@ class TestLangPackViewSetMixin(RestOAuth):
         eq_(instance.active, langpack_data['active'])
         eq_(instance.language, langpack_data['language'])
         eq_(instance.fxos_version, langpack_data['fxos_version'])
+        eq_(instance.name, langpack_data['name'])
+        eq_(instance.get_language_display(), langpack_data['language_display'])
 
 
 class TestLangPackViewSetBase(TestLangPackViewSetMixin):


### PR DESCRIPTION
Needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1122256