### PR TITLE
better comm v2 endpoints (bug 1109234)

### DIFF
--- a/docs/api/topics/comm.rst
+++ b/docs/api/topics/comm.rst
@@ -8,6 +8,63 @@ API for communication between reviewers and developers
 
 .. note:: Under development.
 
+App
+===
+
+.. http:get:: /api/v2/comm/app/(int:id|string:slug)/
+
+    .. note:: Requires authentication.
+
+    Returns all threads for the app.
+
+    **Request**
+
+    Takes an app slug.
+
+    The standard :ref:`list-query-params-label`.
+
+    **Response**
+
+    :status 200: successfully completed.
+    :status 403: not allowed to access this app.
+    :status 404: app not found.
+
+    :param meta: :ref:`meta-response-label`.
+    :type meta: object
+    :param objects: A :ref:`listing <objects-response-label>` of
+        :ref:`threads <thread-response-label>`.
+    :type objects: array
+
+    **?serializer=simple**
+
+    If you pass *simple* as a value to the *serializer* GET parameter, the
+    deserialized threads will consist only of the thread ID and the version
+    number for the app it is representing.
+
+    Example:
+
+    .. code-block:: json
+
+        {
+            "objects": [
+                {
+                    "id": 12345,
+                    "version": {
+                        "id": 444,
+                        "version": "1.2"
+                    }
+                },
+                {
+                    "id": 12348,
+                    "version": {
+                        "id": 474,
+                        "version": "1.3"
+                    }
+                }
+            ],
+        }
+
+
 Thread
 ======
 
@@ -15,27 +72,69 @@ Thread
 
     .. note:: Requires authentication.
 
-    Returns the list of threads where the user has posted a note to, has been CC'd or is an author of the addon that the thread is based on.
+    Returns a list of threads in which the user is involved in.
 
     **Request**
 
     The standard :ref:`list-query-params-label`.
 
-    For ordering params, see :ref:`list-ordering-params-label`.
-
-    :param app: id or slug of the app to filter the threads by.
-    :type app: int|string
-
     **Response**
 
     :param meta: :ref:`meta-response-label`.
     :type meta: object
-    :param objects: A :ref:`listing <objects-response-label>` of :ref:`threads <thread-response-label>`.
+    :param objects: A :ref:`listing <objects-response-label>` of
+         :ref:`threads <thread-response-label>`.
     :type objects: array
-    :param app_threads: If given the **app** parameter, a list of the app's thread IDs and their respective version numbers. The same object is found in the :ref:`thread response <thread-response-label>`.
-    :type app_threads: array of objects
+
 
 .. _thread-response-label:
+
+.. http:get:: /api/v2/comm/thread/(int:id)/
+
+    .. note:: Requires authentication.
+
+    View a thread object.
+
+    **Response**
+
+    A thread object, see below for example.
+
+    :status 200: successfully completed.
+    :status 403: not allowed to access this object.
+    :status 404: not found.
+
+    Example:
+
+    .. code-block:: json
+
+        {
+            "app": {
+                "app_slug": "app-3",
+                "id": 5,
+                "name": "Test App (kinkajou3969)",
+                "review_url": "/reviewers/apps/review/test-app-kinkajou3969/",
+                "thumbnail_url": "/media/img/icons/no-preview.png",
+                "url": "/app/test-app-kinkajou3969/"
+            },
+            "created": "2013-06-14T11:54:24",
+            "id": 2,
+            "modified": "2013-06-24T22:01:37",
+            "notes_count": 47,
+            "version": {
+                "id": 45,
+                "version": "1.6",
+                "deleted": false
+            }
+        }
+
+    Notes on the response.
+
+    :param version.version: Version number noted from the app manifest.
+    :type version.version: string
+    :param version.deleted: whether the version of the app of the note is
+        out-of-date.
+    :type version.deleted: boolean
+
 
 .. http:post:: /api/v2/comm/thread/
 
@@ -58,110 +157,13 @@ Thread
 
     A :ref:`note <note-response-label>` object.
 
-.. http:get:: /api/v2/comm/thread/(int:id)/
-
-    .. note:: Does not require authentication if the thread is public.
-
-    View a thread object.
-
-    **Response**
-
-    A thread object, see below for example.
-
-    :status 200: successfully completed.
-    :status 403: not allowed to access this object.
-    :status 404: not found.
-
-    Example:
-
-    .. code-block:: json
-
-        {
-            "addon": 3,
-            "addon_meta": {
-                "name": "Test App (kinkajou3969)",
-                "slug": "app-3",
-                "thumbnail_url": "/media/img/icons/no-preview.png",
-                "url": "/app/test-app-kinkajou3969/"
-                "review_url": "/reviewers/apps/review/test-app-kinkajou3969/"
-            },
-            "app_threads": [
-                {"id": 1, "version__version": "1.3"},
-                {"id": 2, "version__version": "1.6"},
-                {"id": 3, "version__version": "1.7"}
-            ],
-            "created": "2013-06-14T11:54:24",
-            "id": 2,
-            "modified": "2013-06-24T22:01:37",
-            "notes_count": 47,
-            "recent_notes": [
-                {
-                    "author": 27,
-                    "author_meta": {
-                        "name": "someuser"
-                    },
-                    "body": "sometext",
-                    "created": "2013-06-24T22:01:37",
-                    "id": 119,
-                    "note_type": 0,
-                    "thread": 2
-                },
-                {
-                    "author": 27,
-                    "author_meta": {
-                        "name": "someuser2"
-                    },
-                    "body": "sometext",
-                    "created": "2013-06-24T21:31:56",
-                    "id": 118,
-                    "note_type": 0,
-                    "thread": 2
-                },
-                ...
-                ...
-            ],
-            "version": null,
-            "version": "1.6",
-            "version_is_obsolete": false
-        }
-
-    Notes on the response.
-
-    :param recent_notes: contain 5 recently created notes.
-    :type recent_notes: array
-    :param app_threads: list of app-related thread IDs and their respective version numbers.
-    :type app_threads: array of objects
-    :param version_number: Version number noted from the app manifest.
-    :type version: string
-    :param version_is_obsolete: Whether the version of the app of the note is out-of-date.
-    :type version: boolean
-
-.. _note-patch-label:
-
-.. http:patch:: /api/v2/comm/thread/(int:thread_id)/
-
-    .. note:: Requires authentication.
-
-    Mark all notes in a thread as read.
-
-    **Request**
-
-    :param is_read: set it to `true` to mark the note as read.
-    :type is_read: boolean
-
-    **Response**
-
-    :status: 204 Thread is marked as read.
-    :status: 400 Thread object not found.
-    :status: 403 There is an attempt to modify other fields or not allowed to access the object.
-
 
 Note
 ====
 
 .. http:get:: /api/v2/comm/thread/(int:thread_id)/note/
 
-    .. note:: Does not require authentication if the thread is public.
+    .. note:: Requires authentication.
 
     Returns the list of notes that a thread contains.
 
@@ -185,7 +187,7 @@ Note
 
 .. http:get:: /api/v2/comm/thread/(int:thread_id)/note/(int:id)/
 
-    .. note:: Does not require authentication if the note is in a public thread.
+    .. note:: Requires authentication.
 
     View a note.
 
@@ -219,7 +221,6 @@ Note
             "id": 2,
             "note_type": 0,
             "thread": 2,
-            "is_read": false
         }
 
     Notes on the response.
@@ -228,8 +229,6 @@ Note
     :type attachments: array
     :param note_type: type of action taken with the note.
     :type note_type: int
-    :param is_read: Whether the note is read or unread.
-    :type is_read: boolean
 
 .. _note-type-label:
 
@@ -238,58 +237,8 @@ Note
     make a "Reviewer Comment". And one must be a developer of an app to make
     a "Developer Comment" on an app's thread.
 
-    Note type values and associated actions -
+    All note types are listed in the `code <https://github.com/mozilla/zamboni/blob/master/mkt/constants/comm.py>`_
 
-    ..
-
-        0 - No Action
-
-        1 - Approval
-
-        2 - Rejection
-
-        3 - Disabled
-
-        4 - More Information Required
-
-        5 - Escalation
-
-        6 - Reviewer Comment
-
-        7 - Resubmission
-
-        8 - Approved but Unpublished
-
-        9 - Escalation Cleared
-
-        10 - Escalation due to High Refund Requests
-
-        11 - Escalation due to High Abuse Reports
-
-        12 - Re-review cleared
-
-        13 - Submission
-
-        14 - Developer comment
-
-.. _note-patch-label:
-
-.. http:patch:: /api/v2/comm/thread/(int:thread_id)/note/(int:id)/
-
-    .. note:: Requires authentication.
-
-    Mark an unread note as read.
-
-    **Request**
-
-    :param is_read: set it to `true` to mark the note as read.
-    :type is_read: boolean
-
-    **Response**
-
-    :status: 204 Note marked as read.
-    :status: 400 Note object not found.
-    :status: 403 There is an attempt to modify other fields or not allowed to access the object.
 
 .. _note-post-label:
 

--- a/media/js/devreg/reviewers/reviewers_commbadge.js
+++ b/media/js/devreg/reviewers/reviewers_commbadge.js
@@ -23,6 +23,7 @@ define('reviewersCommbadge', ['login'], function(login) {
         var versionIds = _.map(threads, function(thread) {
             return thread.version;
         });
+
         $('table.activity').each(function(i, table) {
             var $table = $(table);
             if (versionIds.indexOf($table.data('version')) === -1) {

--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -75,7 +75,7 @@ def check_acls_comm_obj(obj, profile):
 def user_has_perm_app(user, app):
     """
     Check if user has any app-level ACLs.
-    (Mozilla contact, admin, review, senior reivewer, developer).
+    (Mozilla contact, admin, review, senior reviewer, developer).
     """
     return (
         check_acls(user, None, 'reviewer') or


### PR DESCRIPTION
For API v2, this redoes the Commbadge endpoints for:

- List of threads for an app
- List of threads relevant to a user

API v1 endpoints are left intact to be deprecated later. This makes the endpoints faster by:

- Getting rid of the ```recent_notes``` field, which loads 5 notes per thread. Commbadge will be changed notes aren't shown until we click through to a thread detail page. This simplifies most pages to be simple lists of links to threads with some metadata.
- Splitting out the thread listing endpoint into two, one to list threads for an app and one to list threads for a user. The app endpoint, ```/comm/app/<APP_SLUG>/```, can take ```?serializer=simple``` to return a extremely slimmed down list of threads for the sole purpose of finding which threads to download in Reviewer Tools, and for navigation in Commbadge.

The code is better since:

- Fields related to ```version``` for threads are now deserialized into one field rather than three prefixed fields
- Remove ```addon``` field in the Thread serializer since we have it in ```addon_meta```, and just rename ```addon_meta``` to ```app```

The endpoints won't be consumed just yet, so this is just part 1. The plan is:

- To move reviewer tools to use the ```serializer=simple``` endpoint to get a simple list of threads that needs to be downloaded. Then download them, latest version first.
- To move Commbadge to use the v2 endpoints, which will involve redesigning a lot of pages. It is my assumption that the thread detail pages are the most important pages since they are linked to in the emails, so I can slim down the rest of the pages to just be listings.

r? @eviljeff 