### PR TITLE
Relocate `app_factory` and related utils used by fake data tools (bug 1130441)

### DIFF
--- a/mkt/account/tests/test_views.py
+++ b/mkt/account/tests/test_views.py
@@ -18,8 +18,8 @@ from mkt.account.views import MineMixin
 from mkt.api.tests.test_oauth import RestOAuth
 from mkt.constants.apps import INSTALL_TYPE_REVIEWER
 from mkt.site.fixtures import fixture
-from mkt.site.tests import TestCase, app_factory
-from mkt.site.utils import urlparams
+from mkt.site.tests import TestCase
+from mkt.site.utils import app_factory, urlparams
 from mkt.webapps.models import Installed, Webapp
 from mkt.users.models import UserProfile
 

--- a/mkt/api/tests/test_fields.py
+++ b/mkt/api/tests/test_fields.py
@@ -13,7 +13,8 @@ from mkt.api.fields import (ESTranslationSerializerField, SlugChoiceField,
                             TranslationSerializerField)
 from mkt.carriers import CARRIER_MAP
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, TestCase
+from mkt.site.tests import TestCase
+from mkt.site.utils import app_factory
 from mkt.translations.models import Translation
 from mkt.webapps.models import Webapp
 

--- a/mkt/comm/tests/test_commands.py
+++ b/mkt/comm/tests/test_commands.py
@@ -7,7 +7,8 @@ from mkt.comm.models import CommunicationNote, CommunicationThread
 from mkt.constants import comm
 from mkt.developers.models import ActivityLog, ActivityLogAttachment
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, TestCase, user_factory
+from mkt.site.tests import TestCase, user_factory
+from mkt.site.utils import app_factory
 from mkt.users.models import UserProfile
 
 

--- a/mkt/comm/tests/test_serializers.py
+++ b/mkt/comm/tests/test_serializers.py
@@ -2,8 +2,8 @@ from nose.tools import eq_, ok_
 
 from mkt.comm import serializers
 from mkt.comm.utils import create_comm_note
-from mkt.site.tests import (app_factory, req_factory_factory, TestCase,
-                            user_factory)
+from mkt.site.tests import req_factory_factory, TestCase, user_factory
+from mkt.site.utils import app_factory
 
 
 class TestNoteSerializer(TestCase):

--- a/mkt/comm/tests/test_utils_.py
+++ b/mkt/comm/tests/test_utils_.py
@@ -7,7 +7,8 @@ from mkt.comm.forms import CommAttachmentFormSet
 from mkt.comm.tests.test_views import AttachmentManagementMixin
 from mkt.comm.utils import create_comm_note
 from mkt.constants import comm
-from mkt.site.tests import app_factory, TestCase, user_factory
+from mkt.site.tests import TestCase, user_factory
+from mkt.site.utils import app_factory
 
 
 class TestCreateCommNote(TestCase, AttachmentManagementMixin):

--- a/mkt/comm/tests/test_utils_mail.py
+++ b/mkt/comm/tests/test_utils_mail.py
@@ -15,7 +15,8 @@ from mkt.comm.utils import create_comm_note
 from mkt.comm.utils_mail import CommEmailParser, save_from_email_reply
 from mkt.constants import comm
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, TestCase, user_factory
+from mkt.site.tests import TestCase, user_factory
+from mkt.site.utils import app_factory
 from mkt.users.models import UserProfile
 
 

--- a/mkt/comm/tests/test_views.py
+++ b/mkt/comm/tests/test_views.py
@@ -18,8 +18,8 @@ from mkt.comm.models import (CommAttachment, CommunicationNote,
 from mkt.comm.views import (EmailCreationPermission, post_email,
                             ThreadPermission)
 from mkt.site.fixtures import fixture
-from mkt.site.tests import (app_factory, req_factory_factory, user_factory,
-                            version_factory)
+from mkt.site.tests import req_factory_factory, user_factory
+from mkt.site.utils import app_factory, version_factory
 from mkt.users.models import UserProfile
 from mkt.webapps.models import Webapp
 

--- a/mkt/developers/tests/test_api_payments.py
+++ b/mkt/developers/tests/test_api_payments.py
@@ -19,7 +19,8 @@ from mkt.developers.models import (AddonPaymentAccount, PaymentAccount,
 from mkt.developers.tests.test_providers import Patcher
 from mkt.prices.models import AddonPremium, Price
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, TestCase
+from mkt.site.tests import TestCase
+from mkt.site.utils import app_factory
 from mkt.webapps.models import AddonUpsell, AddonUser, Webapp
 
 

--- a/mkt/developers/tests/test_cron.py
+++ b/mkt/developers/tests/test_cron.py
@@ -8,7 +8,8 @@ import mkt
 from mkt.developers.cron import (_flag_rereview_adult, exclude_new_region,
                                  process_iarc_changes, send_new_region_emails)
 from mkt.developers.models import ActivityLog
-from mkt.site.tests import app_factory, TestCase, user_factory, WebappTestCase
+from mkt.site.tests import TestCase, user_factory, WebappTestCase
+from mkt.site.utils import app_factory
 from mkt.webapps.models import IARCInfo, RatingDescriptors, RatingInteractives
 
 

--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -18,8 +18,8 @@ from mkt.developers import forms
 from mkt.developers.tests.test_views_edit import TestAdmin
 from mkt.files.helpers import copyfileobj
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, version_factory
 from mkt.site.tests.test_utils_ import get_image_path
+from mkt.site.utils import app_factory, version_factory
 from mkt.tags.models import Tag
 from mkt.translations.models import Translation
 from mkt.users.models import UserProfile
@@ -842,7 +842,7 @@ class TestIARCGetAppInfoForm(mkt.site.tests.WebappTestCase):
         self.app.set_iarc_info(1, 'a')
         eq_(IARCInfo.objects.count(), 1)
 
-        some_app = mkt.site.tests.app_factory()
+        some_app = app_factory()
         form = self._get_form(app=some_app)
         ok_(not form.is_valid())
 

--- a/mkt/developers/tests/test_models.py
+++ b/mkt/developers/tests/test_models.py
@@ -15,6 +15,7 @@ from mkt.developers.models import (ActivityLog, ActivityLogAttachment,
                                    PaymentAccount, PreloadTestPlan,
                                    SolitudeSeller)
 from mkt.developers.providers import get_provider
+from mkt.site.utils import app_factory
 from mkt.site.fixtures import fixture
 from mkt.users.models import UserProfile
 from mkt.webapps.models import Webapp
@@ -296,7 +297,7 @@ class TestActivityLogAttachment(mkt.site.tests.TestCase):
 class TestPreloadTestPlan(mkt.site.tests.TestCase):
 
     def setUp(self):
-        self.app = mkt.site.tests.app_factory()
+        self.app = app_factory()
         self.preload = self.app.preloadtestplan_set.create(filename='test.pdf')
 
     def test_delete_cascade(self):

--- a/mkt/developers/tests/test_providers.py
+++ b/mkt/developers/tests/test_providers.py
@@ -11,7 +11,8 @@ from mkt.developers.models import PaymentAccount, SolitudeSeller
 from mkt.developers.providers import (account_check, Bango, Boku, get_provider,
                                       Reference)
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, TestCase
+from mkt.site.tests import TestCase
+from mkt.site.utils import app_factory
 from mkt.users.models import UserProfile
 
 

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -35,8 +35,8 @@ from mkt.prices.models import AddonPremium, Price
 from mkt.purchase.models import Contribution
 from mkt.site.fixtures import fixture
 from mkt.site.helpers import absolutify
-from mkt.site.tests import (app_factory, assert_no_validation_errors,
-                            version_factory)
+from mkt.site.tests import assert_no_validation_errors
+from mkt.site.utils import app_factory, version_factory
 from mkt.site.tests.test_utils_ import get_image_path
 from mkt.site.utils import urlparams
 from mkt.submit.models import AppSubmissionChecklist
@@ -211,7 +211,7 @@ class TestAppDashboardSorting(AppHubTest):
 
     def clone(self, num=3):
         for x in xrange(num):
-            app = mkt.site.tests.app_factory()
+            app = app_factory()
             AddonUser.objects.create(addon=app, user=self.user)
 
     def test_pagination(self):
@@ -1058,8 +1058,7 @@ class TestDeleteApp(mkt.site.tests.TestCase):
         eq_(Webapp.objects.count(), 0, 'App should have been deleted.')
 
     def test_delete_incomplete_manually(self):
-        webapp = mkt.site.tests.app_factory(
-            name='Boop', status=mkt.STATUS_NULL)
+        webapp = app_factory(name='Boop', status=mkt.STATUS_NULL)
         eq_(list(Webapp.objects.filter(id=webapp.id)), [webapp])
         webapp.delete('POOF!')
         eq_(list(Webapp.objects.filter(id=webapp.id)), [],

--- a/mkt/developers/tests/test_views_api.py
+++ b/mkt/developers/tests/test_views_api.py
@@ -12,8 +12,8 @@ import mkt
 from mkt.api.models import Access
 from mkt.api.tests.test_oauth import RestOAuth
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, TestCase
-from mkt.site.utils import urlparams
+from mkt.site.tests import TestCase
+from mkt.site.utils import app_factory, urlparams
 from mkt.webapps.models import ContentRating, Geodata
 from mkt.users.models import UserProfile
 

--- a/mkt/developers/tests/test_views_edit.py
+++ b/mkt/developers/tests/test_views_edit.py
@@ -29,6 +29,7 @@ from mkt.site.fixtures import fixture
 from mkt.site.helpers import absolutify
 from mkt.site.tests import formset, initial
 from mkt.site.tests.test_utils_ import get_image_path
+from mkt.site.utils import app_factory
 from mkt.translations.models import Translation
 from mkt.users.models import UserProfile
 from mkt.versions.models import Version
@@ -283,8 +284,8 @@ class TestEditBasic(TestEdit):
     @mock.patch('mkt.developers.forms.update_manifests')
     def test_view_manifest_changed_dupe_app_domain(self, fetch):
         self.create_switch('webapps-unique-by-domain')
-        mkt.site.tests.app_factory(name='Super Duper',
-                                   app_domain='https://ballin.com')
+        app_factory(name='Super Duper',
+                    app_domain='https://ballin.com')
         self.login('admin')
 
         # POST with new manifest URL.

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -26,6 +26,7 @@ from mkt.developers.views_payments import (get_inapp_config,
                                            require_in_app_payments)
 from mkt.prices.models import Price
 from mkt.site.fixtures import fixture
+from mkt.site.utils import app_factory
 from mkt.users.models import UserProfile
 from mkt.webapps.models import AddonExcludedRegion as AER
 from mkt.webapps.models import (AddonDeviceType, AddonPremium, AddonUpsell,
@@ -1232,7 +1233,7 @@ class TestPaymentPortal(PaymentsBase):
         eq_(output[0]['portal-url'], '')
 
     def test_reference(self):
-        mkt.site.tests.app_factory(app_slug=self.app_slug)
+        app_factory(app_slug=self.app_slug)
         PaymentAccount.objects.update(provider=PROVIDER_REFERENCE)
         res = self.client.get(self.bango_url)
         eq_(res.status_code, 403)

--- a/mkt/lookup/tests/test_views.py
+++ b/mkt/lookup/tests/test_views.py
@@ -32,8 +32,8 @@ from mkt.prices.models import AddonPaymentData, Refund
 from mkt.purchase.models import Contribution
 from mkt.reviewers.models import QUEUE_TARAKO
 from mkt.site.fixtures import fixture
-from mkt.site.tests import (app_factory, ESTestCase, req_factory_factory,
-                            TestCase)
+from mkt.site.tests import ESTestCase, req_factory_factory, TestCase
+from mkt.site.utils import app_factory, file_factory, version_factory
 from mkt.tags.models import Tag
 from mkt.users.models import UserProfile
 from mkt.webapps.models import AddonUser, Webapp
@@ -758,8 +758,8 @@ class TestAppSummary(AppSummaryTest):
 
     def test_packaged_app_deleted(self):
         self.app.update(is_packaged=True)
-        ver = mkt.site.tests.version_factory(addon=self.app)
-        mkt.site.tests.file_factory(version=ver)
+        ver = version_factory(addon=self.app)
+        file_factory(version=ver)
         self.app.delete()
         self.summary()
 

--- a/mkt/ratings/tests/test_views.py
+++ b/mkt/ratings/tests/test_views.py
@@ -16,6 +16,7 @@ from mkt.developers.models import ActivityLog
 from mkt.prices.models import AddonPurchase
 from mkt.ratings.models import Review, ReviewFlag
 from mkt.site.fixtures import fixture
+from mkt.site.utils import app_factory, version_factory
 from mkt.webapps.models import AddonExcludedRegion, AddonUser, Webapp
 from mkt.users.models import UserProfile
 
@@ -71,9 +72,8 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
                                     body=u'I lôve this app',
                                     rating=5)
         pk = rev.pk
-        ver = mkt.site.tests.version_factory(
-            addon=self.app, version='2.0',
-            file_kw=dict(status=mkt.STATUS_PUBLIC))
+        ver = version_factory(addon=self.app, version='2.0',
+                              file_kw=dict(status=mkt.STATUS_PUBLIC))
         self.app.update_version()
         res, data = self._get_url(self.list_url, app=self.app.pk)
 
@@ -143,7 +143,7 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
         self._get_filter(user='mine', client=self.anon, expected_status=403)
 
     def test_filter_by_app_slug(self):
-        self.app2 = mkt.site.tests.app_factory()
+        self.app2 = app_factory()
         Review.objects.create(addon=self.app2, user=self.user, body='no')
         Review.objects.create(addon=self.app, user=self.user, body='yes')
         res, data = self._get_filter(app=self.app.app_slug)
@@ -151,7 +151,7 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
         eq_(data['info']['current_version'], self.app.current_version.version)
 
     def test_filter_by_app_pk(self):
-        self.app2 = mkt.site.tests.app_factory()
+        self.app2 = app_factory()
         Review.objects.create(addon=self.app2, user=self.user, body='no')
         Review.objects.create(addon=self.app, user=self.user, body='yes')
         res, data = self._get_filter(app=self.app.pk)
@@ -277,7 +277,7 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
     def test_already_rated_version(self):
         self.app.update(is_packaged=True)
         Review.objects.create(addon=self.app, user=self.user, body='yes')
-        mkt.site.tests.version_factory(addon=self.app, version='3.0')
+        version_factory(addon=self.app, version='3.0')
         self.app.update_version()
         res, data = self._get_url(self.list_url, app=self.app.app_slug)
         data = json.loads(res.content)
@@ -362,7 +362,7 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
     def test_new_rating_for_new_version(self):
         self.app.update(is_packaged=True)
         self._create()
-        version = mkt.site.tests.version_factory(addon=self.app, version='3.0')
+        version = version_factory(addon=self.app, version='3.0')
         self.app.update_version()
         eq_(self.app.reload().current_version, version)
         res, data = self._create()
@@ -478,7 +478,7 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
 
     def test_update_change_app(self):
         _, previous_data = self._create_default_review()
-        self.app2 = mkt.site.tests.app_factory()
+        self.app2 = app_factory()
         new_data = {
             'body': 'Totally rocking the free web.',
             'rating': 4,

--- a/mkt/reviewers/tests/test_helpers.py
+++ b/mkt/reviewers/tests/test_helpers.py
@@ -3,6 +3,7 @@ from nose.tools import eq_
 
 import mkt
 import mkt.site.tests
+from mkt.site.utils import app_factory, version_factory
 from mkt.reviewers import helpers
 
 
@@ -11,35 +12,35 @@ class TestGetPosition(mkt.site.tests.TestCase):
     def setUp(self):
         # Add a public, reviewed app for measure. It took 4 days for this app
         # to get reviewed.
-        self.public_app = mkt.site.tests.app_factory(
+        self.public_app = app_factory(
             version_kw={'created': self.days_ago(7),
                         'nomination': self.days_ago(7),
                         'reviewed': self.days_ago(3)})
 
         # Took 8 days for another public app to get reviewed.
-        mkt.site.tests.app_factory(
+        app_factory(
             version_kw={'nomination': self.days_ago(10),
                         'reviewed': self.days_ago(2)})
 
         # Add to the queue 2 pending apps for good measure.
-        mkt.site.tests.app_factory(
+        app_factory(
             status=mkt.STATUS_PENDING,
             file_kw={'status': mkt.STATUS_PENDING},
             version_kw={'nomination': self.days_ago(3)})
 
-        mkt.site.tests.app_factory(
+        app_factory(
             status=mkt.STATUS_PENDING,
             file_kw={'status': mkt.STATUS_PENDING},
             version_kw={'nomination': self.days_ago(1)})
 
         # A deleted app that shouldn't change calculations.
-        mkt.site.tests.app_factory(
+        app_factory(
             status=mkt.STATUS_DELETED,
             file_kw={'status': mkt.STATUS_PENDING},
             version_kw={'nomination': self.days_ago(1)})
 
     def test_min(self):
-        pending_app = mkt.site.tests.app_factory(
+        pending_app = app_factory(
             status=mkt.STATUS_PENDING,
             file_kw={'status': mkt.STATUS_PENDING},
             version_kw={'nomination': self.days_ago(42)})
@@ -48,14 +49,14 @@ class TestGetPosition(mkt.site.tests.TestCase):
 
     def test_packaged_app(self):
         self.public_app.update(is_packaged=True)
-        version = mkt.site.tests.version_factory(
+        version = version_factory(
             addon=self.public_app, file_kw={'status': mkt.STATUS_PENDING})
         self.public_app.reload()
         eq_(self.public_app.latest_version, version)
         self._test_position(self.public_app)
 
     def test_pending_app(self):
-        pending_app = mkt.site.tests.app_factory(
+        pending_app = app_factory(
             status=mkt.STATUS_PENDING,
             file_kw={'status': mkt.STATUS_PENDING})
         self._test_position(pending_app)

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -46,10 +46,9 @@ from mkt.reviewers.views import (_progress, app_review, queue_apps,
                                  route_reviewer)
 from mkt.site.fixtures import fixture
 from mkt.site.helpers import absolutify, isotime
-from mkt.site.tests import (app_factory, check_links, days_ago, formset,
-                            initial, req_factory_factory, user_factory,
-                            version_factory)
-from mkt.site.utils import urlparams
+from mkt.site.tests import (check_links, days_ago, formset, initial,
+                            req_factory_factory, user_factory)
+from mkt.site.utils import app_factory, make_game, urlparams, version_factory
 from mkt.submit.tests.test_views import BasePackagedAppTest
 from mkt.tags.models import Tag
 from mkt.users.models import UserProfile
@@ -1362,7 +1361,7 @@ class TestReviewApp(AppReviewerTest, TestReviewMixin, AccessMixin,
         super(TestReviewApp, self).setUp()
         self.mozilla_contact = 'contact@mozilla.com'
         self.app = self.get_app()
-        self.app = mkt.site.tests.make_game(self.app, True)
+        self.app = make_game(self.app, True)
         self.app.update(status=mkt.STATUS_PENDING,
                         mozilla_contact=self.mozilla_contact)
         self.version = self.app.latest_version
@@ -3901,7 +3900,7 @@ class TestReviewTranslate(RestOAuth):
         self.login_user()
         self.create_switch('reviews-translate')
         user = UserProfile.objects.create(username='diego')
-        app = mkt.site.tests.app_factory(slug='myapp')
+        app = app_factory(slug='myapp')
         self.review = app.reviews.create(title=u'yes', body=u'oui',
                                          addon=app, user=user,
                                          editorreview=True, rating=4)

--- a/mkt/versions/tests/test_models.py
+++ b/mkt/versions/tests/test_models.py
@@ -11,6 +11,7 @@ import mkt.site.tests
 from mkt.files.models import File
 from mkt.files.tests.test_models import UploadTest as BaseUploadTest
 from mkt.site.fixtures import fixture
+from mkt.site.utils import version_factory
 from mkt.versions.models import Version
 from mkt.webapps.models import Webapp
 
@@ -158,7 +159,7 @@ class TestVersion(BaseUploadTest, mkt.site.tests.TestCase):
 
     def test_version_is_public(self):
         addon = Webapp.objects.get(id=337141)
-        version = mkt.site.tests.version_factory(addon=addon)
+        version = version_factory(addon=addon)
 
         # Base test. Everything is in order, the version should be public.
         eq_(version.is_public(), True)

--- a/mkt/versions/tests/test_views.py
+++ b/mkt/versions/tests/test_views.py
@@ -11,7 +11,7 @@ import mkt
 from mkt.api.base import get_url
 from mkt.api.tests.test_oauth import RestOAuth
 from mkt.site.fixtures import fixture
-from mkt.site.tests import app_factory, file_factory
+from mkt.site.utils import app_factory, file_factory
 from mkt.versions.models import Version
 
 

--- a/mkt/webapps/fakedata.py
+++ b/mkt/webapps/fakedata.py
@@ -18,7 +18,7 @@ from mkt.constants.base import STATUS_CHOICES_API_LOOKUP
 from mkt.constants.categories import CATEGORY_CHOICES
 from mkt.developers.tasks import resize_preview, save_icon
 from mkt.ratings.models import Review
-from mkt.site.utils import slugify
+from mkt.site.utils import app_factory, slugify, version_factory
 from mkt.users.models import UserProfile
 from mkt.webapps.models import AppManifest, Preview
 
@@ -106,9 +106,6 @@ def generate_ratings(app, num):
 
 
 def generate_hosted_app(name, category):
-    # Let's not make production code depend on stuff in the test package --
-    # importing it only when called in local dev is fine.
-    from mkt.site.tests import app_factory
     a = app_factory(categories=[category], name=name, complete=False,
                     rated=True)
     a.addondevicetype_set.create(device_type=DEVICE_TYPES.keys()[0])
@@ -192,7 +189,6 @@ def generate_app_package(app, out, apptype, permissions, version='1.0',
 
 def generate_packaged_app(name, apptype, category, permissions=(),
                           versions=(4,), num_locales=2, **kw):
-    from mkt.site.tests import app_factory, version_factory
     now = datetime.datetime.now()
     app = app_factory(categories=[category], name=name, complete=False,
                       rated=True, is_packaged=True,

--- a/mkt/webapps/tests/test_indexers.py
+++ b/mkt/webapps/tests/test_indexers.py
@@ -9,6 +9,7 @@ from mkt.constants.applications import DEVICE_TYPES
 from mkt.reviewers.models import EscalationQueue, RereviewQueue
 from mkt.site.fixtures import fixture
 from mkt.site.tests import ESTestCase, TestCase
+from mkt.site.utils import version_factory
 from mkt.translations.utils import to_language
 from mkt.users.models import UserProfile
 from mkt.webapps.indexers import WebappIndexer
@@ -113,7 +114,7 @@ class TestWebappIndexer(TestCase):
         created_date = self.days_ago(5).replace(microsecond=0)
         nomination_date = self.days_ago(3).replace(microsecond=0)
 
-        mkt.site.tests.version_factory(
+        version_factory(
             addon=self.app, version='43.0',
             has_editor_comment=True,
             has_info_request=True,


### PR DESCRIPTION
This is to allow them to be run by fake-data commands in non-dev
deployments.

(Specifically: deployments don't include things like `mock` which are imported by the unit tests.)