### PR TITLE
Set device_types in website API (bug 1173048)

### DIFF
--- a/mkt/websites/models.py
+++ b/mkt/websites/models.py
@@ -101,6 +101,10 @@ class Website(ModelBase):
         # devices.
         return [device.id for device in DEVICE_TYPE_LIST]
 
+    @property
+    def device_names(self):
+        return [device.api_name for device in DEVICE_TYPE_LIST]
+
     def is_dummy_content_for_qa(self):
         """
         Returns whether this app is a dummy app used for testing only or not.

--- a/mkt/websites/serializers.py
+++ b/mkt/websites/serializers.py
@@ -11,6 +11,7 @@ from mkt.websites.models import Website
 class WebsiteSerializer(serializers.ModelSerializer):
     categories = ListField(serializers.CharField())
     description = TranslationSerializerField()
+    device_types = ListField(serializers.CharField(), source='device_names')
     id = serializers.IntegerField(source='pk')
     short_name = TranslationSerializerField()
     keywords = serializers.SerializerMethodField('get_keywords')
@@ -20,8 +21,9 @@ class WebsiteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Website
-        fields = ['categories', 'description', 'icons', 'id', 'keywords',
-                  'mobile_url', 'name', 'short_name', 'title', 'url']
+        fields = ['categories', 'description', 'device_types', 'icons', 'id',
+                  'keywords', 'mobile_url', 'name', 'short_name', 'title',
+                  'url']
 
     def get_icons(self, obj):
         return dict([(icon_size, obj.get_icon_url(icon_size))


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1173048

r? @diox 

Sample output from my local zamboni:

```
{
    "categories": {},
    "description": null,
    "device_types": [
        "desktop",
        "android-mobile",
        "android-tablet",
        "firefoxos"
    ],
    "icons": {
        "128": "/tmp/img/hub/default-128.png",
        "32": "/tmp/img/hub/default-32.png",
        "48": "/tmp/img/hub/default-48.png",
        "64": "/tmp/img/hub/default-64.png"
    },
    "id": 2,
    "keywords": [],
    "mobile_url": null,
    "name": {
        "en-US": "Bar"
    },
    "short_name": null,
    "title": null,
    "url": "http://google.com"
}
