### PR TITLE
Update babel for better price localisation (bug 1185250)

### DIFF
--- a/mkt/prices/models.py
+++ b/mkt/prices/models.py
@@ -41,17 +41,7 @@ def default_providers():
 def price_locale(price, currency):
     lang = translation.get_language()
     locale = get_locale_from_lang(lang)
-    pricestr = numbers.format_currency(price, currency, locale=locale)
-    if currency == 'EUR':
-        # See bug 865358. EU style guide
-        # (http://publications.europa.eu/code/en/en-370303.htm#position)
-        # disagrees with Unicode CLDR on placement of Euro symbol.
-        bare = pricestr.strip(u'\xa0\u20ac')
-        if lang.startswith(('en', 'ga', 'lv', 'mt')):
-            return u'\u20ac' + bare
-        else:
-            return bare + u'\xa0\u20ac'
-    return pricestr
+    return numbers.format_currency(price, currency, locale=locale)
 
 
 def price_key(data):

--- a/mkt/prices/tests/test_models.py
+++ b/mkt/prices/tests/test_models.py
@@ -115,13 +115,20 @@ class TestPrice(mkt.site.tests.TestCase):
         price = self.make_price('0.00')
         eq_(price.get_price_locale(regions=[USA.id]), '$0.00')
 
-    def test_euro_placement(self):
+    def test_euro_placement_en(self):
         with self.activate('en-us'):
             eq_(Price.objects.get(pk=2).get_price_locale(regions=[ESP.id]),
                 u'\u20ac0.50')
+
+    def test_euro_placement_es(self):
         with self.activate('es'):
             eq_(Price.objects.get(pk=2).get_price_locale(regions=[ESP.id]),
                 u'0,50\xa0\u20ac')
+
+    def test_euro_placement_nl(self):
+        with self.activate('nl'):
+            eq_(Price.objects.get(pk=2).get_price_locale(regions=[ESP.id]),
+                u'\u20ac\xa00,50')
 
     def test_prices(self):
         currencies = Price.objects.get(pk=1).prices()

--- a/mkt/reviewers/tests/test_views.py
+++ b/mkt/reviewers/tests/test_views.py
@@ -4306,7 +4306,7 @@ class TestModerateLog(ModerateLogTest, AccessMixin):
 
         r = self.client.get(self.url, dict(end='2011-01-01'))
         eq_(r.status_code, 200)
-        eq_(pq(r.content)('tbody td').eq(0).text(), 'Jan 1, 2011 12:00:00 AM')
+        eq_(pq(r.content)('tbody td').eq(0).text(), 'Jan 1, 2011, 12:00:00 AM')
 
     def test_action_filter(self):
         """

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,7 +6,7 @@ amqp==1.4.6
 anyjson==0.3.3
 # argparse is required by app-validator, translate-toolkit, curling, receipts
 argparse==1.2.1
-babel==0.9.6
+babel==2.0
 basket-client==0.3.7
 # billiard is required by celery
 billiard==3.3.0.20


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1185250

This is mostly to fix Dutch where the Euro symbol was being placed after the amount instead of in front of it.