### PR TITLE
remove HIDDEN_LANGUAGES; bug 1157775

### DIFF
--- a/migrations/335-perms-locales.py
+++ b/migrations/335-perms-locales.py
@@ -4,7 +4,7 @@ from mkt.access.models import Group, GroupUser
 
 
 LANGS = sorted(list(
-    set(settings.AMO_LANGUAGES + settings.HIDDEN_LANGUAGES) -
+    set(settings.AMO_LANGUAGES) -
     set(['en-US'])))
 
 

--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -797,17 +797,6 @@ HEKA_CONF = {
 
 HEKA = client_from_dict_config(HEKA_CONF)
 
-# Not shown on the site, but .po files exist and these are available on the
-# L10n dashboard.  Generally languages start here and move into AMO_LANGUAGES.
-# This list also enables translation edits.
-HIDDEN_LANGUAGES = (
-    # List of languages from AMO's settings (excluding mkt's active locales).
-    'af', 'ar', 'fa', 'fi', 'he', 'id', 'mn', 'pt-PT', 'sl', 'sv-SE',
-    'uk', 'vi',
-    # The hidden list from AMO's settings:
-    'cy',
-)
-
 # IARC content ratings.
 IARC_ALLOW_CERT_REUSE = True
 

--- a/mkt/submit/tests/test_views.py
+++ b/mkt/submit/tests/test_views.py
@@ -381,13 +381,13 @@ class TestCreateWebApp(BaseWebAppTest):
         eq_(addon.versions.latest().supported_locales, 'es,it')
 
     def test_short_locale(self):
-        # This manifest has a locale code of "pt" which is in the
-        # SHORTER_LANGUAGES setting and should get converted to "pt-PT".
+        # This manifest has a locale code of "zh" which is in the
+        # SHORTER_LANGUAGES setting and should get converted to "zh-CN".
         self.manifest = self.manifest_path('short-locale.webapp')
         self.upload = self.get_upload(abspath=self.manifest,
                                       user=UserProfile.objects.get(pk=999))
         addon = self.post_addon()
-        eq_(addon.default_locale, 'pt-PT')
+        eq_(addon.default_locale, 'zh-CN')
         eq_(addon.versions.latest().supported_locales, 'es')
 
     def test_unsupported_detail_locale(self):

--- a/mkt/submit/tests/webapps/short-locale.webapp
+++ b/mkt/submit/tests/webapps/short-locale.webapp
@@ -27,5 +27,5 @@
       }
     }
   },
-  "default_locale": "pt"
+  "default_locale": "zh"
 }

--- a/mkt/translations/fields.py
+++ b/mkt/translations/fields.py
@@ -184,7 +184,7 @@ class TranslationDescriptor(related.ReverseSingleRelatedObjectDescriptor):
         rv = None
         for locale, string in dict_.items():
             loc = mkt_to_language(locale)
-            if loc not in settings.AMO_LANGUAGES + settings.HIDDEN_LANGUAGES:
+            if loc not in settings.AMO_LANGUAGES:
                 continue
             # The Translation is created and saved in here.
             trans = self.translation_from_string(instance, locale, string)

--- a/mkt/translations/tests/test_models.py
+++ b/mkt/translations/tests/test_models.py
@@ -232,16 +232,6 @@ class TranslationTestCase(TestCase):
         translation.activate('sr-Latn')
         trans_eq(get_model().name, 'yes I speak serbian', 'sr-Latn')
 
-    def test_dict_with_hidden_locale(self):
-        with self.settings(HIDDEN_LANGUAGES=('xxx',)):
-            o = self.TranslatedModel.objects.get(id=1)
-            o.name = {'en-US': 'active language', 'xxx': 'hidden language',
-                      'de': 'another language'}
-            o.save()
-        ts = Translation.objects.filter(id=o.name_id)
-        eq_(sorted(ts.values_list('locale', flat=True)),
-            ['de', 'en-US', 'xxx'])
-
     def test_dict_bad_locale(self):
         m = self.TranslatedModel.objects.get(id=1)
         m.name = {'de': 'oof', 'xxx': 'bam', 'es': 'si'}

--- a/mkt/translations/utils.py
+++ b/mkt/translations/utils.py
@@ -159,7 +159,7 @@ def find_language(locale):
     if not locale:
         return None
 
-    LANGS = settings.AMO_LANGUAGES + settings.HIDDEN_LANGUAGES
+    LANGS = settings.AMO_LANGUAGES
 
     if locale in LANGS:
         return locale

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -610,8 +610,7 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
         addon.status = mkt.STATUS_NULL
         locale_is_set = (addon.default_locale and
                          addon.default_locale in (
-                             settings.AMO_LANGUAGES +
-                             settings.HIDDEN_LANGUAGES) and
+                             settings.AMO_LANGUAGES) and
                          data.get('default_locale') == addon.default_locale)
         if not locale_is_set:
             addon.default_locale = to_language(translation.get_language())

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -539,13 +539,13 @@ class TestRemoveLocale(mkt.site.tests.TestCase):
     def test_remove(self):
         app = Webapp.objects.create()
         app.name = {'en-US': 'woo', 'el': 'yeah'}
-        app.description = {'en-US': 'woo', 'el': 'yeah', 'he': 'ola'}
+        app.description = {'en-US': 'woo', 'el': 'yeah', 'ja': 'ola'}
         app.save()
         app.remove_locale('el')
         qs = (Translation.objects.filter(localized_string__isnull=False)
               .values_list('locale', flat=True))
         eq_(sorted(qs.filter(id=app.name_id)), ['en-US'])
-        eq_(sorted(qs.filter(id=app.description_id)), ['en-US', 'he'])
+        eq_(sorted(qs.filter(id=app.description_id)), ['en-US', 'ja'])
 
     def test_remove_version_locale(self):
         app = app_factory()

--- a/sites/altdev/settings_mkt.py
+++ b/sites/altdev/settings_mkt.py
@@ -90,9 +90,6 @@ VALIDATOR_IAF_URLS = ['https://marketplace.firefox.com',
 AMO_LANGUAGES = AMO_LANGUAGES + ('dbg',)
 LANGUAGES = lazy(langs, dict)(AMO_LANGUAGES)
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
-HIDDEN_LANGUAGES = (
-    'cy',
-)
 
 # Bug 748403
 SIGNING_SERVER = private_mkt.SIGNING_SERVER

--- a/sites/dev/settings_mkt.py
+++ b/sites/dev/settings_mkt.py
@@ -91,9 +91,6 @@ VALIDATOR_IAF_URLS = ['https://marketplace.firefox.com',
 AMO_LANGUAGES = AMO_LANGUAGES + ('dbg', 'rtl', 'ar', 'ha', 'ln', 'sw', 'tl')
 LANGUAGES = lazy(langs, dict)(AMO_LANGUAGES)
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in AMO_LANGUAGES])
-HIDDEN_LANGUAGES = (
-    'cy',
-)
 
 # Bug 748403
 SIGNING_SERVER = private_mkt.SIGNING_SERVER


### PR DESCRIPTION
HIDDEN_LANGUAGES was left over from AMO when we had a dropdown on the list that people could use to choose their language.  Now we preview languages on dev/stage before enabling them in production so this isn't needed anymore.