### PR TITLE
email moz contacts that aren't users for comm (bug 1132010)

### DIFF
--- a/mkt/comm/templates/comm/emails/base.html
+++ b/mkt/comm/templates/comm/emails/base.html
@@ -1,8 +1,15 @@
 {% block content %}{% endblock %}
 
+{% if nonuser_mozilla_contact %}
+You may reply by creating a Firefox Account under your email and posting to {{ url('commonplace.commbadge.show_thread', note.thread.id)|absolutify }}
+
+If you wish to stop receiving email notifications for this thread, ask a reviewer
+to remove you from being a Mozilla contact for this app.
+{% else %}
 You may reply to this email or post to {{ url('commonplace.commbadge.show_thread', note.thread.id)|absolutify }}
 
 If you wish to stop receiving email notifications for this thread, you can click 'Unsubscribe' at {{ url('commonplace.commbadge.show_thread', note.thread.id)|absolutify }}
+{% endif %}
 
 --
 {% block footer %}

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -781,7 +781,8 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
             Translation.objects.remove_for(o, locale)
 
     def get_mozilla_contacts(self):
-        return [x.strip() for x in self.mozilla_contact.split(',')]
+        return filter(None,
+                      [x.strip() for x in self.mozilla_contact.split(',')])
 
     @cached_property
     def upsell(self):


### PR DESCRIPTION
I re-did it to just send an email to Mozilla contacts without creating a CC object.

r? @eviljeff 
