### PR TITLE
use new comm v2 endpoints for review history for speed (bug 1109234)

### DIFF
--- a/mkt/reviewers/templates/reviewers/includes/review_history.html
+++ b/mkt/reviewers/templates/reviewers/includes/review_history.html
@@ -4,7 +4,9 @@
   <table id="review-files" class="item-history"
          data-slug="{{ product.app_slug }}" data-note-types="{{ mkt.comm.U_NOTE_TYPES()|json }}"
          {# Don't use urlparams because we don't want to urlencode the slug. #}
-         data-comm-thread-url="{{ url('comm-thread-list')|urlparams(limit=product.threads.count()) + '&app=' + product.app_slug }}"
+         data-comm-app-url="{{
+            url('api-v2:comm-app-list', product.app_slug)|
+            urlparams(limit=product.threads.count(), serializer='simple') }}"
          data-thread-id-placeholder="0" data-comm-note-url="{{ url('comm-note-list', 0) }}">
     {# Results populated below by reviewers_commbadge.js (Commbadge API) #}
 

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -81,7 +81,7 @@
   </div>
 </section>
 
-{% include 'reviewers/includes/review_history_commbadge.html' %}
+{% include 'reviewers/includes/review_history.html' %}
 
 <form method="POST" enctype="multipart/form-data">
   {{ csrf() }}

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -3949,15 +3949,17 @@ class TestReviewHistory(mkt.site.tests.TestCase, CommTestMixin):
     def test_comm_url(self):
         r = self.client.get(self.url)
         doc = pq(r.content)
-        eq_(doc('#history .item-history').attr('data-comm-thread-url'),
-            reverse('comm-thread-list') + '?limit=1&app=' + self.app.app_slug)
+        eq_(doc('#history .item-history').attr('data-comm-app-url'),
+            reverse('api-v2:comm-app-list', args=[self.addon.app_slug]) +
+            '?limit=1&serializer=simple')
 
     def test_comm_url_multiple_thread(self):
         self._thread_factory()
         r = self.client.get(self.url)
         doc = pq(r.content)
-        eq_(doc('#history .item-history').attr('data-comm-thread-url'),
-            reverse('comm-thread-list') + '?limit=2&app=' + self.app.app_slug)
+        eq_(doc('#history .item-history').attr('data-comm-app-url'),
+            reverse('api-v2:comm-app-list', args=[self.addon.app_slug]) +
+            '?limit=2&serializer=simple')
 
     def test_comm_url_no_encode(self):
         self.addon = app_factory(app_slug='&#21488;&#21271;')
@@ -3965,9 +3967,9 @@ class TestReviewHistory(mkt.site.tests.TestCase, CommTestMixin):
         url = reverse('reviewers.apps.review', args=[self.addon.app_slug])
         r = self.client.get(url)
         doc = pq(r.content)
-        eq_(doc('#history .item-history').attr('data-comm-thread-url'),
-            reverse('comm-thread-list') + '?limit=1&app=' +
-            self.addon.app_slug)
+        eq_(doc('#history .item-history').attr('data-comm-app-url'),
+            reverse('api-v2:comm-app-list', args=[self.addon.app_slug]) +
+            '?limit=1&serializer=simple')
 
 
 class ModerateLogTest(mkt.site.tests.TestCase):


### PR DESCRIPTION
Before we were loading all an app's threads, including app metadata, 5 most recent notes (each one requiring permission checks), and tons of crap. All we need actually are slim objects with thread ID, version ID, and version #. 

## Before (on marketplace-package app on -dev)

![screen shot 2015-03-04 at 10 52 34 am](https://cloud.githubusercontent.com/assets/674727/6490641/aacccaea-c25c-11e4-90d2-03cce59dc7bd.png)

## After (on some local app on localhost)

![screen shot 2015-03-04 at 10 51 41 am](https://cloud.githubusercontent.com/assets/674727/6490640/aacc548e-c25c-11e4-9c02-bb4ad910563a.png)
