### PR TITLE
Add API to fetch the list of apps that require OpenMobile ACL feature (bug 1181575)

### DIFF
--- a/mkt/api/v2/urls.py
+++ b/mkt/api/v2/urls.py
@@ -12,7 +12,8 @@ from mkt.langpacks.views import LangPackViewSet
 from mkt.operators.views import OperatorPermissionViewSet
 from mkt.recommendations.views import RecommendationView
 from mkt.search.views import (MultiSearchView, NonPublicSearchView,
-                              NoRegionSearchView, RocketbarViewV2)
+                              NoRegionSearchView, OpenMobileACLSearchView,
+                              RocketbarViewV2)
 from mkt.websites.views import (WebsiteMetadataScraperView, WebsiteSearchView,
                                 WebsiteView)
 
@@ -64,6 +65,9 @@ urlpatterns = patterns(
     url(r'^apps/search/no-region/$',
         NoRegionSearchView.as_view(),
         name='no-region-search-api'),
+    url(r'^apps/search/openmobile_acl/$',
+        OpenMobileACLSearchView.as_view(),
+        name='openmobile_acl-search-api'),
 
     url(r'^comm/app/%s' % mkt.APP_SLUG,
         CommAppListView.as_view({'get': 'list'}), name='comm-app-list'),

--- a/mkt/search/filters.py
+++ b/mkt/search/filters.py
@@ -335,3 +335,13 @@ class SortingFilter(BaseFilterBackend):
             return queryset.sort(*order_by)
 
         return queryset
+
+
+class OpenMobileACLFilter(BaseFilterBackend):
+    """
+    A django-rest-framework filter backend that finds apps using openmobile_acl
+    feature flag.
+    """
+    def filter_queryset(self, request, queryset, view):
+        return queryset.filter(
+            Bool(must=[F('term', **{'features.has_openmobileacl': True})]))

--- a/mkt/search/tests/test_filters.py
+++ b/mkt/search/tests/test_filters.py
@@ -11,9 +11,10 @@ from django.test.utils import override_settings
 import mkt
 from mkt.constants.applications import DEVICE_CHOICES_IDS
 from mkt.constants.features import FeatureProfile
-from mkt.search.filters import (DeviceTypeFilter, ProfileFilter,
-                                PublicAppsFilter, PublicSearchFormFilter,
-                                RegionFilter, SearchQueryFilter, SortingFilter,
+from mkt.search.filters import (DeviceTypeFilter, OpenMobileACLFilter,
+                                ProfileFilter, PublicAppsFilter,
+                                PublicSearchFormFilter, RegionFilter,
+                                SearchQueryFilter, SortingFilter,
                                 ValidAppsFilter)
 from mkt.search.forms import TARAKO_CATEGORIES_MAPPING
 from mkt.search.views import SearchView
@@ -403,3 +404,12 @@ class TestCombinedFilter(FilterTestsBase):
             in query['function_score']['functions'])
         ok_({'match': {'name_l10n_english': {'boost': 2.5, 'query': u'test'}}}
             in query['function_score']['query']['bool']['should'])
+
+
+class TestOpenMobileACLFilter(FilterTestsBase):
+    filter_classes = [OpenMobileACLFilter]
+
+    def test_feature_acl(self):
+        qs = self._filter(self.req)
+        eq_(qs['query']['filtered']['filter']['bool']['must'],
+            [{'term': {'features.has_openmobileacl': True}}])


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1181575

This returns a list of manifest URLs, that fireplace can then directly compare
to `require('apps').getInstalled()` when handling the ACL install activity.