### PR TITLE
 Remove mkt.webapps.views.BaseFilter (bug 1144663)

### DIFF
--- a/mkt/account/tests/test_utils_.py
+++ b/mkt/account/tests/test_utils_.py
@@ -2,16 +2,17 @@ from django.test.client import RequestFactory
 
 from nose.tools import eq_
 
+import mkt
 import mkt.site.tests
 from mkt.account.utils import purchase_list
 from mkt.constants import apps
 from mkt.site.fixtures import fixture
+from mkt.site.utils import app_factory
 from mkt.users.models import UserProfile
-from mkt.webapps.models import Installed, Webapp
+from mkt.webapps.models import Webapp
 
 
 class TestUtils(mkt.site.tests.TestCase):
-    # TODO: add some more tests for purchase_list.
     fixtures = fixture('user_2519', 'webapp_337141')
 
     def setUp(self):
@@ -19,20 +20,58 @@ class TestUtils(mkt.site.tests.TestCase):
         self.app = Webapp.objects.get(pk=337141)
         self.req = RequestFactory().get('/')
 
-    def _test(self, type, exists):
-        Installed.objects.create(user=self.user, addon=self.app,
-                                 install_type=type)
-        if exists:
-            eq_(list(purchase_list(self.req, self.user, None)[0].object_list),
-                [self.app])
-        else:
-            assert not purchase_list(self.req, self.user, None)[0].object_list
-
     def test_user(self):
-        self._test(apps.INSTALL_TYPE_USER, True)
+        self.user.installed_set.create(
+            addon=self.app,
+            install_type=apps.INSTALL_TYPE_USER)
+        eq_(list(purchase_list(self.req, self.user).object_list), [self.app])
 
     def test_developer(self):
-        self._test(apps.INSTALL_TYPE_DEVELOPER, True)
+        self.user.installed_set.create(
+            addon=self.app,
+            install_type=apps.INSTALL_TYPE_DEVELOPER)
+        eq_(list(purchase_list(self.req, self.user).object_list), [self.app])
 
     def test_reviewer(self):
-        self._test(apps.INSTALL_TYPE_REVIEWER, False)
+        self.user.installed_set.create(
+            addon=self.app,
+            install_type=apps.INSTALL_TYPE_REVIEWER)
+        eq_(list(purchase_list(self.req, self.user).object_list), [])
+
+    def test_ordering(self):
+        self.user.installed_set.create(
+            addon=self.app,
+            install_type=apps.INSTALL_TYPE_USER)
+        app2 = app_factory()
+        self.user.installed_set.create(
+            addon=app2,
+            install_type=apps.INSTALL_TYPE_USER)
+        eq_(list(purchase_list(self.req, self.user).object_list),
+            [app2, self.app])
+
+    def test_contribution_purchase(self):
+        self.user.contribution_set.create(
+            addon=self.app,
+            type=mkt.CONTRIB_PURCHASE)
+        eq_(list(purchase_list(self.req, self.user).object_list), [self.app])
+
+    def test_contribution_refund(self):
+        self.user.contribution_set.create(
+            addon=self.app,
+            type=mkt.CONTRIB_REFUND)
+        eq_(list(purchase_list(self.req, self.user).object_list), [self.app])
+
+    def test_contribution_chargeback(self):
+        self.user.contribution_set.create(
+            addon=self.app,
+            type=mkt.CONTRIB_CHARGEBACK)
+        eq_(list(purchase_list(self.req, self.user).object_list), [self.app])
+
+    def test_contribution_installed_same_app(self):
+        self.user.installed_set.create(
+            addon=self.app,
+            install_type=apps.INSTALL_TYPE_USER)
+        self.user.contribution_set.create(
+            addon=self.app,
+            type=mkt.CONTRIB_PURCHASE)
+        eq_(list(purchase_list(self.req, self.user).object_list), [self.app])

--- a/mkt/account/utils.py
+++ b/mkt/account/utils.py
@@ -1,75 +1,24 @@
-from django import http
-
-from tower import ugettext_lazy as _lazy
-
 import mkt
 from mkt.constants import apps
-from mkt.purchase.models import Contribution
 from mkt.site.models import manual_order
 from mkt.site.utils import paginate
-from mkt.translations.query import order_by_translation
 from mkt.webapps.models import Webapp
-from mkt.webapps.views import BaseFilter
 
 
-class PurchasesFilter(BaseFilter):
-    opts = (('purchased', _lazy(u'Purchase Date')),
-            ('price', _lazy(u'Price')),
-            ('name', _lazy(u'Name')))
+def purchase_list(request, user):
+    # Return all apps that the user has a contribution for as well as all apps
+    # they have installed.
+    def get_ids(qs):
+        return list(qs.order_by('-id').values_list('addon_id', flat=True))
 
-    def __init__(self, *args, **kwargs):
-        self.ids = kwargs.pop('ids')
-        self.uids = kwargs.pop('uids')
-        super(PurchasesFilter, self).__init__(*args, **kwargs)
+    contributed_apps_ids = get_ids(user.contribution_set.filter(type__in=[
+        mkt.CONTRIB_PURCHASE, mkt.CONTRIB_REFUND, mkt.CONTRIB_CHARGEBACK]))
 
-    def filter(self, field):
-        qs = self.base_queryset
-        if field == 'purchased':
-            # Id's are in created order, so let's invert them for this query.
-            # According to my testing we don't actually need to dedupe this.
-            ids = list(reversed(self.ids[0])) + self.ids[1]
-            return manual_order(qs.filter(id__in=ids), ids)
-        elif field == 'price':
-            return (qs.filter(id__in=self.uids)
-                      .order_by('addonpremium__price__price', 'id'))
-        elif field == 'name':
-            return order_by_translation(qs.filter(id__in=self.uids), 'name')
+    installed_apps_ids = get_ids(user.installed_set.filter(install_type__in=[
+        apps.INSTALL_TYPE_USER, apps.INSTALL_TYPE_DEVELOPER]).exclude(
+        addon__in=contributed_apps_ids))
 
-
-def purchase_list(request, user, product_id):
-    cs = (Contribution.objects
-          .filter(user=user,
-                  type__in=[mkt.CONTRIB_PURCHASE, mkt.CONTRIB_REFUND,
-                            mkt.CONTRIB_CHARGEBACK])
-          .order_by('created'))
-    if product_id:
-        cs = cs.filter(addon__guid=product_id)
-
-    ids = list(cs.values_list('addon_id', flat=True))
-    product_ids = []
-    # If you are asking for a receipt for just one item, show only that.
-    # Otherwise, we'll show all apps that have a contribution or are free.
-    if not product_id:
-        product_ids = list(user.installed_set
-                           .filter(install_type__in=[
-                               apps.INSTALL_TYPE_USER,
-                               apps.INSTALL_TYPE_DEVELOPER])
-                           .exclude(addon__in=ids)
-                           .values_list('addon_id', flat=True))
-
-    contributions = {}
-    for c in cs:
-        contributions.setdefault(c.addon_id, []).append(c)
-
-    unique_ids = set(ids + product_ids)
-    listing = PurchasesFilter(request, Webapp.objects.all(),
-                              key='sort', default='purchased',
-                              ids=[ids, product_ids],
-                              uids=unique_ids)
-
-    if product_id and not listing.qs.exists():
-        # User has requested a receipt for an app he ain't got.
-        raise http.Http404
-
-    products = paginate(request, listing.qs, count=len(unique_ids))
-    return products, contributions, listing
+    addon_ids = contributed_apps_ids + installed_apps_ids
+    qs = Webapp.objects.filter(id__in=addon_ids)
+    products = paginate(request, manual_order(qs, addon_ids), count=qs.count())
+    return products

--- a/mkt/developers/templates/developers/apps/dashboard.html
+++ b/mkt/developers/templates/developers/apps/dashboard.html
@@ -37,8 +37,7 @@
            class="button prominent">{{ _('Submit An App') }}</a>
       </p>
     {% else %}
-      {{ impala_addon_listing_header(request.get_full_path(),
-                                     search_filter=filter) }}
+      {% include "webapps/impala/listing/sorter.html" %}
       <div class="items">
         {{ hub_addon_listing_items(addons.object_list) }}
       </div>

--- a/mkt/lookup/views.py
+++ b/mkt/lookup/views.py
@@ -350,10 +350,9 @@ def user_purchases(request, user_id):
     """Shows the purchase page for another user."""
     user = get_object_or_404(UserProfile, pk=user_id)
     is_admin = acl.action_allowed(request, 'Users', 'Edit')
-    products, contributions, listing = purchase_list(request, user, None)
+    products = purchase_list(request, user)
     return render(request, 'lookup/user_purchases.html',
                   {'pager': products, 'account': user, 'is_admin': is_admin,
-                   'listing_filter': listing, 'contributions': contributions,
                    'single': bool(None), 'show_link': False})
 
 
@@ -362,7 +361,7 @@ def user_purchases(request, user_id):
 def user_activity(request, user_id):
     """Shows the user activity page for another user."""
     user = get_object_or_404(UserProfile, pk=user_id)
-    products, contributions, listing = purchase_list(request, user, None)
+    products = purchase_list(request, user)
     is_admin = acl.action_allowed(request, 'Users', 'Edit')
 
     user_items = ActivityLog.objects.for_user(user).exclude(
@@ -372,8 +371,7 @@ def user_activity(request, user_id):
     mkt.log(mkt.LOG.ADMIN_VIEWED_LOG, request.user, user=user)
     return render(request, 'lookup/user_activity.html',
                   {'pager': products, 'account': user, 'is_admin': is_admin,
-                   'listing_filter': listing,
-                   'contributions': contributions, 'single': bool(None),
+                   'single': bool(None),
                    'user_items': user_items, 'admin_items': admin_items,
                    'show_link': False})
 

--- a/mkt/webapps/helpers.py
+++ b/mkt/webapps/helpers.py
@@ -1,29 +1,3 @@
-import jinja2
-
-from jingo import register
-
-
-@register.inclusion_tag('webapps/impala/listing/sorter.html')
-@jinja2.contextfunction
-def impala_addon_listing_header(context, url_base, sort_opts={}, selected=None,
-                                extra_sort_opts={}, search_filter=None):
-    if search_filter:
-        selected = search_filter.field
-        sort_opts = search_filter.opts
-        if hasattr(search_filter, 'extras'):
-            extra_sort_opts = search_filter.extras
-    # When an "extra" sort option becomes selected, it will appear alongside
-    # the normal sort options.
-    old_extras = extra_sort_opts
-    sort_opts, extra_sort_opts = list(sort_opts), []
-    for k, v in old_extras:
-        if k == selected:
-            sort_opts.append((k, v, True))
-        else:
-            extra_sort_opts.append((k, v))
-    return new_context(**locals())
-
-
 def new_context(context, **kw):
     c = dict(context.items())
     c.update(kw)

--- a/mkt/webapps/templates/webapps/impala/listing/sorter.html
+++ b/mkt/webapps/templates/webapps/impala/listing/sorter.html
@@ -1,26 +1,11 @@
-<div id="sorter" class="c pjax-trigger">
+<div id="sorter" class="c">
   <h3>{{ _('Sort by:') }}</h3>
   <ul>
-    {% for item in sort_opts %}
-      {% set value, title = item[:2] %}
-      {% set is_extra = True if item[2] else False %}
-      <li {{ value|class_selected(selected) }}>
-        <a class="{{ 'extra-opt' if is_extra else 'opt' }}"
-           href="{{ url_base|urlparams(sort=value) }}">{{ title }}</a>
-      </li>
-    {% endfor %}
-    {% if extra_sort_opts %}
-      <li class="extras">
-        <a href="#">{{ _('More') }}</a>
-        <ul>
-          {% for value, title in extra_sort_opts %}
-            <li {{ value|class_selected(selected) }}>
-              <a class="extra-opt" href="{{ url_base|urlparams(sort=value) }}">
-                {{ title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </li>
-    {% endif %}
+    <li{% if sorting == 'name' %} class="selected"{% endif %}>
+      <a class="opt" href="{{ request.get_full_path()|urlparams(sort='name') }}">{{ _('Name') }}</a>
+    </li>
+    <li{% if sorting == 'created' %} class="selected"{% endif %}>
+      <a class="opt" href="{{ request.get_full_path()|urlparams(sort='created') }}">{{ _('Created') }}</a>
+    </li>
   </ul>
 </div>

--- a/mkt/webapps/views.py
+++ b/mkt/webapps/views.py
@@ -23,71 +23,11 @@ from mkt.files.models import FileUpload
 from mkt.regions import get_region
 from mkt.submit.views import PreviewViewSet
 from mkt.tags.models import Tag
-from mkt.translations.query import order_by_translation
 from mkt.webapps.models import AddonUser, get_excluded_in, Webapp
 from mkt.webapps.serializers import AppSerializer
 
 
 log = commonware.log.getLogger('z.api')
-
-
-class BaseFilter(object):
-    """
-    Filters help generate querysets for add-on listings.
-
-    You have to define ``opts`` on the subclass as a sequence of (key, title)
-    pairs.  The key is used in GET parameters and the title can be used in the
-    view.
-
-    The chosen filter field is combined with the ``base`` queryset using
-    the ``key`` found in request.GET.  ``default`` should be a key in ``opts``
-    that's used if nothing good is found in request.GET.
-    """
-
-    def __init__(self, request, base, key, default, model=Webapp):
-        self.opts_dict = dict(self.opts)
-        self.extras_dict = dict(self.extras) if hasattr(self, 'extras') else {}
-        self.request = request
-        self.base_queryset = base
-        self.key = key
-        self.model = model
-        self.field, self.title = self.options(self.request, key, default)
-        self.qs = self.filter(self.field)
-
-    def options(self, request, key, default):
-        """Get the (option, title) pair we want according to the request."""
-        if key in request.GET and (request.GET[key] in self.opts_dict or
-                                   request.GET[key] in self.extras_dict):
-            opt = request.GET[key]
-        else:
-            opt = default
-        if opt in self.opts_dict:
-            title = self.opts_dict[opt]
-        else:
-            title = self.extras_dict[opt]
-        return opt, title
-
-    def all(self):
-        """Get a full mapping of {option: queryset}."""
-        return dict((field, self.filter(field)) for field in dict(self.opts))
-
-    def filter(self, field):
-        """Get the queryset for the given field."""
-        filter = self._filter(field) & self.base_queryset
-        order = getattr(self, 'order_%s' % field, None)
-        if order:
-            return order(filter)
-        return filter
-
-    def _filter(self, field):
-        return getattr(self, 'filter_%s' % field)()
-
-    def filter_created(self):
-        return (self.model.objects.order_by('-created')
-                .with_index(addons='created_type_idx'))
-
-    def filter_name(self):
-        return order_by_translation(self.model.objects.all(), 'name')
 
 
 class AppViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1144663

BaseFilter class is something we inherited from AMO. It was created 5 years ago, does a lot of stuff we don't really need anymore, and in a weird way. It should be much cleaner and reliable to simply use queryset filters directly.