### PR TITLE
have comm email moz contacts that don't have mkt accounts (bug 1132010)

### DIFF
--- a/migrations/898-comm-cc-nonuser.sql
+++ b/migrations/898-comm-cc-nonuser.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `comm_thread_cc`
+    MODIFY COLUMN `user_id` int(11) unsigned NULL,
+    ADD COLUMN `nonuser_email` varchar(255) NULL;

--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -168,11 +168,13 @@ class CommunicationThreadCC(ModelBase):
     thread = models.ForeignKey(CommunicationThread,
                                related_name='thread_cc')
     user = models.ForeignKey('users.UserProfile',
-                             related_name='comm_thread_cc')
+                             related_name='comm_thread_cc', blank=True,
+                             null=True)
+    nonuser_email = models.EmailField(null=True)
 
     class Meta:
         db_table = 'comm_thread_cc'
-        unique_together = ('user', 'thread',)
+        unique_together = ('user', 'thread', 'nonuser_email')
 
 
 class CommunicationNoteManager(models.Manager):

--- a/mkt/comm/tests/test_models.py
+++ b/mkt/comm/tests/test_models.py
@@ -137,6 +137,20 @@ class TestCommunicationThread(PermissionTestMixin, TestCase):
         ok_(user_has_perm_app(self.user, self.addon))
 
 
+class TestCommunicationThreadCC(TestCase, CommTestMixin):
+    fixtures = fixture('webapp_337141')
+
+    def setUp(self):
+        self.addon = Webapp.objects.get()
+        self.thread = self._thread_factory()
+
+    def test_create_user_ok(self):
+        ok_(self.thread.thread_cc.create(user=user_factory()))
+
+    def test_create_nonuser_email_ok(self):
+        ok_(self.thread.thread_cc.create(nonuser_email='lol@lol.com'))
+
+
 class TestThreadTokenModel(TestCase):
     fixtures = fixture('user_999', 'webapp_337141')
 

--- a/mkt/comm/utils.py
+++ b/mkt/comm/utils.py
@@ -64,8 +64,12 @@ def post_create_comm_note(note):
         try:
             moz_contact = UserProfile.objects.get(email=email)
             thread.join_thread(moz_contact)
+            # If Mozilla contact wasn't user before, delete old reference.
+            thread.thread_cc.filter(nonuser_email=email).delete()
         except UserProfile.DoesNotExist:
-            pass
+            # Mozilla contact not a user.
+            if email:
+                thread.thread_cc.create(nonuser_email=email)
 
     # Add note author to thread.
     author = note.author

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -781,7 +781,8 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
             Translation.objects.remove_for(o, locale)
 
     def get_mozilla_contacts(self):
-        return [x.strip() for x in self.mozilla_contact.split(',')]
+        return filter(None,
+                      [x.strip() for x in self.mozilla_contact.split(',')])
 
     @cached_property
     def upsell(self):


### PR DESCRIPTION
Commbadge was built assuming everyone involved had Marketplace accounts, which had the benefit of generating nice Reply-To tokens. Not the case. Some Mozilla contacts aren't registered with us.

- Add a flat email field to CommThreadCC
- CommThreadCC determines who gets emailed upon a creation of a note/comment.
- When a note is created, we check for Mozilla contacts without accounts and generate a CommThreadCC with that flat email field.
- When emailing, transform the nonuser CommThreadCC to be a recipient without a token 
- If a Mozilla contact ends up creating an email, we will delete the old CommThreadCC with a flat email field, and generate one that points to the user

Some catches:

- Mozilla contacts w/o user accounts will not have an option to Reply-To the email. Although the email template will state they can

r? well, my Python and context of the Comm system is rusty :)