### PR TITLE
Don't load all Price currencies everytime we load a Webapp (bug 1089848)

### DIFF
--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -394,18 +394,6 @@ class ESAppSerializer(BaseESSerializer, AppSerializer):
         # Remove fields that we don't have in ES at the moment.
         self.fields.pop('upsold', None)
 
-    def _attach_payments_info(self, obj):
-        try:
-            # When fetching Webapp from the database, optimizations are made
-            # with attach_prices() etc. But we can't do that with ES, so we
-            # have to manually select_related() the price when fetching the
-            # AddonPremium object to do fewer queries. The `premium` property
-            # will use `_premium` if it exists.
-            obj._premium = (
-                AddonPremium.objects.select_related('price').get(addon=obj))
-        except AddonPremium.DoesNotExist:
-            obj._premium = None
-
     def fake_object(self, data):
         """Create a fake instance of Webapp and related models from ES data."""
         is_packaged = data['app_type'] != mkt.ADDON_WEBAPP_HOSTED
@@ -468,9 +456,10 @@ class ESAppSerializer(BaseESSerializer, AppSerializer):
         # regions stored in ES instead of making SQL queries.
         obj.get_excluded_region_ids = lambda: data['region_exclusions']
 
-        # Set up payments stuff to avoid extra queries.
+        # Set up payments stuff to avoid extra queries later (we'll still make
+        # some, because price info is not in ES).
         if obj.is_premium():
-            self._attach_payments_info(obj)
+            Webapp.attach_premiums([obj])
 
         # Some methods below will need the raw data from ES, put it on obj.
         obj.es_data = data


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1089848

This already happens once per worker thread, since `Price.get_price_currency()` calls `Price.transformer([])` if necessary. It could be useful to get rid of that too, but let's start slow first.