### PR TITLE
review pages for deleted apps bug 891159

### DIFF
--- a/migrations/901-numeric-slugs-for-deleted-apps.sql
+++ b/migrations/901-numeric-slugs-for-deleted-apps.sql
@@ -1,0 +1,3 @@
+UPDATE addons
+SET app_slug=id
+WHERE status=11;

--- a/mkt/developers/models.py
+++ b/mkt/developers/models.py
@@ -434,7 +434,7 @@ class ActivityLog(ModelBase):
                 # Instead of passing an addon instance you can pass a tuple:
                 # (Webapp, 3) for Webapp with pk=3
                 serialize_me.append(dict(((unicode(arg[0]._meta), arg[1]),)))
-            else:
+            elif arg is not None:
                 serialize_me.append(dict(((unicode(arg._meta), arg.pk),)))
 
         self._arguments = json.dumps(serialize_me)

--- a/mkt/lookup/templates/lookup/helpers/app_header.html
+++ b/mkt/lookup/templates/lookup/helpers/app_header.html
@@ -40,6 +40,11 @@
             {{ _('Review History') }}
           </a>
         </li>
+        <li>
+          <a href="{{ url('commonplace.commbadge.app_dashboard', app.id) }}">
+            {{ _('Communication Dashboard') }}
+          </a>
+        </li>
         {% endif %}
       {% endif %}
     </ul>

--- a/mkt/reviewers/templates/reviewers/includes/details.html
+++ b/mkt/reviewers/templates/reviewers/includes/details.html
@@ -19,7 +19,7 @@
       {% endif %}
     </dd>
     <dt>{{ _('Status') }}</dt>
-    <dd{% if product.status == mkt.STATUS_BLOCKED %} class="warn"{% endif %}>{{ mkt.STATUS_CHOICES[product.status] }}
+    <dd{% if product.status in (mkt.STATUS_BLOCKED, mkt.STATUS_DELETED) %} class="warn"{% endif %}>{{ mkt.STATUS_CHOICES[product.status] }}
       {% if product.in_rereview_queue() %}&middot; <b id="queue-rereview">{{ _('In re-review queue') }}</b>{% endif %}
       {% if product.in_escalation_queue() %}&middot; <b id="queue-escalation">{{ _('In escalation queue') }}</b>{% endif %}
     </dd>

--- a/mkt/reviewers/templates/reviewers/review.html
+++ b/mkt/reviewers/templates/reviewers/review.html
@@ -56,7 +56,7 @@
       </li>
       <li><a href="{{ product.get_detail_url() }}" class="button">
         {{ _('View Listing') }}</a></li>
-      {% if is_admin %}
+      {% if is_admin and not product.is_deleted %}
         <li><a href="{{ product.get_dev_url() }}" class="button manage">
           {{ _('Edit Listing') }}</a></li>
       {% endif %}

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -1367,8 +1367,8 @@ class TestReviewApp(AppReviewerTest, TestReviewMixin, AccessMixin,
         response = self.client.get(self.url)
         eq_(response.status_code, 200)
         doc = pq(response.content)
-        assert doc('input[name=action][value=info]').length
-        assert doc('input[name=action][value=comment]').length
+        assert not doc('input[name=action][value=info]').length
+        assert not doc('input[name=action][value=comment]').length
         assert not doc('input[name=action][value=public]').length
         assert not doc('input[name=action][value=reject]').length
 

--- a/mkt/reviewers/utils.py
+++ b/mkt/reviewers/utils.py
@@ -425,8 +425,6 @@ class ReviewHelper(object):
 
         if not self.version:
             # Return early if there is no version, this app is incomplete.
-            actions['info'] = info
-            actions['comment'] = comment
             return actions
 
         file_status = self.version.files.values_list('status', flat=True)

--- a/mkt/webapps/decorators.py
+++ b/mkt/webapps/decorators.py
@@ -1,6 +1,5 @@
 import functools
 
-from django import http
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 
@@ -39,26 +38,8 @@ def can_become_premium(f):
 
 def app_view(f, qs=Webapp.objects.all):
     @functools.wraps(f)
-    def wrapper(request, addon_id=None, app_slug=None, *args,
-                **kw):
-        """Provides an addon given either an addon_id or app_slug."""
-        assert addon_id or app_slug, 'Must provide addon_id or app_slug'
-
-        def get(**kw):
-            return get_object_or_404(qs(), **kw)
-
-        if addon_id and addon_id.isdigit():
-            addon = get(id=addon_id)
-            # Don't get in an infinite loop if addon.app_slug.isdigit().
-            if addon.app_slug != addon_id:
-                url = request.path.replace(addon_id, addon.app_slug, 1)
-                if request.GET:
-                    url += '?' + request.GET.urlencode()
-                return http.HttpResponsePermanentRedirect(url)
-        elif addon_id:
-            addon = get(app_slug=addon_id)
-        elif app_slug:
-            addon = get(app_slug=app_slug)
+    def wrapper(request, app_slug, *args, **kw):
+        addon = get_object_or_404(qs(), app_slug=app_slug)
         return f(request, addon, *args, **kw)
     return wrapper
 

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -558,7 +558,7 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
 
         # Update or NULL out various fields.
         models.signals.pre_delete.send(sender=Webapp, instance=self)
-        self.update(status=mkt.STATUS_DELETED, app_slug=None,
+        self.update(status=mkt.STATUS_DELETED, app_slug=str(self.id),
                     app_domain=None, _current_version=None)
         models.signals.post_delete.send(sender=Webapp, instance=self)
 

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -155,8 +155,8 @@ class TestWebapp(WebappTestCase):
         # When an app is deleted its slugs and domain should get relinquished.
         post_mortem = Webapp.with_deleted.filter(id=app.id)
         eq_(post_mortem.count(), 1)
-        for attr in ('app_slug', 'app_domain'):
-            eq_(getattr(post_mortem[0], attr), None)
+        eq_(getattr(post_mortem[0], 'app_domain'), None)
+        eq_(getattr(post_mortem[0], 'app_slug'), '337141')
 
     def test_soft_deleted_valid(self):
         app = self.get_app()


### PR DESCRIPTION
Makes review pages viewable even after the app has been deleted.  To workaround them not having a slug any more all deleted apps now get a numeric slug equal to their id on deletion (all numeric slugs being otherwise prohibited)