### PR TITLE
Revert "class fixture loading support (bug 1142943)"

### DIFF
--- a/mkt/site/tests/__init__.py
+++ b/mkt/site/tests/__init__.py
@@ -9,12 +9,10 @@ from functools import partial
 from urlparse import SplitResult, urlsplit, urlunsplit
 
 from django import forms, test
-from django.db import connections, transaction, DEFAULT_DB_ALIAS
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.core.files.storage import default_storage as storage
-from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from django.test.client import Client, RequestFactory
 from django.utils import translation
@@ -346,105 +344,7 @@ class MockBrowserIdMixin(object):
 JINJA_INSTRUMENTED = False
 
 
-class ClassFixtureTestCase(test.TestCase):
-    """ Based on the changes to TestCase (& TransactionTestCase) in Django1.8.
-
-    Fixtures are loaded once per class, and a class setUpTestData method is
-    added to be overridden by sublasses.  `transaction.atomic()` is used to
-    achieve test isolation.
-    See orginal code:
-    https://github.com/django/django/blob/1.8b2/django/test/testcases.py
-    #L747-990.
-
-    A noteable difference is that this class assumes the database supports
-    transactions.  This class will be obsolete on upgrade to 1.8.
-    """
-    fixtures = None
-
-    @classmethod
-    def _databases_names(cls, include_mirrors=True):
-        # If the test case has a multi_db=True flag, act on all databases,
-        # including mirrors or not. Otherwise, just on the default DB.
-        if getattr(cls, 'multi_db', False):
-            return [alias for alias in connections
-                    if (include_mirrors or
-                        connections[alias].settings_dict['TEST']['MIRROR'])]
-        else:
-            return [DEFAULT_DB_ALIAS]
-
-    @classmethod
-    def _enter_atomics(cls):
-        """Helper method to open atomic blocks for multiple databases"""
-        atomics = {}
-        for db_name in cls._databases_names():
-            atomics[db_name] = transaction.atomic(using=db_name)
-            atomics[db_name].__enter__()
-        return atomics
-
-    @classmethod
-    def _rollback_atomics(cls, atomics):
-        """Rollback atomic blocks opened through the previous method"""
-        for db_name in reversed(cls._databases_names()):
-            transaction.set_rollback(True, using=db_name)
-            atomics[db_name].__exit__(None, None, None)
-
-    @classmethod
-    def setUpClass(cls):
-        cls.cls_atomics = cls._enter_atomics()
-
-        if cls.fixtures:
-            for db_name in cls._databases_names(include_mirrors=False):
-                    try:
-                        call_command('loaddata', *cls.fixtures, **{
-                            'verbosity': 0,
-                            'commit': False,
-                            'database': db_name,
-                        })
-                    except Exception:
-                        cls._rollback_atomics(cls.cls_atomics)
-                        raise
-        cls.setUpTestData()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls._rollback_atomics(cls.cls_atomics)
-        for conn in connections.all():
-            conn.close()
-
-    @classmethod
-    def setUpTestData(cls):
-        """Load initial data for the TestCase"""
-        pass
-
-    def _should_reload_connections(self):
-        return False
-
-    def _fixture_setup(self):
-        assert not self.reset_sequences, (
-            'reset_sequences cannot be used on TestCase instances')
-        self.atomics = self._enter_atomics()
-
-    def _fixture_teardown(self):
-        self._rollback_atomics(self.atomics)
-
-    def _post_teardown(self):
-        """Patch _post_teardown so connections don't get closed.
-        In django 1.6's _post_teardown connections are closed and we don't want
-        that to happen after each test anymore.  This method isn't copied from
-        Django 1.6 code.
-        https://github.com/django/django/blob/1.6.10/django/test/testcases.py
-        #L788
-        """
-        if not self._should_reload_connections():
-            real_connections_all = connections.all
-            connections.all = lambda: []
-        super(ClassFixtureTestCase, self)._post_teardown()
-        if not self._should_reload_connections():
-            connections.all = real_connections_all
-
-
-class TestCase(MockEsMixin, RedisTest, MockBrowserIdMixin,
-               ClassFixtureTestCase):
+class TestCase(MockEsMixin, RedisTest, MockBrowserIdMixin, test.TestCase):
     """Base class for all mkt tests."""
     client_class = TestClient
 


### PR DESCRIPTION
Reverts mozilla/zamboni#2979

This breaks when there is one error in the tests, all following tests end up having connection/transaction issues. See https://travis-ci.org/mozilla/zamboni/builds/55664668 for instance.