### PR TITLE
Implement multi-type search for apps+websites (bug 1149995)

### DIFF
--- a/lib/es/management/commands/reindex.py
+++ b/lib/es/management/commands/reindex.py
@@ -46,7 +46,7 @@ INDEXES = (
     (ES_INDEXES['mkt_feed_item'], f_indexers.FeedItemIndexer, 1000),
 
     # Currently using 500 because we don't really know what size they'll be.
-    (ES_INDEXES['mkt_website'], WebsiteIndexer, 500),
+    (ES_INDEXES['website'], WebsiteIndexer, 500),
 )
 
 INDEX_DICT = {

--- a/mkt/api/v2/urls.py
+++ b/mkt/api/v2/urls.py
@@ -11,8 +11,8 @@ from mkt.comm.views import CommAppListView, ThreadViewSetV2
 from mkt.langpacks.views import LangPackViewSet
 from mkt.operators.views import OperatorPermissionViewSet
 from mkt.recommendations.views import RecommendationView
-from mkt.search.views import (NonPublicSearchView, NoRegionSearchView,
-                              RocketbarViewV2)
+from mkt.search.views import (MultiSearchView, NonPublicSearchView,
+                              NoRegionSearchView, RocketbarViewV2)
 from mkt.websites.views import WebsiteSearchView
 
 
@@ -92,4 +92,6 @@ urlpatterns = patterns(
     url(r'^langpacks', include(langpacks.urls)),
     url(r'^websites/search/', WebsiteSearchView.as_view(),
         name='website-search-api'),
+    url(r'^multi-search/', MultiSearchView.as_view(),
+        name='multi-search-api'),
 ) + v1_urls

--- a/mkt/search/filters.py
+++ b/mkt/search/filters.py
@@ -173,7 +173,7 @@ class ReviewerSearchFormFilter(SearchFormFilter):
 
 class PublicAppsFilter(BaseFilterBackend):
     """
-    A django-rest-framework filter backend that filters only public apps --
+    A django-rest-framework filter backend that filters only public items --
     those with PUBLIC status and not disabled.
 
     """
@@ -185,7 +185,7 @@ class PublicAppsFilter(BaseFilterBackend):
 
 class ValidAppsFilter(BaseFilterBackend):
     """
-    A django-rest-framework filter backend that filters only valid apps --
+    A django-rest-framework filter backend that filters only valid items --
     those with any valid status and not disabled or deleted.
 
     """

--- a/mkt/search/indexers.py
+++ b/mkt/search/indexers.py
@@ -375,6 +375,30 @@ class BaseIndexer(object):
             return mapping
 
     @classmethod
+    def attach_trending_and_popularity_mappings(cls, mapping):
+        doc_type = cls.get_mapping_type_name()
+        new_properties = {}
+
+        # Add global popularity and trending fields.
+        new_properties['popularity'] = {
+            'type': 'long', 'doc_values': True
+        }
+        new_properties['trending'] = {
+            'type': 'long', 'doc_values': True
+        }
+        # Add region-specific popularity and trending fields.
+        for region in mkt.regions.ALL_REGION_IDS:
+            new_properties['popularity_%s' % region] = {
+                'type': 'long', 'doc_values': True
+            }
+            new_properties['trending_%s' % region] = {
+                'type': 'long', 'doc_values': True
+            }
+        # Add everything to the mapping.
+        mapping[doc_type]['properties'].update(new_properties)
+        return mapping
+
+    @classmethod
     def extract_field_translations(cls, obj, field, db_field=None,
                                    include_field_for_search=False):
         """

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -694,7 +694,7 @@ ES_INDEXES = {
     'mkt_feed_collection': 'feed_collections',
     'mkt_feed_shelf': 'feed_shelves',
     'mkt_feed_item': 'feed_items',
-    'mkt_website': 'websites'
+    'website': 'websites'
     # Adding an index? Also add the index to reindex.py.
 }
 ES_URLS = ['http://%s' % h for h in ES_HOSTS]

--- a/mkt/websites/indexers.py
+++ b/mkt/websites/indexers.py
@@ -10,7 +10,7 @@ class WebsiteIndexer(BaseIndexer):
 
     @classmethod
     def get_mapping_type_name(cls):
-        return 'mkt_website'
+        return 'website'
 
     @classmethod
     def get_model(cls):
@@ -37,12 +37,14 @@ class WebsiteIndexer(BaseIndexer):
                     'device': {'type': 'byte'},
                     'icon_hash': cls.string_not_indexed(),
                     'icon_type': cls.string_not_indexed(),
+                    'is_disabled': {'type': 'boolean'},
                     'last_updated': {'format': 'dateOptionalTime',
                                      'type': 'date'},
                     'modified': {'type': 'date', 'format': 'dateOptionalTime'},
                     'region_exclusions': {'type': 'short'},
                     'short_title': {'type': 'string',
                                     'analyzer': 'default_icu'},
+                    'status': {'type': 'byte'},
                     'title': {
                         'type': 'string',
                         'analyzer': 'default_icu',
@@ -58,13 +60,15 @@ class WebsiteIndexer(BaseIndexer):
                     # FIXME: Add custom analyzer for url, that strips http,
                     # https, maybe also www. and any .tld ?
                     'url': {'type': 'string', 'analyzer': 'simple'},
-                    # FIXME: status.
                 }
             }
         }
 
         # Attach boost field, because we are going to need search by relevancy.
         cls.attach_boost_mapping(mapping)
+
+        # Attach popularity and trending.
+        cls.attach_trending_and_popularity_mappings(mapping)
 
         # Add extra mapping for translated fields, containing the "raw"
         # translations.
@@ -86,7 +90,7 @@ class WebsiteIndexer(BaseIndexer):
         attach_trans_dict(cls.get_model(), [obj])
 
         attrs = ('created', 'default_locale', 'id', 'icon_hash', 'icon_type',
-                 'last_updated', 'modified')
+                 'is_disabled', 'last_updated', 'modified', 'status')
         doc = dict(zip(attrs, attrgetter(*attrs)(obj)))
 
         doc['boost'] = obj.get_boost()

--- a/mkt/websites/models.py
+++ b/mkt/websites/models.py
@@ -6,6 +6,7 @@ from django.dispatch import receiver
 import json_field
 
 from mkt.constants.applications import DEVICE_TYPES
+from mkt.constants.base import STATUS_PUBLIC
 from mkt.site.models import ModelBase
 from mkt.tags.models import Tag
 from mkt.translations.fields import save_signal, TranslatedField
@@ -27,7 +28,6 @@ class Website(ModelBase):
     icon_type = models.CharField(max_length=25, blank=True)
     icon_hash = models.CharField(max_length=8, blank=True)
     last_updated = models.DateTimeField(db_index=True, auto_now_add=True)
-    # FIXME status
 
     class Meta:
         ordering = (('-last_updated'), )
@@ -48,6 +48,18 @@ class Website(ModelBase):
         device_ids = self.devices or []
         with no_translation():
             return [DEVICE_TYPES[d].api_name for d in device_ids]
+
+    @property
+    def status(self):
+        # For now, all websites are public.
+        # FIXME: add real field and migration.
+        return STATUS_PUBLIC
+
+    @property
+    def is_disabled(self):
+        # For now, all websites are enabled.
+        # FIXME: add real field and migration.
+        return False
 
     def get_boost(self):
         """

--- a/mkt/websites/tests/test_indexers.py
+++ b/mkt/websites/tests/test_indexers.py
@@ -19,17 +19,17 @@ class TestWebsiteIndexer(TestCase):
         ok_(isinstance(self.indexer, WebsiteIndexer))
 
     def test_get_mapping_ok(self):
-        eq_(WebsiteIndexer.get_mapping_type_name(), 'mkt_website')
+        eq_(WebsiteIndexer.get_mapping_type_name(), 'website')
         ok_(isinstance(self.indexer.get_mapping(), dict))
 
     def test_index(self):
-        with self.settings(ES_INDEXES={'mkt_website': 'websites'}):
+        with self.settings(ES_INDEXES={'website': 'websites'}):
             eq_(WebsiteIndexer.get_index(), 'websites')
 
     def test_mapping(self):
         mapping = WebsiteIndexer.get_mapping()
-        eq_(mapping.keys(), ['mkt_website'])
-        eq_(mapping['mkt_website']['_all'], {'enabled': False})
+        eq_(mapping.keys(), ['website'])
+        eq_(mapping['website']['_all'], {'enabled': False})
 
     def _get_doc(self):
         return self.indexer.extract_document(self.obj.pk, self.obj)

--- a/mkt/websites/tests/test_views.py
+++ b/mkt/websites/tests/test_views.py
@@ -9,6 +9,7 @@ from nose.tools import eq_
 from mkt.api.tests.test_oauth import RestOAuth
 from mkt.constants.applications import DEVICE_GAIA, DEVICE_DESKTOP
 from mkt.constants.regions import BRA, GTM, URY
+from mkt.site.fixtures import fixture
 from mkt.site.tests import ESTestCase, TestCase
 from mkt.websites.models import Website
 from mkt.websites.utils import website_factory
@@ -16,6 +17,8 @@ from mkt.websites.views import WebsiteView
 
 
 class TestWebsiteESView(RestOAuth, ESTestCase):
+    fixtures = fixture('user_2519')
+
     def setUp(self):
         self.website = website_factory(**{
             'title': 'something',
@@ -35,7 +38,13 @@ class TestWebsiteESView(RestOAuth, ESTestCase):
         super(TestWebsiteESView, self).tearDown()
 
     def _reindex(self):
-        self.reindex(Website, 'mkt_website')
+        self.reindex(Website, 'website')
+
+    def test_verbs(self):
+        self._allowed_verbs(self.url, ['get'])
+
+    def test_has_cors(self):
+        self.assertCORS(self.anon.get(self.url), 'get')
 
     def test_basic(self):
         with self.assertNumQueries(0):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1149995

Sorting results by relevancy works, but most of the rest of the sort options are semi-broken either because the corresponding field does not exist in websites mapping (rating, reviewed, name_sort)
or because it's empty (popularity, trending). A follow-up bug will take care of those.