### PR TITLE
Explicitely floor() values in FeaturesBitField (bug 1172487)

### DIFF
--- a/mkt/constants/features.py
+++ b/mkt/constants/features.py
@@ -376,12 +376,12 @@ class FeaturesBitField(object):
             self.values = [0] * int(math.ceil(self.size / 8.0))
 
     def get(self, i):
-        index = int(math.ceil(i / 8))
+        index = int(math.floor(i / 8.0))
         bit = i % 8
         return (self.values[index] & (1 << bit)) != 0
 
     def set(self, i, value):
-        index = int(math.ceil(i / 8))
+        index = int(math.floor(i / 8.0))
         bit = i % 8
         if value:
             self.values[index] |= 1 << bit

--- a/mkt/constants/tests/test_features.py
+++ b/mkt/constants/tests/test_features.py
@@ -165,3 +165,15 @@ class TestFeaturesBitField(mkt.site.tests.TestCase):
         bitfield = FeaturesBitField.from_base64('gQE=', len(self.test_data))
         eq_(bitfield.to_list(), self.test_data)
         eq_(bitfield.to_base64(), 'gQE=')
+
+    def test_from_base64_full_of_truth(self):
+        bitfield = FeaturesBitField.from_base64('/wE=', len(self.test_data))
+        eq_(bitfield.to_list(), [True] * 9)
+        eq_(bitfield.values, [255, 1])
+        eq_(bitfield.to_base64(), '/wE=')
+
+    def test_from_base64_full_of_lies(self):
+        bitfield = FeaturesBitField.from_base64('AAA=', len(self.test_data))
+        eq_(bitfield.to_list(), [False] * 9)
+        eq_(bitfield.values, [0, 0])
+        eq_(bitfield.to_base64(), 'AAA=')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1172487

Because the result of an integer division in python *2* is already floored, the math.ceil() call didn't have any effect, but it's wrong, our indexes begin at 0, so I removed it for clarity.

Also add a couple dumb tests regarding base64 conversion.