### PR TITLE
Remove default_language from region API (bug 1154837)

### DIFF
--- a/docs/api/topics/site.rst
+++ b/docs/api/topics/site.rst
@@ -126,7 +126,6 @@ Regions
             "resource_uri": "/api/v2/services/region/ap/",
             "slug": "ap",
             "default_currency": "USD",
-            "default_language": "en-AP",
         }
 
 Configuration

--- a/mkt/api/serializers.py
+++ b/mkt/api/serializers.py
@@ -71,7 +71,6 @@ class CarrierSerializer(serializers.Serializer):
 
 class RegionSerializer(CarrierSerializer):
     default_currency = serializers.CharField()
-    default_language = serializers.CharField()
 
 
 class CategorySerializer(serializers.Serializer):

--- a/mkt/api/tests/test_views.py
+++ b/mkt/api/tests/test_views.py
@@ -111,7 +111,6 @@ class TestRegion(RestOAuth):
             eq_(row['slug'], region.slug)
             eq_(row['id'], region.id)
             eq_(row['default_currency'], region.default_currency)
-            eq_(row['default_language'], region.default_language)
         eq_(len(data['objects']), len(mkt.regions.REGIONS_DICT))
         eq_(data['meta']['total_count'], len(mkt.regions.REGIONS_DICT))
 
@@ -138,7 +137,6 @@ class TestRegion(RestOAuth):
         eq_(data['slug'], region.slug)
         eq_(data['id'], region.id)
         eq_(data['default_currency'], region.default_currency)
-        eq_(data['default_language'], region.default_language)
 
     def get_region(self, slug):
         return self.anon.get(reverse('regions-detail', kwargs={'pk': slug}))


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1154837

It's a backwards-incompatible change, but that property is unreliable, was never really documented, and useless to third parties.