### PR TITLE
deserialize full preview for feed app (bug 1148509)

### DIFF
--- a/mkt/feed/indexers.py
+++ b/mkt/feed/indexers.py
@@ -76,9 +76,13 @@ class FeedAppIndexer(BaseIndexer):
             'created': obj.created,
             'image_hash': obj.image_hash,
             'item_type': feed.FEED_TYPE_APP,
-            'preview': {'id': obj.preview.id,
-                        'thumbnail_size': obj.preview.thumbnail_size,
-                        'thumbnail_url': obj.preview.thumbnail_url}
+            'preview': {
+                'id': obj.preview.id,
+                'image_size': obj.preview.image_size,
+                'image_url': obj.preview.image_url,
+                'thumbnail_size': obj.preview.thumbnail_size,
+                'thumbnail_url': obj.preview.thumbnail_url
+            }
             if getattr(obj, 'preview') else None,
             'pullquote_attribution': obj.pullquote_attribution,
             'pullquote_rating': obj.pullquote_rating,

--- a/mkt/feed/tests/test_indexers.py
+++ b/mkt/feed/tests/test_indexers.py
@@ -41,7 +41,8 @@ class TestFeedAppIndexer(FeedTestMixin, BaseFeedIndexerTest,
             pullquote_rating=4, pullquote_text=self._get_test_l10n(),
             app_type=feed.FEEDAPP_QUOTE)
         self.obj.update(preview=Preview.objects.create(
-            addon=self.app, sizes={'thumbnail': [50, 50]}))
+            addon=self.app, sizes={'image': [100, 100],
+                                   'thumbnail': [50, 50]}))
 
         self.indexer = self.obj.get_indexer()()
         self.model = FeedApp
@@ -54,9 +55,13 @@ class TestFeedAppIndexer(FeedTestMixin, BaseFeedIndexerTest,
         self._assert_test_l10n(doc['description_translations'])
         eq_(doc['image_hash'], 'LOL')
         eq_(doc['item_type'], feed.FEED_TYPE_APP)
-        eq_(doc['preview'], {'id': self.obj.preview.id,
-                             'thumbnail_size': [50, 50],
-                             'thumbnail_url': self.obj.preview.thumbnail_url})
+        eq_(doc['preview'], {
+            'id': self.obj.preview.id,
+            'image_size': [100, 100],
+            'image_url': self.obj.preview.image_url,
+            'thumbnail_size': [50, 50],
+            'thumbnail_url': self.obj.preview.thumbnail_url
+        })
         eq_(doc['pullquote_attribution'], 'mscott')
         eq_(doc['pullquote_rating'], 4)
         self._assert_test_l10n(doc['pullquote_text_translations'])

--- a/mkt/feed/tests/test_serializers.py
+++ b/mkt/feed/tests/test_serializers.py
@@ -42,7 +42,8 @@ class TestFeedAppESSerializer(FeedTestMixin, mkt.site.tests.TestCase):
         self.feedapp = self.feed_app_factory(
             app_type=feed.FEEDAPP_DESC, description={'en-US': 'test'})
         self.feedapp.update(preview=Preview.objects.create(
-            addon=self.feedapp.app, sizes={'thumbnail': [50, 50]}))
+            addon=self.feedapp.app, sizes={'image': [100, 100],
+                                           'thumbnail': [50, 50]}))
 
         self.data_es = self.feedapp.get_indexer().extract_document(
             None, obj=self.feedapp)
@@ -63,8 +64,10 @@ class TestFeedAppESSerializer(FeedTestMixin, mkt.site.tests.TestCase):
         eq_(data['description']['en-US'], 'test')
         eq_(data['preview'], {
             'id': self.feedapp.preview.id,
+            'image_size': [100, 100],
+            'image_url': self.feedapp.preview.image_url,
             'thumbnail_size': [50, 50],
-            'thumbnail_url': self.feedapp.preview.thumbnail_url})
+            'thumbnail_url': self.obj.preview.thumbnail_url})
 
     def test_deserialize_many(self):
         data = serializers.FeedAppESSerializer(

--- a/mkt/submit/serializers.py
+++ b/mkt/submit/serializers.py
@@ -100,7 +100,9 @@ class FeedPreviewESSerializer(PreviewSerializer):
     scale feed app tiles appropriately.
     """
     id = serializers.IntegerField(source='id')
+    image_size = serializers.Field(source='image_size')
     thumbnail_size = serializers.Field(source='thumbnail_size')
 
     class Meta(PreviewSerializer.Meta):
-        fields = ['id', 'thumbnail_size', 'thumbnail_url']
+        fields = ['id', 'image_size', 'image_url', 'thumbnail_size',
+                  'thumbnail_url']


### PR DESCRIPTION
Bigger images unfortunately, but at least they are deferred on the frontend and the Feed won't have more than two or three of them at the most.