### PR TITLE
Fix region iterations on devhub (1129169)

### DIFF
--- a/media/js/devreg/payments.js
+++ b/media/js/devreg/payments.js
@@ -203,11 +203,11 @@ define('payments', [], function() {
                     var $chkbox = $regions.find('input:checkbox[value=' + regionId + ']');
                     var $row = $('#paid-regions tr[data-region=' + regionId + ']');
 
-                    // If we've already dealt with this region append this provider to existing row and break.
+                    // If we've already dealt with this region append this provider to existing row and continue.
                     if (regionSeen && $row.length) {
                         var $billingMethodCell = $row.find('.lm');
                         $billingMethodCell.text($billingMethodCell.text() + ', ' + localMethod + ' (' + provider + ')');
-                        break;
+                        continue;
                     }
 
                     if ($row.length) {


### PR DESCRIPTION
When Boku accounts were added we're bailing early on the loop when we should be continuing to go through the rest of the data.