### PR TITLE
Only show paid regions if supported (bug 1126002)

### DIFF
--- a/media/css/devreg/payments.styl
+++ b/media/css/devreg/payments.styl
@@ -701,3 +701,9 @@ for region in ar bd br cl cn co cr cz de ec es fr gr gt hu "in" it jp me mx ni p
     .region-{region} {
         background-image: url(unquote('../../img/mkt/icons/regions/' + region + '.png'));
     }
+
+.no-payment-regions:not(.hidden) {
+    border-bottom: 1px dotted $faint-gray;
+    padding-bottom: 1.2em;
+    text-align: center;
+}

--- a/media/js/devreg/payments-manage.js
+++ b/media/js/devreg/payments-manage.js
@@ -56,18 +56,32 @@ define('payments-manage', ['payments'], function(payments) {
             });
             $ul.append($el);
         });
+
         $confirm_delete_overlay.on('click', 'a.payment-account-delete-confirm', _pd(function() {
             $.post(data['delete-url']).then(function () {
-                refreshAccountForm(data)
+                refreshAccountForm(data);
             });
+
             $confirm_delete_overlay.remove();
+            z.body.removeClass('overlayed');
+            var accountName = data.name;
             var currentAppName = data['current-app-name'];
             var paymentAccounts = data['app-payment-accounts'][currentAppName];
             // If this app is associated with the account and it only has one
             // account show the warning.
             if (paymentAccounts && paymentAccounts.length === 1) {
                 $('#paid-island-incomplete').removeClass('hidden');
+                $('.no-payment-regions').removeClass('hidden');
             }
+
+            if (paymentAccounts.indexOf(accountName) > -1 && data.provider) {
+                // Fire a custom event for the account deletion so we can update
+                // The regions UI as necessary.
+                console.log('Firing a custom event for the payment account deletion: ' +
+                    JSON.stringify({account: accountName, provider: data.provider}));
+                $('body').trigger('app-payment-account-deletion', {provider: data.provider});
+            }
+
         }));
     }
 

--- a/mkt/developers/templates/developers/payments/premium.html
+++ b/mkt/developers/templates/developers/payments/premium.html
@@ -203,7 +203,8 @@
                        data-payment-methods="{{ payment_methods|json }}"
                        data-pricelist-api-url="{{ api_pricelist_url }}"
                        data-tier-zero-id="{{ tier_zero_id }}"
-                       data-provider-lookup="{{ provider_lookup|json }}">
+                       data-provider-lookup="{{ provider_lookup|json }}"
+                       data-enabled-provider-ids="{{ enabled_provider_ids|json }}">
                     <h3>{{ _('Regions') }}</h3>
                     {{ region_form.regions.errors }}
 
@@ -239,6 +240,11 @@
                           {% endfor %}
                         </tbody>
                       </table>
+
+                      <p class="hint no-payment-regions {% if addon.has_payment_account() %}hidden{% endif %}">
+                       <em>{{ _('Add a payment account to enable your app for sale in more regions') }}</em>
+                      </p>
+
                       <p class="hint note rest-of-world">
                         {% trans %}
                           As "Rest of World" is selected your app will be

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -582,6 +582,8 @@ class TestPayments(Patcher, mkt.site.tests.TestCase):
         res = self.client.get(self.url)
         pqr = pq(res.content)
         eq_(len(pqr('#paid-island-incomplete:not(.hidden)')), 1)
+        eq_(json.loads(pqr('#region-list').attr('data-enabled-provider-ids')),
+            [])
 
     def setup_payment_acct(self, make_owner, user=None, bango_id=123):
         # Set up Solitude return values.
@@ -633,7 +635,10 @@ class TestPayments(Patcher, mkt.site.tests.TestCase):
         eq_(self.webapp.payment_account(PROVIDER_BANGO).payment_account.pk,
             acct.pk)
         eq_(AddonPremium.objects.all().count(), 0)
-        eq_(len(pq(res.content)('#paid-island-incomplete.hidden')), 1)
+        pqr = pq(res.content)
+        eq_(len(pqr('#paid-island-incomplete.hidden')), 1)
+        eq_(json.loads(pqr('#region-list').attr('data-enabled-provider-ids')),
+            [PROVIDER_BANGO])
 
     def test_associate_acct_to_app(self):
         self.make_premium(self.webapp, price=self.price.price)

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -180,6 +180,9 @@ def payments(request, addon_id, addon, webapp=False):
                    'all_paid_region_ids_by_name': paid_region_ids_by_name,
                    'providers': providers,
                    'provider_regions': provider_regions,
+                   'enabled_provider_ids':
+                       [acct.payment_account.provider
+                           for acct in addon.all_payment_accounts()]
                    })
 
 


### PR DESCRIPTION
In order to only move the checkboxes if they match the account this branch:

* Exposes the enabled payment account providers
* Use that to check what regions to move
* Fires a custom event on account deletion so that the checkbox UI gets updated if the associated account was deleted
* As a bonus this fixes a bug where the overlayed class wasn't removed during the confirm deletion flow.