### PR TITLE
Avoid useless XHR when #receipt-check-result is absent (bug 1035376)

### DIFF
--- a/media/js/devreg/reviewers/editors.js
+++ b/media/js/devreg/reviewers/editors.js
@@ -182,7 +182,7 @@ function initReviewActions() {
 
     function check_receipt() {
         var $node = $('#receipt-check-result');
-        if ($node) {
+        if ($node.length) {
             $.getJSON($node.data('url'), function(data) {
                 if (data.status) {
                     $node.text(gettext('Receipt checked by app.'));
@@ -227,9 +227,10 @@ function initQueue() {
 
     var url = $q.attr('data-url');
     var addon_ids = $.map($('.addon-row'), function(el) {
-            return $(el).attr('data-addon');
-        });
-    if(!(('localStorage' in window) && window.localStorage['dont_poll'])) {
+        return $(el).attr('data-addon');
+    });
+
+    if(!(('localStorage' in window) && window.localStorage.dont_poll)) {
         (function checkCurrentlyViewing() {
             $.post(url, {'addon_ids': addon_ids.join(',')}, function(data) {
                 $('#addon-queue .locked').removeClass('locked')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1035376

There is still a useless XHR done on install for free apps but at least with this change, we are no longer trying to do an xhr to `''`, which uselessly loads the current HTML page.
