### PR TITLE
Force update_cached_manifests() task to be called after request is done (bug 1145160)

### DIFF
--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -678,6 +678,7 @@ class TestPublishForm(mkt.site.tests.TestCase):
         assert not form.is_valid()
 
 
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestPublishFormPackaged(mkt.site.tests.TestCase):
     """
     Test that changing the app visibility doesn't affect the version statuses

--- a/mkt/developers/tests/test_views_versions.py
+++ b/mkt/developers/tests/test_views_versions.py
@@ -175,7 +175,7 @@ class BaseAddVersionTest(BasePackagedAppTest):
         return res
 
 
-@mock.patch('mkt.webapps.tasks.update_cached_manifests.delay', new=mock.Mock)
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestAddVersion(BaseAddVersionTest):
 
     def setUp(self):
@@ -276,6 +276,7 @@ class TestAddVersion(BaseAddVersionTest):
             'VIP App not in escalation queue')
 
 
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestAddVersionPrereleasePermissions(BaseAddVersionTest):
     @property
     def package(self):
@@ -298,6 +299,7 @@ class TestAddVersionPrereleasePermissions(BaseAddVersionTest):
             'App not in escalation queue')
 
 
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestAddVersionNoPermissions(BaseAddVersionTest):
     @property
     def package(self):

--- a/mkt/lookup/tests/test_views.py
+++ b/mkt/lookup/tests/test_views.py
@@ -740,6 +740,7 @@ class AppSummaryTest(SummaryTest):
         return res
 
 
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestAppSummary(AppSummaryTest):
     fixtures = fixture('prices', 'user_admin', 'user_support_staff',
                        'webapp_337141', 'user_operator')

--- a/mkt/ratings/tests/test_views.py
+++ b/mkt/ratings/tests/test_views.py
@@ -9,6 +9,7 @@ from django.http import QueryDict
 from django.test.utils import override_settings
 
 
+import mock
 from mock import patch
 from nose.tools import eq_, ok_
 
@@ -24,6 +25,7 @@ from mkt.webapps.models import AddonExcludedRegion, AddonUser, Webapp
 from mkt.users.models import UserProfile
 
 
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestRatingResource(RestOAuth, mkt.site.tests.MktPaths):
     fixtures = fixture('user_2519', 'webapp_337141')
 

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -150,6 +150,7 @@ class SearchMixin(object):
         eq_(res.status_code, 200)
 
 
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestReviewersHome(AppReviewerTest, AccessMixin):
 
     def setUp(self):

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -286,6 +286,7 @@ def _update_manifest(id, check_hash, failed_fetches):
 
 
 @post_request_task
+@write
 def update_cached_manifests(id, **kw):
     try:
         webapp = Webapp.objects.get(pk=id)

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -285,7 +285,7 @@ def _update_manifest(id, check_hash, failed_fetches):
         webapp.set_iarc_storefront_data()
 
 
-@task
+@post_request_task
 def update_cached_manifests(id, **kw):
     try:
         webapp = Webapp.objects.get(pk=id)

--- a/mkt/webapps/tests/test_crons.py
+++ b/mkt/webapps/tests/test_crons.py
@@ -136,6 +136,7 @@ class TestCleanup(mkt.site.tests.TestCase):
 
 
 @mock.patch('lib.crypto.packaged.sign_app')
+@mock.patch('mkt.webapps.models.Webapp.get_cached_manifest', mock.Mock)
 class TestSignApps(mkt.site.tests.TestCase):
     fixtures = fixture('webapp_337141')
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1145160

Otherwise it's possible for this task to be called too soon, before the view transaction has been committed. This was probably already a potential issue before, but by simplifying the transaction code, 31c0cc5f made it happen more often.