### PR TITLE
Exclude fields we don't need when querying ES (bug 1127144)

### DIFF
--- a/mkt/lookup/views.py
+++ b/mkt/lookup/views.py
@@ -455,13 +455,13 @@ def app_search(request):
             results.append(app)
         else:
             # This is a result from elasticsearch which returns `Result`
-            # objects and name as a list, one for each locale.
-            for name in app.name:
+            # objects and "name_translations" as a list, one for each locale.
+            for trans in app.name_translations:
                 results.append({
                     'id': app.id,
                     'url': reverse('lookup.app_summary', args=[app.id]),
                     'app_slug': app.get('app_slug'),
-                    'name': name,
+                    'name': trans['string'],
                 })
     return {'results': results}
 

--- a/mkt/reviewers/templates/reviewers/queue.html
+++ b/mkt/reviewers/templates/reviewers/queue.html
@@ -38,7 +38,7 @@
               {% for qa in addons %}
                 <tr data-addon="{{ qa.app.id }}" class="addon-row" id="addon-{{ qa.app.id }}">
                   <td><div class="addon-locked"></div></td>
-                  <td class="app-name"><a href="{{ url('reviewers.apps.review', qa.app.app_slug) }}">{{ qa.app.name[0] }}</a></td>
+                  <td class="app-name"><a href="{{ url('reviewers.apps.review', qa.app.app_slug) }}">{{ qa.app.name_translations[0]['string'] }}</a></td>
                   <td class="flags">{{ app_flags(qa.app) }}</td>
                   <td class="waiting-time">{{ qa.date_field|es2datetime|timelabel }}</td>
                   <td>{{ device_list_es(qa.app) }}</td>

--- a/mkt/search/filters.py
+++ b/mkt/search/filters.py
@@ -72,11 +72,11 @@ class SearchQueryFilter(BaseFilterBackend):
 
         if analyzer:
             should.append(
-                query.Match(**{'name_%s' % analyzer: {'query': q,
-                                                      'boost': 2.5}}))
+                query.Match(**{'name_l10n_%s' % analyzer: {'query': q,
+                                                           'boost': 2.5}}))
             should.append(
-                query.Match(**{'title_%s' % analyzer: {'query': q,
-                                                       'boost': 2.5}}))
+                query.Match(**{'title_l10n_%s' % analyzer: {'query': q,
+                                                            'boost': 2.5}}))
 
         # Add searches on the description field.
         should.append(
@@ -84,7 +84,7 @@ class SearchQueryFilter(BaseFilterBackend):
                                      'type': 'phrase'}))
 
         if analyzer:
-            desc_field = 'description_%s' % analyzer
+            desc_field = 'description_l10n_%s' % analyzer
             desc_analyzer = ('%s_analyzer' % analyzer
                              if analyzer in mkt.STEMMER_MAP else analyzer)
             should.append(

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -52,14 +52,14 @@ class TestQueryFilter(FilterTestsBase):
             in should)
         ok_({'prefix': {'name': {'boost': 1.5, 'value': 'search terms'}}}
             in should)
-        ok_({'match': {'name_english': {'query': 'search terms',
-                                        'boost': 2.5}}}
+        ok_({'match': {'name_l10n_english': {'query': 'search terms',
+                                             'boost': 2.5}}}
             in should)
-        ok_({'match': {'description_english': {'query': 'search terms',
-                                               'boost': 0.6,
-                                               'analyzer': 'english_analyzer',
-                                               'type': 'phrase'}}}
-            in should)
+        ok_({'match': {'description_l10n_english':
+            {'query': 'search terms',
+             'boost': 0.6,
+             'analyzer': 'english_analyzer',
+             'type': 'phrase'}}} in should)
 
     def test_fuzzy_single_word(self):
         qs = self._filter(data={'q': 'term'})
@@ -81,13 +81,13 @@ class TestQueryFilter(FilterTestsBase):
         with self.activate(locale='pl'):
             qs = self._filter(data={'q': u'próba'})
             should = (qs['query']['function_score']['query']['bool']['should'])
-            ok_({'match': {'name_polish': {'query': u'pr\xf3ba',
-                                           'boost': 2.5}}}
+            ok_({'match': {'name_l10n_polish': {'query': u'pr\xf3ba',
+                                                'boost': 2.5}}}
                 in should)
-            ok_({'match': {'description_polish': {'query': u'pr\xf3ba',
-                                                  'boost': 0.6,
-                                                  'analyzer': 'polish',
-                                                  'type': 'phrase'}}}
+            ok_({'match': {'description_l10n_polish': {'query': u'pr\xf3ba',
+                                                       'boost': 0.6,
+                                                       'analyzer': 'polish',
+                                                       'type': 'phrase'}}}
                 in should)
 
 
@@ -387,5 +387,5 @@ class TestCombinedFilter(FilterTestsBase):
         query = qs['query']['filtered']['query']
         ok_({'field_value_factor': {'field': 'boost'}}
             in query['function_score']['functions'])
-        ok_({'match': {'name_english': {'boost': 2.5, 'query': u'test'}}}
+        ok_({'match': {'name_l10n_english': {'boost': 2.5, 'query': u'test'}}}
             in query['function_score']['query']['bool']['should'])

--- a/mkt/search/tests/test_views.py
+++ b/mkt/search/tests/test_views.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
 from django.test.client import RequestFactory
-from django.test.utils import override_settings
 
 from mock import patch
 from nose.tools import eq_, ok_
@@ -241,50 +240,48 @@ class TestSearchView(RestOAuth, ESTestCase):
 
         with patch('mkt.api.middleware.RestSharedSecretMiddleware'
                    '.process_request', fakeauth):
-            with self.settings(SITE_URL=''):
-                self.create()
+            self.create()
             res = self.anon.get(self.url, data={'cat': self.category})
             obj = res.json['objects'][0]
             assert 'user' in obj
 
     def test_dehydrate(self):
-        with self.settings(SITE_URL='http://hy.fr'):
-            self.create()
-            res = self.anon.get(self.url, data={'cat': self.category})
-            eq_(res.status_code, 200)
-            obj = res.json['objects'][0]
-            content_ratings = obj['content_ratings']
-            eq_(obj['absolute_url'],
-                absolutify(self.webapp.get_absolute_url()))
-            eq_(obj['app_type'], self.webapp.app_type)
-            eq_(obj['categories'], [self.category])
-            eq_(content_ratings['body'], 'generic')
-            eq_(content_ratings['rating'], None)
-            eq_(content_ratings['descriptors'], [])
-            eq_(content_ratings['interactives'], [])
-            eq_(obj['current_version'], u'1.0')
-            eq_(obj['description'],
-                {'en-US': self.webapp.description.localized_string})
-            eq_(obj['icons']['128'], self.webapp.get_icon_url(128))
-            ok_(obj['icons']['128'].endswith('?modified=fakehash'))
-            eq_(obj['id'], long(self.webapp.id))
-            eq_(obj['is_offline'], False)
-            eq_(obj['manifest_url'], self.webapp.get_manifest_url())
-            eq_(obj['package_path'], None)
-            eq_(obj['payment_account'], None)
-            self.assertApiUrlEqual(obj['privacy_policy'],
-                                   '/apps/app/337141/privacy/')
-            eq_(obj['public_stats'], self.webapp.public_stats)
-            eq_(obj['ratings'], {'average': 0.0, 'count': 0})
-            self.assertApiUrlEqual(obj['resource_uri'],
-                                   '/apps/app/337141/')
-            eq_(obj['slug'], self.webapp.app_slug)
-            self.assertSetEqual(obj['supported_locales'],
-                                ['en-US', 'es', 'pt-BR'])
-            eq_(obj['tags'], [])
-            ok_('1.0' in obj['versions'])
-            self.assertApiUrlEqual(obj['versions']['1.0'],
-                                   '/apps/versions/1268829/')
+        self.create()
+        res = self.anon.get(self.url, data={'cat': self.category})
+        eq_(res.status_code, 200)
+        obj = res.json['objects'][0]
+        content_ratings = obj['content_ratings']
+        eq_(obj['absolute_url'],
+            absolutify(self.webapp.get_absolute_url()))
+        eq_(obj['app_type'], self.webapp.app_type)
+        eq_(obj['categories'], [self.category])
+        eq_(content_ratings['body'], 'generic')
+        eq_(content_ratings['rating'], None)
+        eq_(content_ratings['descriptors'], [])
+        eq_(content_ratings['interactives'], [])
+        eq_(obj['current_version'], u'1.0')
+        eq_(obj['description'],
+            {'en-US': self.webapp.description.localized_string})
+        eq_(obj['icons']['128'], self.webapp.get_icon_url(128))
+        ok_(obj['icons']['128'].endswith('?modified=fakehash'))
+        eq_(obj['id'], long(self.webapp.id))
+        eq_(obj['is_offline'], False)
+        eq_(obj['manifest_url'], self.webapp.get_manifest_url())
+        eq_(obj['package_path'], None)
+        eq_(obj['payment_account'], None)
+        self.assertApiUrlEqual(obj['privacy_policy'],
+                               '/apps/app/337141/privacy/')
+        eq_(obj['public_stats'], self.webapp.public_stats)
+        eq_(obj['ratings'], {'average': 0.0, 'count': 0})
+        self.assertApiUrlEqual(obj['resource_uri'],
+                               '/apps/app/337141/')
+        eq_(obj['slug'], self.webapp.app_slug)
+        self.assertSetEqual(obj['supported_locales'],
+                            ['en-US', 'es', 'pt-BR'])
+        eq_(obj['tags'], [])
+        ok_('1.0' in obj['versions'])
+        self.assertApiUrlEqual(obj['versions']['1.0'],
+                               '/apps/versions/1268829/')
 
         # These only exists if requested by a reviewer.
         ok_('latest_version' not in obj)
@@ -637,7 +634,6 @@ class TestSearchView(RestOAuth, ESTestCase):
         eq_(obj['is_packaged'], False)
         eq_(obj['package_path'], None)
 
-    @override_settings(SITE_URL='http://hy.fr')
     def test_app_type_packaged(self):
         self.webapp.update(is_packaged=True)
         f = self.webapp.current_version.all_files[0]
@@ -943,7 +939,6 @@ class TestFeaturedSearchView(RestOAuth, ESTestCase):
         eq_(res.status_code, 404)
 
 
-@patch.object(settings, 'SITE_URL', 'http://testserver')
 class TestSuggestionsView(ESTestCase):
     fixtures = fixture('webapp_337141')
 
@@ -1003,7 +998,6 @@ class TestSuggestionsView(ESTestCase):
             eq_(json.loads(res.content)[1], [])
 
 
-@patch.object(settings, 'SITE_URL', 'http://testserver')
 class TestNonPublicSearchView(RestOAuth, ESTestCase):
     fixtures = fixture('user_2519', 'webapp_337141')
 
@@ -1073,7 +1067,6 @@ class TestNonPublicSearchView(RestOAuth, ESTestCase):
         eq_(len(res.json['objects']), 0)
 
 
-@patch.object(settings, 'SITE_URL', 'http://testserver')
 class TestNoRegionSearchView(RestOAuth, ESTestCase):
     fixtures = fixture('user_2519', 'webapp_337141')
 

--- a/mkt/search/views.py
+++ b/mkt/search/views.py
@@ -72,11 +72,14 @@ class MultiSearchView(SearchView):
         return context
 
     def get_queryset(self):
-        return Search(
+        excluded_fields = list(set(WebappIndexer.hidden_fields +
+                                   WebsiteIndexer.hidden_fields))
+        return (Search(
             using=BaseIndexer.get_es(),
             index=[WebappIndexer.get_index(), WebsiteIndexer.get_index()],
             doc_type=[WebappIndexer.get_mapping_type_name(),
                       WebsiteIndexer.get_mapping_type_name()])
+                .extra(_source={'exclude': excluded_fields}))
 
 
 class FeaturedSearchView(SearchView):

--- a/mkt/websites/indexers.py
+++ b/mkt/websites/indexers.py
@@ -7,6 +7,20 @@ from mkt.translations.models import attach_trans_dict
 class WebsiteIndexer(BaseIndexer):
     translated_fields = ('description', 'short_title', 'title', 'url')
     fields_with_language_analyzers = ('description', 'title')
+    hidden_fields = (
+        '*.raw',
+        '*_sort',
+        'popularity_*',
+        'trending_*',
+        'boost',
+        # 'title' and 'description', as well as the locale variants, are only
+        # used for filtering. The fields that are used by the API are
+        # 'title_translations' and 'description_translations'.
+        'title',
+        'description',
+        'title_l10n_',
+        'description_l10n_',
+    )
 
     @classmethod
     def get_mapping_type_name(cls):

--- a/mkt/websites/tests/test_indexers.py
+++ b/mkt/websites/tests/test_indexers.py
@@ -52,7 +52,7 @@ class TestWebsiteIndexer(TestCase):
         eq_(doc['description'], [unicode(self.obj.description)])
         eq_(doc['description_translations'], [{
             'lang': u'en-US', 'string': unicode(self.obj.description)}])
-        eq_(doc['description_english'], [unicode(self.obj.description)])
+        eq_(doc['description_l10n_english'], [unicode(self.obj.description)])
         eq_(doc['default_locale'], self.obj.default_locale)
         eq_(doc['icon_hash'], self.obj.icon_hash)
         eq_(doc['icon_type'], self.obj.icon_type)
@@ -68,7 +68,7 @@ class TestWebsiteIndexer(TestCase):
         eq_(doc['title'], [unicode(self.obj.title)])
         eq_(doc['title_translations'], [{
             'lang': u'en-US', 'string': unicode(self.obj.title)}])
-        eq_(doc['title_english'], [unicode(self.obj.title)])
+        eq_(doc['title_l10n_english'], [unicode(self.obj.title)])
         eq_(doc['device'], self.obj.devices)
         eq_(doc['region_exclusions'], self.obj.region_exclusions)
 
@@ -85,8 +85,8 @@ class TestWebsiteIndexer(TestCase):
         eq_(sorted(doc['title_translations']),
             [{'lang': 'en-US', 'string': title['en-US']},
              {'lang': 'fr', 'string': title['fr']}])
-        eq_(doc['title_english'], [title['en-US']])
-        eq_(doc['title_french'], [title['fr']])
+        eq_(doc['title_l10n_english'], [title['en-US']])
+        eq_(doc['title_l10n_french'], [title['fr']])
 
     def test_installs_to_popularity(self):
         self.obj = website_factory()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1127144

To keep the `hidden_fields` property manageable, I had to use wildcards and change the name of the analyzer-specific variants of the translated fields, so we'll need a reindex, but I *think* it should still be ok to use this code with an old index, worst case scenario some search results will be missing some specific results for the duration of the reindex.

