### PR TITLE
Add NFC feature requirement and accept old signatures (bug 1150372)

### DIFF
--- a/docs/api/topics/search.rst
+++ b/docs/api/topics/search.rst
@@ -102,7 +102,7 @@ features table.
 Each bit in the features bitfield represents the presence or absence
 of a feature.
 
-Feature table version 6:
+Feature table version 7:
 
 =====  ============================
   bit   feature
@@ -158,6 +158,7 @@ Feature table version 6:
    48   Asm.js Precompilation
    49   512MB RAM Device
    50   1GB RAM Device
+   51   NFC
 =====  ============================
 
 
@@ -165,7 +166,7 @@ For example, a device with only the 'App Management API', 'Proximity',
 'Ambient Light Sensor', and 'Vibration' features enabled would send this
 feature profile signature::
 
-    4400880000000.51.6
+    8801000000000.52.7
 
 .. [1] `other` denotes a payment system other than the Firefox Marketplace
   payments. This field is not currently populated by the Marketplace Developer

--- a/migrations/902-add-nfc.sql
+++ b/migrations/902-add-nfc.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `addons_features`
+    ADD COLUMN `has_nfc` bool NOT NULL;

--- a/mkt/constants/tests/test_features.py
+++ b/mkt/constants/tests/test_features.py
@@ -7,34 +7,42 @@ import mock
 from nose.tools import eq_, ok_
 
 import mkt.site.tests
-
 from mkt.constants.features import APP_FEATURES, FeatureProfile
 
 
-APP_FEATURES = OrderedDict(itertools.islice(APP_FEATURES.iteritems(), 45))
+MOCK_APP_FEATURES_LIMIT = 45
+MOCK_APP_FEATURES = OrderedDict(
+    itertools.islice(APP_FEATURES.iteritems(), MOCK_APP_FEATURES_LIMIT))
 
 
-@mock.patch('mkt.constants.features.APP_FEATURES', APP_FEATURES)
-class TestFeatureProfile(mkt.site.tests.TestCase):
+class TestFeaturesMixin(object):
+    features = 0x110022000000
+    signature = '110022000000.%d.%d' % (
+        MOCK_APP_FEATURES_LIMIT, settings.APP_FEATURES_VERSION)
+    expected_features = ['apps', 'proximity', 'light_events', 'vibrate']
 
-    def setUp(self):
-        self.features = 0x110022000000
-        self.signature = '110022000000.45.%s' % settings.APP_FEATURES_VERSION
-        self.truths = ['apps', 'proximity', 'light_events', 'vibrate']
-
-    def test_init(self):
-        profile = FeatureProfile(**dict((f, True) for f in self.truths))
-        eq_(profile.to_signature(), self.signature)
-        eq_(profile.to_int(), self.features)
+    def _test_profile_values(self, profile):
+        for k, v in profile.iteritems():
+            if v:
+                ok_(k in self.expected_features,
+                    '"%s" is true in profile but not in expected_features' % k)
+            else:
+                ok_(k not in self.expected_features,
+                    '"%s" is false in profile but is in expected_features' % k)
 
     def _test_profile(self, profile):
         eq_(profile.to_int(), self.features)
         eq_(profile.to_signature(), self.signature)
-        for k, v in profile.iteritems():
-            if v:
-                ok_(k in self.truths, '%s not in truths' % k)
-            else:
-                ok_(k not in self.truths, '%s is in truths' % k)
+        self._test_profile_values(profile)
+
+
+@mock.patch('mkt.constants.features.APP_FEATURES', MOCK_APP_FEATURES)
+class TestFeatureProfileFixed(TestFeaturesMixin, mkt.site.tests.TestCase):
+    def test_init(self):
+        profile = FeatureProfile(**dict(
+            (f, True) for f in self.expected_features))
+        eq_(profile.to_signature(), self.signature)
+        eq_(profile.to_int(), self.features)
 
     def test_from_int(self):
         profile = FeatureProfile.from_int(self.features)
@@ -42,8 +50,9 @@ class TestFeatureProfile(mkt.site.tests.TestCase):
 
     def test_from_int_all_false(self):
         self.features = 0
-        self.signature = '0.45.%s' % settings.APP_FEATURES_VERSION
-        self.truths = []
+        self.signature = '0.%d.%d' % (
+            MOCK_APP_FEATURES_LIMIT, settings.APP_FEATURES_VERSION)
+        self.expected_features = []
         self.test_from_int()
 
     def test_from_signature(self):
@@ -56,8 +65,24 @@ class TestFeatureProfile(mkt.site.tests.TestCase):
 
         ok_(all([k.startswith(prefix) for k in kwargs.keys()]))
         eq_(kwargs.values().count(False), bin(self.features)[2:].count('0'))
-        eq_(len(kwargs.values()), len(APP_FEATURES) - len(self.truths))
+        eq_(len(kwargs.values()),
+            len(MOCK_APP_FEATURES) - len(self.expected_features))
 
     def test_to_kwargs(self):
         self._test_kwargs('')
         self._test_kwargs('prefix_')
+
+
+class TestFeatureProfileDynamic(TestFeaturesMixin, mkt.site.tests.TestCase):
+    def test_from_int_limit(self):
+        profile = FeatureProfile.from_int(
+            self.features, limit=MOCK_APP_FEATURES_LIMIT)
+        self._test_profile_values(profile)
+
+    def test_from_old_signature(self):
+        profile = FeatureProfile.from_signature(self.signature)
+        self._test_profile_values(profile)
+        new_signature = profile.to_signature()
+        ok_(new_signature != self.signature)
+        profile = FeatureProfile.from_signature(new_signature)
+        self._test_profile_values(profile)

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -511,7 +511,7 @@ API_THROTTLE = True
 
 # The version we append to the app feature profile. Bump when we add new app
 # features to the `AppFeatures` model.
-APP_FEATURES_VERSION = 6
+APP_FEATURES_VERSION = 7
 
 # This is the aud (audience) for app purchase JWTs.
 # It must match that of the pay server that processes nav.mozPay().


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1150372

Bonus: I've added support for parsing old signatures. Surprisingly, this wasn't working, so each time we added a feature, we were filtering incorrectly. Added tests to cover that.