### PR TITLE
Add file_size to fireplace serializer, display it in human-readable format (bug 1132138)

### DIFF
--- a/mkt/fireplace/serializers.py
+++ b/mkt/fireplace/serializers.py
@@ -1,3 +1,5 @@
+from django.template.defaultfilters import filesizeformat
+
 from mkt.webapps.serializers import SimpleAppSerializer, SimpleESAppSerializer
 
 
@@ -9,16 +11,23 @@ class BaseFireplaceAppSerializer(object):
             128: app.get_icon_url(128)
         }
 
+    # We don't care about the integer value of the file size in fireplace, we
+    # just want to display it to the user in a human-readable way.
+    def transform_file_size(self, obj, value):
+        if value:
+            return filesizeformat(value)
+        return None
+
 
 class FireplaceAppSerializer(BaseFireplaceAppSerializer, SimpleAppSerializer):
 
     class Meta(SimpleAppSerializer.Meta):
         fields = ['author', 'banner_message', 'banner_regions', 'categories',
                   'content_ratings', 'current_version', 'description',
-                  'device_types', 'homepage', 'icons', 'id', 'is_offline',
-                  'is_packaged', 'last_updated', 'manifest_url', 'name',
-                  'payment_required', 'premium_type', 'previews', 'price',
-                  'price_locale', 'privacy_policy', 'public_stats',
+                  'device_types', 'file_size', 'homepage', 'icons', 'id',
+                  'is_offline', 'is_packaged', 'last_updated', 'manifest_url',
+                  'name', 'payment_required', 'premium_type', 'previews',
+                  'price', 'price_locale', 'privacy_policy', 'public_stats',
                   'release_notes', 'ratings', 'slug', 'status',
                   'support_email', 'support_url', 'upsell', 'user']
         exclude = []

--- a/mkt/fireplace/tests/test_views.py
+++ b/mkt/fireplace/tests/test_views.py
@@ -56,6 +56,24 @@ class TestAppDetail(BaseAPI):
         self._allowed_verbs(self.url, ['get'])
         self._allowed_verbs(url, [])
 
+    def test_file_size(self):
+        self.app = Webapp.objects.get(pk=337141)
+
+        res = self.client.get(self.url)
+        data = json.loads(res.content)
+        eq_(data['file_size'], u'379.0\xa0KB')
+
+        file_ = self.app.current_version.all_files[0]
+        file_.update(size=1024 * 1024 * 1.1)
+        res = self.client.get(self.url)
+        data = json.loads(res.content)
+        eq_(data['file_size'], u'1.1\xa0MB')
+
+        file_.update(size=0)
+        res = self.client.get(self.url)
+        data = json.loads(res.content)
+        eq_(data['file_size'], None)
+
 
 class TestFeaturedSearchView(RestOAuth, ESTestCase):
     fixtures = fixture('user_2519', 'webapp_337141')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1132138

`file_size` was missing from fireplace serializer. I added it and cheated a little bit by changing the output to let the API to the formatting instead of doing it on the consumer pages side. Let me know what you think, @ngokevin.