### PR TITLE
Website model/API changes needed for phase 0 (bug 1162325)

### DIFF
--- a/migrations/907-websites-model-adjustments.sql
+++ b/migrations/907-websites-model-adjustments.sql
@@ -1,0 +1,17 @@
+-- Drop url, we'll replace it with a non-translated field. We don't care about existing data at this point.
+ALTER TABLE `websites_website` DROP FOREIGN KEY `url_refs_id_7f415bd0`;
+ALTER TABLE `websites_website` DROP COLUMN `url`;
+
+-- Drop short_title, replace with short_name.
+ALTER TABLE `websites_website` DROP FOREIGN KEY `short_title_refs_id_7f415bd0`;
+ALTER TABLE `websites_website` DROP COLUMN `short_title`;
+
+-- Add optional mobile_url and new url column.
+ALTER TABLE `websites_website` ADD COLUMN `mobile_url` varchar(255);
+ALTER TABLE `websites_website` ADD COLUMN `url` varchar(255);
+
+-- Add new name and short_name columns and indexes. Those are translated fields.
+ALTER TABLE `websites_website` ADD COLUMN `name` integer unsigned REFERENCES `translations` (`id`);
+ALTER TABLE `websites_website` ADD COLUMN `short_name` integer unsigned REFERENCES `translations` (`id`);
+CREATE INDEX `websites_website_name` ON `websites_website` (`name`);
+CREATE INDEX `websites_website_short_name` ON `websites_website` (`short_name`);

--- a/mkt/search/tests/test_views.py
+++ b/mkt/search/tests/test_views.py
@@ -1271,6 +1271,8 @@ class TestMultiSearchView(RestOAuth, ESTestCase):
         self.webapp.update(categories=[self.shared_category, 'business'])
         self.webapp.popularity.create(region=0, value=11.0)
         self.website = website_factory(
+            name='something something webcube',
+            short_name='something',
             title='title something something webcube',
             description={'en-US': 'desc something something webcube',
                          'fr': 'desc something something webcube fr'},
@@ -1348,8 +1350,7 @@ class TestMultiSearchView(RestOAuth, ESTestCase):
         objs = res.json['objects']
         eq_(res.json['meta']['total_count'], 2)
         eq_(len(objs), 2)
-        # Website should be first because it's more relevant (exact match) than
-        # the Webapp.
+        # Website should be first because it's more relevant than the Webapp.
         eq_(objs[0]['doc_type'], 'website')
         eq_(objs[0]['id'], self.website.pk)
         eq_(objs[0]['title'], self.website.title)

--- a/mkt/websites/models.py
+++ b/mkt/websites/models.py
@@ -17,9 +17,11 @@ from mkt.websites.indexers import WebsiteIndexer
 class Website(ModelBase):
     default_locale = models.CharField(max_length=10,
                                       default=settings.LANGUAGE_CODE)
-    url = TranslatedField()
+    url = models.URLField(max_length=255, blank=True, null=True)
+    mobile_url = models.URLField(max_length=255, blank=True, null=True)
     title = TranslatedField()
-    short_title = TranslatedField()
+    name = TranslatedField()
+    short_name = TranslatedField()
     description = TranslatedField()
     keywords = models.ManyToManyField(Tag)
     region_exclusions = JSONField(default=None)

--- a/mkt/websites/serializers.py
+++ b/mkt/websites/serializers.py
@@ -11,9 +11,9 @@ class WebsiteSerializer(serializers.ModelSerializer):
     description = TranslationSerializerField()
     device_types = ListField(serializers.CharField(), source='device_names')
     id = serializers.IntegerField(source='pk')
-    short_title = TranslationSerializerField()
+    short_name = TranslationSerializerField()
+    name = TranslationSerializerField()
     title = TranslationSerializerField()
-    url = TranslationSerializerField()  # FIXME: add extra URL validation.
 
     # FIXME: keywords, regions, icons... try to stay compatible with Webapp API
     # as much as possible.
@@ -21,7 +21,7 @@ class WebsiteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Website
         fields = ['categories', 'description', 'device_types', 'id',
-                  'short_title', 'title', 'url']
+                  'mobile_url', 'name', 'short_name', 'title', 'url']
 
 
 class ESWebsiteSerializer(BaseESSerializer, WebsiteSerializer):
@@ -29,8 +29,8 @@ class ESWebsiteSerializer(BaseESSerializer, WebsiteSerializer):
         """Create a fake instance of Website from ES data."""
         obj = Website(id=data['id'])
 
-        # Set base attributes on the fake instance using the data from ES.
-        self._attach_fields(obj, data, ('default_locale',))
+        # Set basic attributes on the fake instance using the data from ES.
+        self._attach_fields(obj, data, ('default_locale', 'url'))
 
         # Set attributes with names that don't exactly match the one on the
         # model.
@@ -40,7 +40,7 @@ class ESWebsiteSerializer(BaseESSerializer, WebsiteSerializer):
         # Attach translations for all translated attributes. obj.default_locale
         # should be set first for this to work.
         self._attach_translations(
-            obj, data, ('url', 'description', 'short_title', 'title'))
+            obj, data, ('description', 'name', 'short_name', 'title'))
 
         # Some methods might need the raw data from ES, put it on obj.
         obj.es_data = data
@@ -49,7 +49,6 @@ class ESWebsiteSerializer(BaseESSerializer, WebsiteSerializer):
 
 
 class ReviewerESWebsiteSerializer(ESWebsiteSerializer):
-    class Meta:
+    class Meta(ESWebsiteSerializer.Meta):
         model = Website
-        fields = ['categories', 'description', 'device_types', 'id',
-                  'short_title', 'status', 'title', 'url']
+        fields = ESWebsiteSerializer.Meta.fields + ['status']

--- a/mkt/websites/tests/test_views.py
+++ b/mkt/websites/tests/test_views.py
@@ -53,10 +53,12 @@ class TestWebsiteESView(RestOAuth, ESTestCase):
         data = response.json['objects'][0]
         eq_(data['description'], {'en-US': self.website.description})
         eq_(data['title'], {'en-US': self.website.title})
-        eq_(data['short_title'], {'en-US': self.website.short_title})
-        eq_(data['url'], {'en-US': self.website.url})
+        eq_(data['name'], {'en-US': self.website.name})
+        eq_(data['short_name'], {'en-US': self.website.short_name})
+        eq_(data['url'], self.website.url)
         eq_(data['device_types'], ['firefoxos', 'desktop'])
         eq_(data['categories'], ['books', 'sports'])
+        # FIXME: regions, keywords, icon
 
     def test_list(self):
         self.website2 = website_factory(url='http://www.lol.com/')
@@ -157,11 +159,12 @@ class TestWebsiteView(TestCase):
         data = response.json['objects'][0]
         eq_(data['description'], {'en-US': self.website.description})
         eq_(data['title'], {'en-US': self.website.title})
-        eq_(data['short_title'], {'en-US': self.website.short_title})
-        eq_(data['url'], {'en-US': self.website.url})
+        eq_(data['name'], {'en-US': self.website.name})
+        eq_(data['short_name'], {'en-US': self.website.short_name})
+        eq_(data['url'], self.website.url)
         eq_(data['device_types'], ['firefoxos', 'desktop'])
         eq_(data['categories'], ['books', 'sports'])
-        # FIXME: regions, keywords
+        # FIXME: regions, keywords, icon
 
     def test_list(self):
         self.website2 = website_factory()

--- a/mkt/websites/utils.py
+++ b/mkt/websites/utils.py
@@ -20,11 +20,12 @@ def rand_text():
 def website_factory(**kwargs):
     text = rand_text()
     data = {
-        'url': 'http://%s.example.com' % text,
-        'short_title': text[:10],
-        'title': 'Title %s' % text,
-        'description': 'Description for %s' % text,
+        'description': 'Description for %s' % text.capitalize(),
+        'name': text.capitalize(),
+        'short_name': text[:10].capitalize(),
         'status': STATUS_PUBLIC,
+        'title': 'Title for %s' % text.capitalize(),
+        'url': 'http://%s.example.com' % text,
     }
     data.update(kwargs)
     return Website.objects.create(**data)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1162325

- `name` is introduced, it's the main field to use to display a website.
- `short_name` replaces `short_title`. 
- `title` is kept, but is not really meant to be exposed to the consumer pages. It's helpful to increase a website relevancy though.
- `mobile_url` is added for websites that have a mobile-specific version at a different URL.