### PR TITLE
Update curling to 0.4.0, getting rid of oauth2 (bug 846349)

### DIFF
--- a/mkt/developers/api_payments.py
+++ b/mkt/developers/api_payments.py
@@ -2,7 +2,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 
 import commonware
-from curling.lib import HttpClientError, HttpServerError
 from rest_framework import status
 from rest_framework.mixins import (CreateModelMixin, DestroyModelMixin,
                                    ListModelMixin, RetrieveModelMixin,
@@ -14,6 +13,7 @@ from rest_framework.serializers import (HyperlinkedModelSerializer,
                                         Serializer,
                                         ValidationError)
 from rest_framework.viewsets import GenericViewSet
+from slumber.exceptions import HttpClientError, HttpServerError
 from tower import ugettext as _
 
 import mkt

--- a/mkt/developers/forms_payments.py
+++ b/mkt/developers/forms_payments.py
@@ -9,7 +9,7 @@ from django.forms.formsets import formset_factory, BaseFormSet
 
 import commonware
 import happyforms
-from curling.lib import HttpClientError
+from slumber.exceptions import HttpClientError
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 import mkt

--- a/mkt/developers/tests/test_api_payments.py
+++ b/mkt/developers/tests/test_api_payments.py
@@ -5,10 +5,10 @@ from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from curling.lib import HttpClientError, HttpServerError
 from mock import Mock, patch
 from nose.tools import eq_, ok_
 from rest_framework.request import Request
+from slumber.exceptions import HttpClientError, HttpServerError
 
 import mkt
 from mkt.api.tests.test_oauth import RestOAuth

--- a/mkt/developers/tests/test_forms_payments.py
+++ b/mkt/developers/tests/test_forms_payments.py
@@ -1,9 +1,9 @@
 from django.test.client import RequestFactory
 
 import mock
-from curling.lib import HttpClientError
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
+from slumber.exceptions import HttpClientError
 
 import mkt
 import mkt.site.tests

--- a/mkt/developers/tests/test_views_payments.py
+++ b/mkt/developers/tests/test_views_payments.py
@@ -6,10 +6,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 
 import mock
-from curling.lib import HttpClientError
 from mock import ANY
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
+from slumber.exceptions import HttpClientError
 from waffle.models import Switch
 
 import mkt

--- a/mkt/developers/views_payments.py
+++ b/mkt/developers/views_payments.py
@@ -12,7 +12,7 @@ from django.views.decorators.http import require_POST
 import commonware
 import jinja2
 import waffle
-from curling.lib import HttpClientError
+from slumber.exceptions import HttpClientError
 from tower import ugettext as _
 from waffle.decorators import waffle_switch
 

--- a/mkt/lookup/tests/test_views.py
+++ b/mkt/lookup/tests/test_views.py
@@ -10,7 +10,6 @@ from django.test.client import RequestFactory
 
 import mock
 from babel import numbers
-from curling.lib import HttpClientError
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 from slumber import exceptions
@@ -283,7 +282,8 @@ class TestBangoRedirect(TestCase):
     def test_bango_portal_redirect_api_error(self, api):
         message = 'Something went wrong.'
         error = {'__all__': [message]}
-        api.bango.login.post.side_effect = HttpClientError(content=error)
+        api.bango.login.post.side_effect = exceptions.HttpClientError(
+            content=error)
         res = self.client.get(self.portal_url, follow=True)
         eq_(res.redirect_chain, [('http://testserver/lookup/', 302)])
         ok_(message in [msg.message for msg in res.context['messages']][0])

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -22,7 +22,7 @@ commonware==0.4.3
 cryptography==0.8
 # cssutils is required by app-validator
 cssutils==0.9.7b3
-curling==0.3.12
+curling==0.4
 # defusedxml is required by djangorestframework
 defusedxml==0.4.1
 dennis==0.4.2
@@ -76,9 +76,7 @@ m2secret==0.1.1
 ndg-httpsclient==0.3.3
 newrelic==2.20.1.18
 nose==1.3.4
-# oauth2 is required by curling
-oauth2==1.5.211
-oauthlib==0.6.2
+oauthlib==0.7.2
 # ordereddict is required by kombu
 ordereddict==1.1
 # polib is required by dennis


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=846349

Latest curling switched to oauthlib.