### PR TITLE
improve lookup tool urls

### DIFF
--- a/mkt/lookup/tests/test_views.py
+++ b/mkt/lookup/tests/test_views.py
@@ -774,6 +774,10 @@ class TestAppSummary(AppSummaryTest):
         super(TestAppSummary, self).setUp()
         self._setUp()
 
+    def test_slug(self):
+        self.url = reverse('lookup.app_summary', args=[self.app.app_slug])
+        self.summary()
+
     def test_app_deleted(self):
         self.app.delete()
         self.summary()

--- a/mkt/lookup/urls.py
+++ b/mkt/lookup/urls.py
@@ -6,7 +6,7 @@ from . import views
 # These views all start with user ID.
 user_patterns = patterns(
     '',
-    url(r'^summary$', views.user_summary,
+    url(r'^$', views.user_summary,
         name='lookup.user_summary'),
     url(r'^purchases$', views.user_purchases,
         name='lookup.user_purchases'),
@@ -20,7 +20,7 @@ user_patterns = patterns(
 # These views all start with app/addon ID.
 app_patterns = patterns(
     '',
-    url(r'^summary$', views.app_summary,
+    url(r'^$', views.app_summary,
         name='lookup.app_summary'),
     url(r'^activity$', views.app_activity,
         name='lookup.app_activity'),
@@ -30,7 +30,7 @@ app_patterns = patterns(
 # These views all start with website/<ID>.
 website_patterns = patterns(
     '',
-    url(r'^summary$', views.website_summary,
+    url(r'^$', views.website_summary,
         name='lookup.website_summary'),
     url(r'^edit$', views.website_edit,
         name='lookup.website_edit'),
@@ -40,10 +40,10 @@ website_patterns = patterns(
 # These views all start with transaction ID.
 transaction_patterns = patterns(
     '',
+    url(r'^$', views.transaction_summary,
+        name='lookup.transaction_summary'),
     url(r'^refund$', views.transaction_refund,
         name='lookup.transaction_refund'),
-    url(r'^summary$', views.transaction_summary,
-        name='lookup.transaction_summary'),
 )
 
 

--- a/mkt/lookup/views.py
+++ b/mkt/lookup/views.py
@@ -260,7 +260,11 @@ def transaction_refund(request, tx_uuid):
 
 @permission_required([('AppLookup', 'View')])
 def app_summary(request, addon_id):
-    app = get_object_or_404(Webapp.with_deleted, pk=addon_id)
+    if unicode(addon_id).isdigit():
+        query = {'pk': addon_id}
+    else:
+        query = {'app_slug': addon_id}
+    app = get_object_or_404(Webapp.with_deleted, **query)
 
     if request.FILES:
         promo_img_form = PromoImgForm(request.POST, request.FILES)


### PR DESCRIPTION
- Alias ```/lookup/<obj_type>/<obj_id>/summary``` to ```/lookup/<obj_type>/<obj_id>```.
- Allow app slugs for app URLs rather than just numerical app IDs.
