### PR TITLE
Remove celery-tasktree

### DIFF
--- a/.baked
+++ b/.baked
@@ -40,7 +40,7 @@
             "aesfield", "amqp", "anyjson", "apiclient", "appvalidator",
             "argparse", "babel", "baked", "basket", "billiard", "bleach",
             "boto", "browserid", "cache_nuggets", "caching", "caching",
-            "captcha", "cef", "celery", "celery_tasktree", "celeryutils",
+            "captcha", "cef", "celery", "celeryutils",
             "certifi", "chardet", "commonware", "commonware", "coverage",
             "cronjobs", "csp", "cssselect", "cssutils", "curling", "dateutil",
             "debug", "debug_toolbar", "defusedxml", "dennis",

--- a/mkt/developers/tasks.py
+++ b/mkt/developers/tasks.py
@@ -20,7 +20,6 @@ from django.utils.http import urlencode
 
 import requests
 from appvalidator import validate_app, validate_packaged_app
-from celery_tasktree import task_with_callbacks
 from celeryutils import task
 from django_statsd.clients import statsd
 from PIL import Image
@@ -328,7 +327,7 @@ def save_icon(webapp, content):
     webapp.save()
 
 
-@task_with_callbacks
+@task
 @write
 def fetch_icon(webapp, file_obj=None, **kw):
     """

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -12,7 +12,6 @@ boto==2.20.0
 # cef is required by heka-py-cef
 cef==0.5
 celery==3.0.25
-celery-tasktree==0.3.2
 certifi==14.05.14
 chardet==2.3.0
 commonware==0.4.3


### PR DESCRIPTION
It doesn't seem like we were actually using this. Celery 3.x also has newer options to do similar task chaining so let's get rid of the dependency.