### PR TITLE
drop unique indices on website submission

### DIFF
--- a/migrations/923-website-submission-no-unique.sql
+++ b/migrations/923-website-submission-no-unique.sql
@@ -1,0 +1,12 @@
+-- Removes unique keys from columns.
+-- Foreign key constraints prevent us from dropping the index outright.
+-- This creates new non-unique indices, and then drops the old unique ones
+ALTER TABLE `websites_websitesubmission` DROP INDEX works_well;
+
+ALTER TABLE `websites_websitesubmission` ADD INDEX (description);
+ALTER TABLE `websites_websitesubmission` ADD INDEX (name);
+ALTER TABLE `websites_websitesubmission` ADD INDEX (submitter_id);
+
+DROP INDEX description on `websites_websitesubmission`;
+DROP INDEX name on `websites_websitesubmission`;
+DROP INDEX submitter_id on `websites_websitesubmission`;


### PR DESCRIPTION
Had to create an new non-unique index for the foreign key constraints, then drop the unique ones.