### PR TITLE
Switch previews/icons tasks to post_request_task (bug 1153669)

### DIFF
--- a/mkt/developers/tests/test_forms.py
+++ b/mkt/developers/tests/test_forms.py
@@ -14,6 +14,7 @@ from nose.tools import eq_, ok_
 
 import mkt
 import mkt.site.tests
+from lib.post_request_task import task as post_request_task
 from mkt.developers import forms
 from mkt.developers.tests.test_views_edit import TestAdmin
 from mkt.files.helpers import copyfileobj
@@ -53,6 +54,9 @@ class TestPreviewForm(mkt.site.tests.TestCase):
             copyfileobj(open(get_image_path(name)), f)
         assert form.is_valid(), form.errors
         form.save(self.addon)
+        # Since the task is a post-request-task and we are outside the normal
+        # request-response cycle, manually send the tasks.
+        post_request_task._send_tasks()
         eq_(self.addon.previews.all()[0].sizes,
             {u'image': [250, 297], u'thumbnail': [100, 119]})
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1153669

This should ensure the tasks for previews and icons handling are not fired before all transactions have been committed.

As a result, the `transaction.atomic()` call in mkt/submit/views.py is now useless since the task will be called after the view transaction is done anyway.