### PR TITLE
Add pagination to versions list in review page (bug 1002434)

### DIFF
--- a/media/css/devreg/reviewers.styl
+++ b/media/css/devreg/reviewers.styl
@@ -757,18 +757,17 @@ button.search, .log-filter-outside button {
         color: #333;
         font-weight: bold;
     }
-    #review-files-paginate {
-        float: right;
-        margin-top: 2em;
-    }
 }
-#review-files-paginate ol {
-    float: right;
-    margin: 0;
-    padding-left: 10px;
-    text-align: right;
-    top: -20px;
-    width: auto;
+#review-files-paginate {
+    text-align: center;
+    padding: 10px;
+}
+#review-files-paginate .button,
+#review-files .activity .comm-notes-paginator .button {
+    height: 30px;
+    line-height: 30px;
+    min-width: 85px;
+    padding: 0 5px;
 }
 #review-files .activity .comm-notes-paginator {
     border-bottom: none;
@@ -1456,12 +1455,6 @@ span.currently_viewing_warning {
 #review-files table.activity .comm-notes-paginator {
     td {
         padding: 0;
-    }
-    a.button {
-        height: 30px;
-        line-height: 30px;
-        min-width: 85px;
-        padding: 0 5px;
     }
 }
 #review-files table.activity .loading-msg {

--- a/media/js/devreg/reviewers/reviewers_commbadge.js
+++ b/media/js/devreg/reviewers/reviewers_commbadge.js
@@ -27,18 +27,31 @@ define('reviewersCommbadge', ['login'], function(login) {
         var versionIds = _.map(threads, function(thread) {
             return thread.version.id;
         });
+
+        // Version ids that are actually being displayed. Useful to filter out
+        // threads that we don't need to make a XHR for.
+        var displayedVersions = [];
+
         $('table.activity').each(function(i, table) {
             var $table = $(table);
-            if (versionIds.indexOf($table.data('version')) === -1) {
+            var versionId = $table.data('version');
+            if (versionIds.indexOf(versionId) === -1) {
                 // No data for this table. Remove loading and add no results.
                 $table.removeClass('comm-loading').find('tbody').append(noResults);
             }
+            displayedVersions.push(versionId);
         });
 
-        // Load the threads by latest version first since those most visible.
+        // Filter out useless threads...
+        threads = threads.filter(function(thread) {
+            return displayedVersions.indexOf(thread.version.id) !== -1;
+        });
+
+        // ... then sort them by negative version id to get the latest first,
+        // since those most visible.
         threads = _.sortBy(threads, function(thread) {
-            return thread.version.id;
-        }).reverse();
+            return 0 - thread.version.id;
+        });
 
         // Now, fetch all of the notes for each thread.
         for (var i = 0; i < threads.length; i++) {

--- a/mkt/reviewers/templates/reviewers/includes/paginator_history.html
+++ b/mkt/reviewers/templates/reviewers/includes/paginator_history.html
@@ -1,0 +1,8 @@
+{% if num_pages > 1 %}
+  <a {% if not pager.has_next() %}class="button disabled"{% else %}class="button" rel="next" href="{{ pager.url|urlparams(page=pager.next_page_number()) }}#history"{% endif %}>
+    {{ _('Older versions') }}
+  </a>
+  <a {% if not pager.has_previous() %}class="button disabled"{% else %}class="button" rel="prev" href="{{ pager.url|urlparams(page=pager.previous_page_number()) }}#history"{% endif %}>
+    {{ _('Newer versions') }}
+  </a>
+{% endif %}

--- a/mkt/reviewers/templates/reviewers/includes/review_history.html
+++ b/mkt/reviewers/templates/reviewers/includes/review_history.html
@@ -62,36 +62,33 @@
                   </td>
                 </tr>
               {% endif %}
-              {% if version.approvalnotes %}
-                <tr>
-                  <th>{{ _('Notes for Reviewers') }}</th>
-                  <td class="activity_approval">
-                    <div class="history-notes">
-                      {{ version.approvalnotes|urlize(100)|nl2br }}
-                    </div>
-                  </td>
-                </tr>
-              {% endif %}
+              {# No need to show approvalnotes, that'll be handled by commbadge, see below. #}
             </thead>
             <tbody>
               {# Results populated here by reviewers_commbadge.js (Commbadge API) #}
-              <tr class="comm-notes-paginator">
-                <th>&nbsp;</th>
-                <td>
-                  <a class="button next" href="#">{{ _('Next Page') }}</a>
-                  <a class="button prev" href="#">{{ _('Previous Page') }}</a>
-                </td>
-              </tr>
               <tr class="loading-msg">
                 <td>{{ _('Loading App History &hellip;')|safe }}</td>
               </tr>
             </tbody>
+            <tfoot>
+              {# Paginator will be displayed if necessary. #}
+              <tr class="comm-notes-paginator">
+                <th>&nbsp;</th>
+                <td>
+                  <a class="button next" href="#">{{ _('Next Comments') }}</a>
+                  <a class="button prev" href="#">{{ _('Previous Comments') }}</a>
+                </td>
+              </tr>
+            </tfoot>
           </table>
         </td>
 
       </tr>
     {% endfor %}
   </table>
+  <div id="review-files-paginate">
+    {% include "reviewers/includes/paginator_history.html"  %}
+  </div>
 </div>
 
 {% include "reviewers/includes/commbadge_note_template.html" %}

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -46,7 +46,8 @@ from mkt.site.fixtures import fixture
 from mkt.site.helpers import absolutify, isotime
 from mkt.site.tests import (check_links, days_ago, formset, initial,
                             req_factory_factory, user_factory)
-from mkt.site.utils import app_factory, make_game, urlparams, version_factory
+from mkt.site.utils import (app_factory, make_game, paginate, urlparams,
+                            version_factory)
 from mkt.submit.tests.test_views import BasePackagedAppTest
 from mkt.tags.models import Tag
 from mkt.users.models import UserProfile
@@ -1988,6 +1989,32 @@ class TestReviewApp(AppReviewerTest, TestReviewMixin, AccessMixin,
         self.post(data)
         tags = self.get_app().tags.values_list('tag_text', flat=True)
         assert 'tarako' not in tags
+
+    def test_versions_history_pagination(self):
+        self.app.update(is_packaged=True)
+        version_factory(addon=self.app, version='2.0')
+        version_factory(addon=self.app, version='3.0')
+
+        # Mock paginate to paginate with only 2 versions to limit the
+        # number of versions this test has to create.
+        with mock.patch('mkt.reviewers.views.paginate',
+                        lambda req, objs, limit: paginate(req, objs, 2)):
+            content = pq(self.client.get(self.url).content)
+        eq_(len(content('#review-files tr.listing-body')), 2)
+        eq_(len(content('#review-files-paginate a[rel=next]')), 1)
+        eq_(len(content('#review-files-paginate a[rel=prev]')), 0)
+        link = content('#review-files-paginate a[rel=next]')[0].attrib['href']
+        eq_(link, '%s?page=2#history' % self.url)
+
+        # Look at page 2.
+        with mock.patch('mkt.reviewers.views.paginate',
+                        lambda req, objs, limit: paginate(req, objs, 2)):
+            content = pq(self.client.get(link).content)
+        eq_(len(content('#review-files tr.listing-body')), 1)
+        eq_(len(content('#review-files-paginate a[rel=next]')), 0)
+        eq_(len(content('#review-files-paginate a[rel=prev]')), 1)
+        eq_(content('#review-files-paginate a[rel=prev]')[0].attrib['href'],
+            '%s?page=1#history' % self.url)
 
 
 class TestCannedResponses(AppReviewerTest):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1002434

I originally wanted to do everything in JavaScript, but I prefer for something like that to be tested, and I didn't have the motivation to resurrect front-end testing in zamboni all by myself... so I did it in Django.

Screenshot of a faked (artificially set the limit of commbadge notes to load to 5 instead of 25 to show pagination) situation with every paginator shown :
![screen shot 2015-03-19 at 16 11 20](https://cloud.githubusercontent.com/assets/187006/6733486/bedcc204-ce52-11e4-8733-6baeb88f4974.png)
