### PR TITLE
Put ETag with the minifest in the cache to improve performance (bug 1177530)

### DIFF
--- a/mkt/detail/views.py
+++ b/mkt/detail/views.py
@@ -1,5 +1,3 @@
-import hashlib
-
 from django import http
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import etag
@@ -9,14 +7,10 @@ import commonware.log
 import mkt
 from mkt.constants import MANIFEST_CONTENT_TYPE
 from mkt.site.decorators import allow_cross_site_request
-from mkt.webapps.decorators import app_view_factory
 from mkt.webapps.models import Webapp
 
 
 log = commonware.log.getLogger('z.detail')
-
-
-addon_all_view = app_view_factory(qs=Webapp.objects.all)
 
 
 @allow_cross_site_request
@@ -31,22 +25,12 @@ def manifest(request, uuid):
                                 mkt.STATUS_BLOCKED]
     is_owner = addon.authors.filter(pk=request.user.pk).exists()
     is_owner_avail = addon.status == mkt.STATUS_APPROVED
-    package_etag = hashlib.sha256()
 
     if (addon.is_packaged and
         not addon.disabled_by_user and
             (is_avail or (is_owner_avail and is_owner))):
 
-        manifest_content = addon.get_cached_manifest()
-        package_etag.update(manifest_content)
-
-        if addon.is_packaged:
-            # Update the hash with the content of the package itself.
-            package_file = addon.get_latest_file()
-            if package_file:
-                package_etag.update(package_file.hash)
-
-        manifest_etag = package_etag.hexdigest()
+        manifest_content, manifest_etag = addon.get_cached_manifest()
 
         @etag(lambda r, a: manifest_etag)
         def _inner_view(request, addon):

--- a/mkt/langpacks/models.py
+++ b/mkt/langpacks/models.py
@@ -98,8 +98,8 @@ class LangPack(ModelBase):
         return self.download_url
 
     def get_minifest_contents(self, force=False):
-        """Return the "mini" manifest for this langpack, caching it in the
-        process.
+        """Return the "mini" manifest + etag for this langpack, caching it in
+        the process.
 
         Call this with `force=True` whenever we need to update the cached
         version of this manifest, e.g., when a new version of the langpack

--- a/mkt/langpacks/tests/test_models.py
+++ b/mkt/langpacks/tests/test_models.py
@@ -50,7 +50,7 @@ class TestLangPackBasic(TestCase):
             version='0.3',
             manifest=json.dumps(fake_manifest))
         storage_mock.size.return_value = 666
-        minifest_contents = json.loads(langpack.get_minifest_contents())
+        minifest_contents = json.loads(langpack.get_minifest_contents()[0])
 
         eq_(minifest_contents,
             {'version': '0.3',
@@ -64,7 +64,7 @@ class TestLangPackBasic(TestCase):
         langpack, minifest_contents = self.test_get_minifest_contents()
         langpack.update(manifest='{}')
         # Because of caching, get_minifest_contents should not have changed.
-        new_minifest_contents = json.loads(langpack.get_minifest_contents())
+        new_minifest_contents = json.loads(langpack.get_minifest_contents()[0])
         eq_(minifest_contents, new_minifest_contents)
 
     def test_language_choices_and_display(self):

--- a/mkt/langpacks/views.py
+++ b/mkt/langpacks/views.py
@@ -90,13 +90,10 @@ def manifest(request, uuid):
     langpack = get_object_or_404(LangPack, pk=uuid_hex)
 
     if langpack.active or action_allowed(request, 'LangPacks', '%'):
-        manifest_contents = langpack.get_minifest_contents()
-        langpack_etag = hashlib.sha256()
-        langpack_etag.update(manifest_contents)
-        langpack_etag.update(unicode(langpack.file_version))
+        manifest_contents, langpack_etag = langpack.get_minifest_contents()
 
         @condition(last_modified_func=lambda request: langpack.modified,
-                   etag_func=lambda request: langpack_etag.hexdigest())
+                   etag_func=lambda request: langpack_etag)
         def _inner_view(request):
             return HttpResponse(manifest_contents,
                                 content_type=MANIFEST_CONTENT_TYPE)

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -1738,7 +1738,8 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
 
     def get_cached_manifest(self, force=False):
         """
-        Build, cache and return the "mini" manifest for this app.
+        Build, cache and return the "mini" manifest + corresponding etag
+        for this app.
 
         Call this with `force=True` whenever we need to update the cached
         version of this manifest, e.g., when a new version of the packaged app

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -1767,7 +1767,7 @@ class TestPackagedManifest(BasePackagedAppTest):
         self.setup_files()
         manifest = self._get_manifest_json()
 
-        data = json.loads(webapp.get_cached_manifest(self.file))
+        data = json.loads(webapp.get_cached_manifest(self.file)[0])
         eq_(data['name'], webapp.name)
         eq_(data['version'], webapp.current_version.version)
         eq_(data['size'], self.file.size)

--- a/mkt/webapps/tests/test_utils_.py
+++ b/mkt/webapps/tests/test_utils_.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 from django.core.cache import cache
@@ -48,41 +49,52 @@ class TestCachedMinifest(TestCase):
         self.webapp = Webapp.objects.get(pk=337141)
 
     @patch('mkt.webapps.utils.storage')
+    def test_etag(self, storage_mock):
+        storage_mock.size.return_value = 999
+        manifest, etag = get_cached_minifest(self.webapp)
+
+        expected_etag = hashlib.sha256()
+        expected_etag.update(manifest)
+        expected_etag.update(self.webapp.get_latest_file().hash)
+        eq_(etag, expected_etag.hexdigest())
+
+    @patch('mkt.webapps.utils.storage')
     def test_get_cached_minifest_caching_force(self, storage_mock):
         storage_mock.size.return_value = 999
-        minifest = json.loads(get_cached_minifest(self.webapp))
+        minifest = json.loads(get_cached_minifest(self.webapp)[0])
         eq_(minifest['size'], 999)
 
         # Change the size, the minifest should be updated because we are
         # passing force=True.
         storage_mock.size.return_value = 666
-        new_minifest = json.loads(get_cached_minifest(self.webapp, force=True))
+        new_minifest = json.loads(
+            get_cached_minifest(self.webapp, force=True)[0])
         ok_(new_minifest != minifest)
         eq_(new_minifest['size'], 666)
 
     @patch('mkt.webapps.utils.storage')
     def test_get_cached_minifest_caching(self, storage_mock):
         storage_mock.size.return_value = 999
-        minifest = json.loads(get_cached_minifest(self.webapp))
+        minifest = json.loads(get_cached_minifest(self.webapp)[0])
         eq_(minifest['size'], 999)
 
         # Change the size, the minifest should stay the same thanks to caching.
         storage_mock.size.return_value = 666
-        new_minifest = json.loads(get_cached_minifest(self.webapp))
+        new_minifest = json.loads(get_cached_minifest(self.webapp)[0])
         eq_(new_minifest, minifest)
 
     @patch('mkt.webapps.utils.storage')
     def test_caching_key_differs_between_models(self, storage_mock):
         storage_mock.size.return_value = 999
 
-        ok_(not cache.get('webapp:337141:manifest'))
-        get_cached_minifest(self.webapp)
+        ok_(not cache.get('1:webapp:337141:manifest'))
+        get_cached_minifest(self.webapp)  # Build the cache for the webapp.
 
         ok_(not cache.get(
-            'langpack:12345678123456781234567812345678:manifest'))
+            '1:langpack:12345678123456781234567812345678:manifest'))
         langpack = LangPack(pk='12345678123456781234567812345678',
                             manifest='{}')
-        get_cached_minifest(langpack)
+        get_cached_minifest(langpack)  # Build the cache for the langpack.
 
-        ok_(cache.get('webapp:337141:manifest'))
-        ok_(cache.get('langpack:12345678123456781234567812345678:manifest'))
+        ok_(cache.get('1:webapp:337141:manifest'))
+        ok_(cache.get('1:langpack:12345678123456781234567812345678:manifest'))


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1177530

This should remove the query to fetch the file when we are serving the manifest from the cache.