### PR TITLE
Fix fixture json.

### DIFF
--- a/mkt/site/fixtures/init.json
+++ b/mkt/site/fixtures/init.json
@@ -1699,7 +1699,7 @@
             "password": "",
             "read_dev_agreement": null,
             "region": null,
-            "source": 0,
+            "source": 0
         },
         "model": "users.userprofile",
         "pk": 1


### PR DESCRIPTION
This fixes error 
'django.core.serializers.base.DeserializationError: Problem installing fixture 'zamboni/mkt/site/fixtures/init.json': Expecting property name enclosed in double quotes: line 1703 column 9 (char 45632)' when running python manage.py loaddata ini.

r?