### PR TITLE
Override installs_allowed_from in API responses for a whitelisted set of apps (bug 1145338).

### DIFF
--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -1219,3 +1219,9 @@ DEV_PAY_PROVIDERS = {
 # JWT algorithms that we support for decoding.
 # Any JWT we receive with another algorithm will be rejected.
 SUPPORTED_JWT_ALGORITHMS = ['HS256', 'RS512']
+
+# We want to override the installs_allowed_from value in API responses for some
+# apps. These settings define the app IDs for which we do that and the value
+# with which we override (bug 1145338).
+IAF_OVERRIDE_APPS = []
+IAF_OVERRIDE_VALUE = ['https://marketplace.firefox.com']

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1308,7 +1308,10 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
             return {}
 
         try:
-            return file_.version.manifest
+            manifest = file_.version.manifest
+            if file_.version.addon_id in settings.IAF_OVERRIDE_APPS:
+                manifest['installs_allowed_from'] = settings.IAF_OVERRIDE_VALUE
+            return manifest
         except AppManifest.DoesNotExist:
             # TODO: Remove this when we're satisified the above is working.
             log.info('Falling back to loading manifest from file system. '

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -1641,6 +1641,18 @@ class TestManifest(BaseWebAppTest):
             eq_(webapp.get_manifest_json(webapp.latest_version.all_files[0]),
                 manifest_json)
 
+    def test_installs_allowed_from_override(self):
+        webapp = self.post_addon()
+        with override_settings(IAF_OVERRIDE_APPS=[webapp.pk]):
+            json = webapp.get_manifest_json(webapp.latest_version.all_files[0])
+            eq_(json['installs_allowed_from'], settings.IAF_OVERRIDE_VALUE)
+
+    def test_installs_allowed_from_override_no_match(self):
+        webapp = self.post_addon()
+        with override_settings(IAF_OVERRIDE_APPS=[]):
+            json = webapp.get_manifest_json(webapp.latest_version.all_files[0])
+            ok_(json['installs_allowed_from'] != settings.IAF_OVERRIDE_VALUE)
+
 
 class PackagedFilesMixin(MktPaths):
 


### PR DESCRIPTION
No-longer secret, thanks to good work from @jasonthomas. `IAF_OVERRIDE_APPS` will be set in a local setting on dev, stage, and prod by hiera. 

Everything else is the same as the security PR r+ed by @robhudson, so I'm going to merge it.