### PR TITLE
expose review id, expose has_flagged to anon users (bug 1131597)

### DIFF
--- a/docs/api/topics/ratings.rst
+++ b/docs/api/topics/ratings.rst
@@ -48,6 +48,7 @@ _`List`
                     "app": "/api/v2/apps/app/18/",
                     "body": "This app is top notch. Aces in my book!",
                     "created": "2013-04-17T15:25:16",
+                    "has_flagged": false,
                     "is_author": true,
                     "modified": "2013-04-17T15:34:19",
                     "rating": 5,
@@ -65,6 +66,9 @@ _`List`
             ]
         }
 
+    :param has_flagged: whether this review has been flagged for review, either
+                        already by the user, or by the set of anonymous users.
+    :type has_flagged: boolean
     :param is_author: whether the authenticated user is the author of the rating.
                      Parameter not present in anonymous requests.
     :type is_author: boolean
@@ -91,6 +95,7 @@ _`Detail`
             "app": "/api/v2/apps/app/18/",
             "body": "This app is top notch. Aces in my book!",
             "created": "2013-04-17T15:25:16",
+            "has_flagged": false,
             "is_author": true,
             "modified": "2013-04-17T15:34:19",
             "rating": 5,

--- a/mkt/ratings/tests/test_views.py
+++ b/mkt/ratings/tests/test_views.py
@@ -53,6 +53,7 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
         eq_(data['body'], review.body)
         self.assertCloseToNow(data['created'], now=review.created)
         self.assertCloseToNow(data['modified'], now=review.modified)
+        eq_(data['id'], review.id)
         eq_(data['rating'], review.rating)
         eq_(data['report_spam'],
             reverse('ratings-flag', kwargs={'pk': review.pk}))
@@ -120,6 +121,7 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
         eq_(data['info']['average'], self.app.average_rating)
         eq_(data['info']['slug'], self.app.app_slug)
         eq_(data['info']['current_version'], ver.version)
+
         if client != self.anon:
             eq_(data['user']['can_rate'], True)
             eq_(data['user']['has_rated'], True)
@@ -148,11 +150,12 @@ class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
         self.app.update_version()
 
         reset_queries()
-        with self.assertNumQueries(5):
-            # 5 queries:
+        with self.assertNumQueries(7):
+            # 7 queries:
             # - 2 for the Reviews queryset and the translations
             # - 2 for the Version associated to the reviews (qs + translations)
             # - 1 for the File attached to the Version
+            # - 2 for the has_flagged field
             #
             # Note: We patch get_app() to avoid the app queries to pollute the
             # queries count.


### PR DESCRIPTION
Prevents from an anon user from trying to flag a review that another anon user has already flagged.

r? @diox