### PR TITLE
Set dir and lang on fireplace pages (bug 1155826)

### DIFF
--- a/mkt/commonplace/templates/commonplace/index.html
+++ b/mkt/commonplace/templates/commonplace/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html{% if appcache %} manifest="{{ url('commonplace.appcache')|urlparams(repo=repo) }}"{% endif %}>
+<html{% if appcache %} manifest="{{ url('commonplace.appcache')|urlparams(repo=repo) }}"{% endif %}{% if repo == 'fireplace' %} lang="{{ LANG }}" dir="{{ DIR }}"{% endif %}>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">

--- a/mkt/commonplace/tests/test_views.py
+++ b/mkt/commonplace/tests/test_views.py
@@ -309,3 +309,42 @@ class TestBuildId(CommonplaceTestMixin):
             src = pq(script).attr('src')
             if 'fireplace' in src:
                 ok_(src.endswith('?b=0118999'))
+
+
+class TestLangAttrs(CommonplaceTestMixin):
+
+    def test_lang_en(self):
+        res = self._test_url('/server.html')
+        doc = pq(res.content)
+        html = doc('html[lang][dir]')
+        eq_(html.attr('lang'), 'en-US')
+        eq_(html.attr('dir'), 'ltr')
+
+    def test_lang_fr(self):
+        res = self._test_url('/server.html?lang=fr')
+        doc = pq(res.content)
+        html = doc('html[lang][dir]')
+        eq_(html.attr('lang'), 'fr')
+        eq_(html.attr('dir'), 'ltr')
+
+    @override_settings(LANGUAGE_URL_MAP={'ar': 'ar'})
+    def test_lang_ar(self):
+        res = self._test_url('/server.html?lang=ar')
+        doc = pq(res.content)
+        html = doc('html[lang][dir]')
+        eq_(html.attr('lang'), 'ar')
+        eq_(html.attr('dir'), 'rtl')
+
+    @override_settings(LANGUAGE_URL_MAP={'rtl': 'rtl'})
+    def test_lang_rtl(self):
+        res = self._test_url('/server.html?lang=rtl')
+        doc = pq(res.content)
+        html = doc('html[lang][dir]')
+        eq_(html.attr('lang'), 'rtl')
+        eq_(html.attr('dir'), 'rtl')
+
+    def test_comm_does_not_set_tags(self):
+        res = self._test_url('/comm/')
+        doc = pq(res.content)
+        ok_(not doc('html[lang]'), 'html[lang] should not be set')
+        ok_(not doc('html[dir]'), 'html[dir] should not be set')

--- a/mkt/commonplace/views.py
+++ b/mkt/commonplace/views.py
@@ -8,6 +8,7 @@ from django.core.files.storage import default_storage as storage
 from django.core.urlresolvers import resolve
 from django.http import HttpResponse, Http404
 from django.shortcuts import render
+from django.utils import translation
 from django.views.decorators.cache import cache_control
 from django.views.decorators.gzip import gzip_page
 
@@ -124,6 +125,8 @@ def commonplace(request, repo, **kwargs):
 
     ctx = {
         'BUILD_ID': BUILD_ID,
+        'LANG': request.LANG,
+        'DIR': lang_dir(request.LANG),
         'appcache': repo in settings.COMMONPLACE_REPOS_APPCACHED,
         'include_persona': False,
         'include_splash': include_splash,
@@ -210,3 +213,10 @@ def potatolytics(request):
         'allowed_origins': get_allowed_origins(request,
                                                include_loop=False)
     })
+
+
+def lang_dir(lang):
+    if lang == 'rtl' or translation.get_language_bidi():
+        return 'rtl'
+    else:
+        return 'ltr'


### PR DESCRIPTION
It makes the spinner go in the right direction.

![rtl-from-zamboni mov](https://cloud.githubusercontent.com/assets/211578/7324170/739d00f4-ea79-11e4-9b34-0c7ede97fc99.gif)
