### PR TITLE
Store manifest when upload a langpack and simpliy model (bug 1122273)

### DIFF
--- a/docs/api/topics/langpacks.rst
+++ b/docs/api/topics/langpacks.rst
@@ -49,9 +49,6 @@ Detail
     :type created: string
     :param fxos_version: The Firefox OS version this langpack provides translations for.
     :type fxos_version: string
-    :param hash: The
-     SHA256 hash of the package.
-    :type hash: string
     :param language: The language code (i.e. "de", or "pt-BR") this langpack provides translations for.
     :type language: string
     :param language_display: The language this langpack provides translations for, in a human-readable format (i.e. Deutsch).
@@ -60,8 +57,6 @@ Detail
     :type active: string
     :param modified: The date that the langpack was last modified (in ISO 8601 format).
     :type modified: string
-    :param size: The size (in bytes) of the Langpack package.
-    :type size: int
     :param uuid: Unique identifier for this langpack.
     :type uuid: string
     :param version: The version of the Langpack package itself.

--- a/migrations/894-simplify-langpacks.sql
+++ b/migrations/894-simplify-langpacks.sql
@@ -1,0 +1,11 @@
+-- filename is now automatically generated.
+ALTER TABLE `langpacks_langpack` DROP COLUMN `filename`;
+
+-- hash was only used for the etag, which is calculated differently now.
+ALTER TABLE `langpacks_langpack` DROP COLUMN `hash`;
+
+-- size was only used in the manifest, it's now automatically generated.
+ALTER TABLE `langpacks_langpack` DROP COLUMN `size`;
+
+-- original manifest is important to be able to serve a correct minifest.
+ALTER TABLE `langpacks_langpack` ADD COLUMN `manifest` longtext NOT NULL;

--- a/mkt/detail/tests/test_views.py
+++ b/mkt/detail/tests/test_views.py
@@ -198,10 +198,10 @@ class TestPackagedManifest(mkt.site.tests.TestCase):
         res = self.client.get(self.url)
         self.assertCORS(res, 'get')
 
-    @mock.patch('mkt.webapps.models.storage')
+    @mock.patch('mkt.webapps.utils.storage')
     @mock.patch('mkt.webapps.models.packaged')
-    def test_calls_sign(self, _sign, _storage):
-        _sign.sign.return_value = '/path/to/signed.zip'
+    def test_calls_sign(self, _packaged, _storage):
+        _packaged.sign.return_value = '/path/to/signed.zip'
         _storage.size.return_value = 1234
         self.client.get(self.url)
-        assert _sign.sign.called
+        assert _packaged.sign.called

--- a/mkt/files/utils.py
+++ b/mkt/files/utils.py
@@ -43,6 +43,7 @@ def get_file(fileorpath):
 
 
 class WebAppParser(object):
+    langpacks_allowed = False
 
     def extract_locale(self, locales, key, default=None):
         """Gets a locale item based on key.
@@ -106,7 +107,7 @@ class WebAppParser(object):
     def parse(self, fileorpath):
         data = self.get_json_data(fileorpath)
 
-        if data.get('role') == 'langpack':
+        if not self.langpacks_allowed and data.get('role') == 'langpack':
             raise forms.ValidationError(
                 _(u'The "langpack" role is invalid for Web Apps. Please submit'
                   u' this app as a language pack instead.'))

--- a/mkt/langpacks/serializers.py
+++ b/mkt/langpacks/serializers.py
@@ -58,13 +58,12 @@ class LangPackSerializer(serializers.ModelSerializer):
     language_display = serializers.CharField(read_only=True,
                                              source='get_language_display')
     manifest_url = serializers.CharField(read_only=True)
-    name = serializers.CharField(read_only=True)
 
     class Meta:
         model = LangPack
-        fields = ('active', 'created', 'fxos_version', 'hash', 'language',
-                  'language_display', 'manifest_url', 'modified', 'name',
-                  'size', 'uuid', 'version')
+        fields = ('active', 'created', 'fxos_version', 'language',
+                  'language_display', 'manifest_url', 'modified', 'uuid',
+                  'version')
 
     def validate(self, attrs):
         errors = {}

--- a/mkt/langpacks/tests/test_utils_.py
+++ b/mkt/langpacks/tests/test_utils_.py
@@ -4,64 +4,92 @@ from django.forms import ValidationError
 from mock import patch
 from nose.tools import eq_
 
+from mkt.files.tests.test_utils_ import TestWebAppParser
 from mkt.langpacks.utils import LanguagePackParser
-from mkt.site.tests import TestCase
 
 
-class TestLangPackUpload(TestCase):
+class TestLangPackUpload(TestWebAppParser):
+    klass = LanguagePackParser
+    base_mock_data = {
+        'name': 'Blah',
+        'developer': {
+            'name': 'Mozilla Marketplace Testing'
+        },
+        'role': 'langpack',
+        'version': '0.1',
+        'languages-provided': {
+            'de': {},
+        },
+        'languages-target': {
+            'app://*.gaiamobile.org/manifest.webapp': '2.2'
+        }
+    }
+
     @patch('mkt.files.utils.WebAppParser.get_json_data')
     def test_upload_multiple_languages(self, get_json_data_mock):
-        get_json_data_mock.return_value = {
-            'role': 'langpack',
+        get_json_data_mock.return_value = self.build_data_mock({
             'languages-provided': {
                 'es': {},
                 'de': {},
-            },
-            'languages-target': {
-                'app://*.gaiamobile.org/manifest.webapp': '2.2'
             }
-        }
+        })
         expected = [u'Your language pack contains too many languages. '
                     u'Only one language per pack is supported.']
         with self.assertRaises(ValidationError) as e:
             # The argument to parse() is supposed to be a filename, it doesn't
             # matter here though since we are mocking get_json_data().
-            LanguagePackParser().parse('')
+            self.klass().parse('')
         eq_(e.exception.messages, expected)
 
     @patch('mkt.files.utils.WebAppParser.get_json_data')
     def test_upload_multiple_targets(self, get_json_data_mock):
-        get_json_data_mock.return_value = {
-            'role': 'langpack',
-            'languages-provided': {
-                'es': {},
-            },
+        get_json_data_mock.return_value = self.build_data_mock({
             'languages-target': {
                 'app://*.gaiamobile.org/manifest.webapp': '2.2',
                 'app://somethingelse.gaiamobile.org/manifest.webapp': '2.3'
             }
-        }
+        })
         expected = [u'Your language pack contains too many targets. Only one '
                     u'target per pack is supported.']
         with self.assertRaises(ValidationError) as e:
             # The argument to parse() is supposed to be a filename, it doesn't
             # matter here though since we are mocking get_json_data().
-            LanguagePackParser().parse('')
+            self.klass().parse('')
         eq_(e.exception.messages, expected)
 
     @patch('mkt.files.utils.WebAppParser.get_json_data')
     def test_upload_no_role(self, get_json_data_mock):
-        get_json_data_mock.return_value = {
-            'languages-provided': {
-                'es': {}
-            },
-            'languages-target': {
-                'app://*.gaiamobile.org/manifest.webapp': '2.2'
-            }
-        }
+        get_json_data_mock.return_value = self.build_data_mock()
+        del get_json_data_mock.return_value['role']
         expected = [u'Your language pack should contain "role": "langpack".']
         with self.assertRaises(ValidationError) as e:
             # The argument to parse() is supposed to be a filename, it doesn't
             # matter here though since we are mocking get_json_data().
-            LanguagePackParser().parse('')
+            self.klass().parse('')
         eq_(e.exception.messages, expected)
+
+    @patch('mkt.files.utils.WebAppParser.get_json_data')
+    def test_upload_version_missing(self, get_json_data_mock):
+        get_json_data_mock.return_value = self.build_data_mock()
+        del get_json_data_mock.return_value['version']
+        expected = [u'Your language pack should contain a version.']
+        with self.assertRaises(ValidationError) as e:
+            self.klass().parse('')
+        eq_(e.exception.messages, expected)
+
+    @patch('mkt.files.utils.WebAppParser.get_json_data')
+    def test_homescreen_role(self, get_json_data_mock):
+        # Parent class also have this test, we are overriding it since
+        # homescreen apps are not valid langpacks.
+        get_json_data_mock.return_value = self.build_data_mock()
+        get_json_data_mock.return_value['role'] = 'homescreen'
+        expected = [u'Your language pack should contain "role": "langpack".']
+        with self.assertRaises(ValidationError) as e:
+            # The argument to parse() is supposed to be a filename, it doesn't
+            # matter here though since we are mocking get_json_data().
+            self.klass().parse('')
+        eq_(e.exception.messages, expected)
+
+    def test_langpack_role(self):
+        # Parent class has this test, but we don't want it here.
+        pass

--- a/mkt/langpacks/utils.py
+++ b/mkt/langpacks/utils.py
@@ -7,16 +7,15 @@ from mkt.files.utils import WebAppParser
 
 
 class LanguagePackParser(WebAppParser):
+    langpacks_allowed = True
+
     def __init__(self, instance=None):
         self.instance = instance
 
     def parse(self, upload):
         """Parse the FileUpload passed in argument and return langpack data.
         May raise forms.ValidationError()"""
-        # At the moment, we don't care about most of the manifest for
-        # langpacks so we simply extract the minimum we require ; in the future
-        # we might want to call the parent's parse() method and have a way to
-        # deal with extra stuff in the child.
+        output = super(LanguagePackParser, self).parse(upload)
         data = self.get_json_data(upload)
 
         if data.get('role') != 'langpack':
@@ -54,9 +53,11 @@ class LanguagePackParser(WebAppParser):
                 _(u'Your language pack version must be different to the one '
                   u'you are replacing.'))
 
-        output = {
+        # We don't really care about the base fields from the parent, but it
+        # helps tests.
+        output.update({
             'language': languages_provided[0],
             'fxos_version': languages_target[0],
             'version': version,
-        }
+        })
         return output

--- a/mkt/submit/tests/test_views.py
+++ b/mkt/submit/tests/test_views.py
@@ -235,13 +235,13 @@ class UploadAddon(object):
         if data is None:
             data = {'free_platforms': ['free-desktop']}
         data.update(upload=self.upload.pk)
-        r = self.client.post(self.url, data, follow=True)
-        eq_(r.status_code, 200)
+        response = self.client.post(self.url, data, follow=True)
+        eq_(response.status_code, 200)
         if not expect_errors:
             # Show any unexpected form errors.
-            if r.context and 'form' in r.context:
-                eq_(r.context['form'].errors, {})
-        return r
+            if response.context and 'form' in response.context:
+                eq_(response.context['form'].errors, {})
+        return response
 
 
 class BaseWebAppTest(BaseUploadTest, UploadAddon, TestCase):

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -1772,7 +1772,7 @@ class TestPackagedManifest(BasePackagedAppTest):
         with self.assertNumQueries(0):
             webapp.get_cached_manifest()
 
-    @mock.patch('mkt.webapps.models.cache')
+    @mock.patch('mkt.webapps.utils.cache')
     def test_cached_manifest_no_version_not_cached(self, cache_mock):
         webapp = self.post_addon(
             data={'packaged': True, 'free_platforms': 'free-firefoxos'})

--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -1,7 +1,15 @@
-from nose.tools import eq_
+import json
 
+from django.core.cache import cache
+
+from mock import patch
+from nose.tools import eq_, ok_
+
+from mkt.langpacks.models import LangPack
+from mkt.site.fixtures import fixture
 from mkt.site.tests import TestCase
-from mkt.webapps.utils import get_supported_locales
+from mkt.webapps.models import Webapp
+from mkt.webapps.utils import get_cached_minifest, get_supported_locales
 
 
 class TestSupportedLocales(TestCase):
@@ -31,3 +39,50 @@ class TestSupportedLocales(TestCase):
     def test_unsupported_locale(self):
         self.manifest.update({'locales': {'xx': {'name': 'xx'}}})
         self.check([])
+
+
+class TestCachedMinifest(TestCase):
+    fixtures = fixture('webapp_337141')
+
+    def setUp(self):
+        self.webapp = Webapp.objects.get(pk=337141)
+
+    @patch('mkt.webapps.utils.storage')
+    def test_get_cached_minifest_caching_force(self, storage_mock):
+        storage_mock.size.return_value = 999
+        minifest = json.loads(get_cached_minifest(self.webapp))
+        eq_(minifest['size'], 999)
+
+        # Change the size, the minifest should be updated because we are
+        # passing force=True.
+        storage_mock.size.return_value = 666
+        new_minifest = json.loads(get_cached_minifest(self.webapp, force=True))
+        ok_(new_minifest != minifest)
+        eq_(new_minifest['size'], 666)
+
+    @patch('mkt.webapps.utils.storage')
+    def test_get_cached_minifest_caching(self, storage_mock):
+        storage_mock.size.return_value = 999
+        minifest = json.loads(get_cached_minifest(self.webapp))
+        eq_(minifest['size'], 999)
+
+        # Change the size, the minifest should stay the same thanks to caching.
+        storage_mock.size.return_value = 666
+        new_minifest = json.loads(get_cached_minifest(self.webapp))
+        eq_(new_minifest, minifest)
+
+    @patch('mkt.webapps.utils.storage')
+    def test_caching_key_differs_between_models(self, storage_mock):
+        storage_mock.size.return_value = 999
+
+        ok_(not cache.get('webapp:337141:manifest'))
+        get_cached_minifest(self.webapp)
+
+        ok_(not cache.get(
+            'langpack:12345678123456781234567812345678:manifest'))
+        langpack = LangPack(pk='12345678123456781234567812345678',
+                            manifest='{}')
+        get_cached_minifest(langpack)
+
+        ok_(cache.get('webapp:337141:manifest'))
+        ok_(cache.get('langpack:12345678123456781234567812345678:manifest'))


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1122273

We need to keep some keys in the minifest identical to the manifest, before the platform compares the two and will complain if some keys like name, developer, locales are different.

This means we can drop the custom name property. In addition, some refactoring was needed to be able to share webapps manifest parsing and minifest generation, and as a result we're able to drop a few fields.