### PR TITLE
don't analyze webapp/website tags in ES (e.g., for "featured-game")

### DIFF
--- a/mkt/search/filters.py
+++ b/mkt/search/filters.py
@@ -89,7 +89,7 @@ class SearchQueryFilter(BaseFilterBackend):
                                     'analyzer': desc_analyzer}}))
 
         # Add searches on tag field.
-        should.append(query.Match(tags={'query': q}))
+        should.append(query.Term(tags={'value': q}))
         if ' ' not in q:
             should.append(query.Fuzzy(tags={'value': q, 'prefix_length': 1}))
 

--- a/mkt/webapps/indexers.py
+++ b/mkt/webapps/indexers.py
@@ -191,7 +191,7 @@ class WebappIndexer(BaseIndexer):
                                       'type': 'date', 'doc_values': True},
                     'status': {'type': 'byte'},
                     'supported_locales': cls.string_not_analyzed(),
-                    'tags': {'type': 'string', 'analyzer': 'simple'},
+                    'tags': cls.string_not_analyzed(),
                     'upsell': {
                         'type': 'object',
                         'properties': {

--- a/mkt/websites/indexers.py
+++ b/mkt/websites/indexers.py
@@ -92,7 +92,7 @@ class WebsiteIndexer(BaseIndexer):
                     'short_name': {'type': 'string',
                                    'analyzer': 'default_icu'},
                     'status': {'type': 'byte'},
-                    'tags': {'type': 'string', 'analyzer': 'simple'},
+                    'tags': cls.string_not_analyzed(),
                     'title': {
                         'type': 'string',
                         'analyzer': 'default_icu',


### PR DESCRIPTION
Tags with dashes in the text weren't matching when doing ES queries on tag (bool must term = ```featured-game``` on apps with tag indexed as ```["featured-game"]```)