### PR TITLE
Add Validation & Submission API for FxOS Add-ons (bug 1196223)

### DIFF
--- a/docs/api/topics/addon_submission.rst
+++ b/docs/api/topics/addon_submission.rst
@@ -18,8 +18,8 @@ Like apps, submitting an addon involves a few steps. The client must be logged
 in for all these steps and the user submitting the addon must have accepted the
 terms of use.
 
-1. :ref:`Validate your addon <validation-post-label>`. The validation will
-   return a validation id.
+1. :ref:`Validate your addon <addon_validation-post-label>`. The validation
+   will return a validation id.
 2. :ref:`Post your app <addon-post-label>` using the validation id.
    This will create an addon and populate the data with the
    contents of the manifest. It will return the current app data.
@@ -27,4 +27,76 @@ terms of use.
 4. :ref:`Ask for a review <addon-status-patch-label>`. All addons need to be
    reviewed, this will add it to the review queue.
 
+.. _addon_validation:
+
+Addon Validation
+================
+
+.. note:: The validation API does not require you to be authenticated, however
+    you cannot create addons from those validations. To validate and then
+    submit an addon you must be authenticated with the same account for both
+    steps.
+
+.. _addon_validation-post-label:
+
+.. http:post:: /api/v2/extensions/validation/
+
+    **Request**
+
+    The zip file containting your add-on should be sent as the POST data
+    directly. The ``Content-Type`` header *must* to be set to
+    ``application/zip`` and the ``Content-Disposition`` header *must* be set to
+    ``form-data; name="binary_data"; filename="extension.zip"``
+
+    **Response**
+
+    Returns a :ref:`validation <addon_validation-response-label>` result.
+
+    :status 201: successfully created, processed.
+    :status 202: successfully created, still processing.
+
+.. _addon_validation-response-label:
+
+.. http:get:: /api/v2/extensions/validation/(string:id)/
+
+    **Response**
+
+    Returns a particular validation. You should poll this API until it returns
+    a result with the ``processed`` property set to ``true`` before moving on
+    with the submission process.
+
+    :param id: the id of the validation.
+    :type id: string
+    :param processed: if the validation has been processed.
+    :type processed: boolean
+    :param valid: if the validation passed.
+    :type valid: boolean
+    :param validation: the resulting validation messages if it failed.
+    :type validation: string
+    :status 200: successfully completed.
+
+
+.. _addon_creation:
+
+Addon Creation
+==============
+
+.. _addon-post-label:
+
+.. http:post:: /api/v2/extensions/extension/
+
+    .. note:: Requires authentication and a successful validation result.
+
+    **Request**
+
+    :param upload: the id of the :ref:`validation result <addon_validation>`
+        for your addon.
+    :type upload: string
+
+    **Response**
+
+    :status: 201 successfully created.
+
+
 To Be Continued...
+

--- a/docs/api/topics/app_submission.rst
+++ b/docs/api/topics/app_submission.rst
@@ -10,7 +10,7 @@ How to submit an app
 Submitting an app involves a few steps. The client must be logged in for all
 these steps and the user submitting the app must have accepted the `terms of use`_.
 
-1. :ref:`Validate your app <validation-post-label>`. The validation will return
+1. :ref:`Validate your app <app_validation-post-label>`. The validation will return
    a validation id.
 2. :ref:`Post your app <app-post-label>` using the validation id.
    This will create an app and populate the data with the

--- a/docs/api/topics/app_validation.rst
+++ b/docs/api/topics/app_validation.rst
@@ -1,13 +1,13 @@
-.. _validation:
+.. _app_validation:
 
-Validation
-==========
+App Validation
+==============
 
 .. note:: The validation does not require you to be authenticated, however you
     cannot create apps from those validations. To validate and then submit an
     app you must be authenticated with the same account for both steps.
 
-.. _validation-post-label:
+.. _app_validation-post-label:
 
 .. http:post:: /api/v2/apps/validation/
 
@@ -45,19 +45,18 @@ Validation
 
     **Response**
 
-    Returns a :ref:`validation <validation-response-label>` result.
+    Returns a :ref:`validation <app_validation-response-label>` result.
 
     :status 201: successfully created, processed.
     :status 202: successfully created, still processing.
 
-.. _validation-response-label:
+.. _app_validation-response-label:
 
 .. http:get:: /api/v2/apps/validation/(string:id)/
 
     **Response**
 
-    Returns a particular validation. You should poll this API to it returns
-    a processed result before moving on with the submission process.
+    Returns a particular validation.
 
     :param id: the id of the validation.
     :type id: string

--- a/mkt/api/tests/test_handlers.py
+++ b/mkt/api/tests/test_handlers.py
@@ -557,6 +557,15 @@ class TestPackagedAppCreateHandler(CreatePackagedHandler):
         app = Webapp.objects.get(app_slug=content['slug'])
         eq_(app.is_packaged, True)
 
+    def test_create_extension_is_refused(self):
+        self.packaged_copy_over(self.file, 'extension.zip')
+        obj = self.create()
+        res = self.client.post(self.list_url,
+                               data=json.dumps({'upload': obj.uuid}))
+        res = self.client.post(self.list_url,
+                               data=json.dumps({'upload': obj.uuid}))
+        eq_(res.status_code, 400)
+
 
 class TestListHandler(CreateHandler, MktPaths):
     fixtures = fixture('user_2519', 'user_999')

--- a/mkt/api/v2/urls.py
+++ b/mkt/api/v2/urls.py
@@ -8,6 +8,7 @@ from mkt.api.base import SubRouterWithFormat
 from mkt.api.v1.urls import urlpatterns as v1_urls
 from mkt.api.views import endpoint_removed
 from mkt.comm.views import CommAppListView, ThreadViewSetV2
+from mkt.extensions.urls import extensions
 from mkt.games.views import DailyGamesView
 from mkt.langpacks.views import LangPackViewSet
 from mkt.operators.views import OperatorPermissionViewSet
@@ -73,6 +74,8 @@ urlpatterns = patterns(
     url(r'^comm/app/%s' % mkt.APP_SLUG,
         CommAppListView.as_view({'get': 'list'}), name='comm-app-list'),
     url(r'^comm/thread', include(comm_thread.urls)),
+
+    url(r'^extensions/', include(extensions.urls)),
 
     url(r'^feed/builder/$', views.FeedBuilderView.as_view(),
         name='feed.builder'),

--- a/mkt/developers/templates/developers/api.html
+++ b/mkt/developers/templates/developers/api.html
@@ -101,7 +101,7 @@ echo '{"{{ settings.DOMAIN }}": {"key": "{{ consumers[0].key }}", "secret": "{{ 
 curling {{ settings.SITE_URL }}/api/v2/account/settings/mine/
 
 # This makes a POST to validate an hosted app:
-curling -d '{"manifest": "http://myapp.testmanifest.com/manifest.webapp"}' {{ settings.SITE_URL }}/api/v2/apps/validation/
+curling -d '{"manifest": "http://myapp.testmanifest.com/manifest.webapp"}' -X POST {{ settings.SITE_URL }}/api/v2/apps/validation/
         </pre>
       </div>
     {% endif %}

--- a/mkt/extensions/models.py
+++ b/mkt/extensions/models.py
@@ -62,7 +62,7 @@ class Extension(ModelBase):
         return os.path.join(self.path_prefix, nfd_str(self.filename))
 
     @classmethod
-    def from_upload(cls, upload, instance=None):
+    def from_upload(cls, upload, user=None, instance=None):
         """Handle creating/editing the Extension instance and saving it to db,
         as well as file operations, from a FileUpload instance. Can throw
         a ValidationError or SigningError, so should always be called within a
@@ -93,8 +93,9 @@ class Extension(ModelBase):
         instance.clean_slug()
         instance.save()
 
-        # Now that the instance has been saved, we can generate a file path,
-        # move the file and set it to PENDING.
+        # Now that the instance has been saved, we can add the author,
+        # generate a file path, move the file and set it to PENDING.
+        instance.authors.add(user)
         instance.handle_file_operations(upload)
         instance.update(status=STATUS_PENDING)
         return instance

--- a/mkt/extensions/serializers.py
+++ b/mkt/extensions/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework.serializers import ModelSerializer
+
+from mkt.api.fields import TranslationSerializerField
+from mkt.extensions.models import Extension
+
+
+class ExtensionSerializer(ModelSerializer):
+    name = TranslationSerializerField()
+
+    class Meta:
+        model = Extension
+        fields = ['id', 'version', 'name', 'slug', 'status']

--- a/mkt/extensions/tests/test_views.py
+++ b/mkt/extensions/tests/test_views.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+import json
+
+from django.core.urlresolvers import reverse
+
+from nose.tools import eq_, ok_
+
+from mkt.api.tests.test_oauth import RestOAuth
+from mkt.constants.base import STATUS_PENDING
+from mkt.extensions.models import Extension
+from mkt.files.models import FileUpload
+from mkt.files.tests.test_models import UploadTest
+from mkt.site.fixtures import fixture
+from mkt.site.storage_utils import private_storage
+from mkt.site.tests import MktPaths
+from mkt.users.models import UserProfile
+
+
+class TestExtensionValidationViewSet(MktPaths, RestOAuth):
+    fixtures = fixture('user_2519')
+
+    def setUp(self):
+        super(TestExtensionValidationViewSet, self).setUp()
+        self.list_url = reverse('api-v2:extension-validation-list')
+        self.user = UserProfile.objects.get(pk=2519)
+
+    def _test_create_success(self, client):
+        headers = {
+            'HTTP_CONTENT_TYPE': 'application/zip',
+            'HTTP_CONTENT_DISPOSITION': 'form-data; name="binary_data"; '
+                                        'filename="foo.zip"'
+        }
+        with open(self.packaged_app_path('extension.zip'), 'rb') as fd:
+            response = client.post(self.list_url, fd.read(),
+                                   content_type='application/zip', **headers)
+
+        eq_(response.status_code, 202)
+        data = response.json
+        upload = FileUpload.objects.get(pk=data['id'])
+        eq_(upload.valid, True)  # We directly set uploads as valid atm.
+        eq_(upload.name, 'foo.zip')
+        ok_(upload.hash.startswith('sha256:58ef3f15dd423c3ab9b0285ac01e692c5'))
+        ok_(upload.path)
+        ok_(private_storage.exists(upload.path))
+        return upload
+
+    def test_create_anonymous(self):
+        upload = self._test_create_success(client=self.anon)
+        eq_(upload.user, None)
+
+    def test_create_logged_in(self):
+        upload = self._test_create_success(client=self.client)
+        eq_(upload.user, self.user)
+
+    def test_create_missing_no_data(self):
+        headers = {
+            'HTTP_CONTENT_TYPE': 'application/zip',
+            'HTTP_CONTENT_DISPOSITION': 'form-data; name="binary_data"; '
+                                        'filename="foo.zip"'
+        }
+        response = self.anon.post(self.list_url,
+                                  content_type='application/zip', **headers)
+        eq_(response.status_code, 400)
+
+    def test_create_missing_content_disposition(self):
+        headers = {
+            'HTTP_CONTENT_TYPE': 'application/zip',
+        }
+        with open(self.packaged_app_path('extension.zip'), 'rb') as fd:
+            response = self.client.post(
+                self.list_url, fd.read(), content_type='application/zip',
+                **headers)
+        eq_(response.status_code, 400)
+
+    def test_create_wrong_type(self):
+        headers = {
+            'HTTP_CONTENT_TYPE': 'application/foobar',
+            'HTTP_CONTENT_DISPOSITION': 'form-data; name="binary_data"; '
+                                        'filename="foo.zip"'
+        }
+        with open(self.packaged_app_path('extension.zip'), 'rb') as fd:
+            response = self.client.post(
+                self.list_url, fd.read(), content_type='application/foobar',
+                **headers)
+        eq_(response.status_code, 400)
+
+    def test_create_invalid_zip(self):
+        headers = {
+            'HTTP_CONTENT_TYPE': 'application/zip',
+            'HTTP_CONTENT_DISPOSITION': 'form-data; name="binary_data"; '
+                                        'filename="foo.zip"'
+        }
+        response = self.client.post(
+            self.list_url, 'XXXXXX', content_type='application/zip', **headers)
+        eq_(response.status_code, 400)
+
+    def test_create_no_manifest_json(self):
+        headers = {
+            'HTTP_CONTENT_TYPE': 'application/zip',
+            'HTTP_CONTENT_DISPOSITION': 'form-data; name="binary_data"; '
+                                        'filename="foo.zip"'
+        }
+        # mozball.zip is an app, not an extension, it has no manifest.json.
+        with open(self.packaged_app_path('mozball.zip'), 'rb') as fd:
+            response = self.client.post(
+                self.list_url, fd.read(), content_type='application/zip',
+                **headers)
+        eq_(response.status_code, 400)
+
+    def test_view_result_anonymous(self):
+        upload = FileUpload.objects.create(valid=True)
+        url = reverse('api-v2:extension-validation-detail',
+                      kwargs={'pk': upload.pk})
+        response = self.anon.get(url)
+        eq_(response.status_code, 200)
+        eq_(response.json['valid'], True)
+
+
+class TestExtensionViewSet(UploadTest, RestOAuth):
+    fixtures = fixture('user_2519', 'user_999')
+
+    def setUp(self):
+        super(TestExtensionViewSet, self).setUp()
+        self.list_url = reverse('api-v2:extension-list')
+        self.user = UserProfile.objects.get(pk=2519)
+
+    def test_create_logged_in(self):
+        upload = self.get_upload(
+            abspath=self.packaged_app_path('extension.zip'), user=self.user)
+        eq_(upload.valid, True)
+        response = self.client.post(self.list_url,
+                                    json.dumps({'upload': upload.pk}))
+        eq_(response.status_code, 201)
+        data = response.json
+        eq_(data['version'], '0.1')
+        eq_(data['name'], {"en-US": u"My Lîttle Extension"})
+        eq_(data['status'], STATUS_PENDING)
+        ok_(data['slug'])
+        eq_(Extension.objects.count(), 1)
+        extension = Extension.objects.get(pk=data['id'])
+        eq_(extension.status, STATUS_PENDING)
+        eq_(list(extension.authors.all()), [self.user])
+
+    def test_create_upload_has_no_user(self):
+        upload = self.get_upload(
+            abspath=self.packaged_app_path('extension.zip'), user=None)
+        response = self.client.post(self.list_url,
+                                    json.dumps({'upload': upload.pk}))
+        eq_(response.status_code, 404)
+
+    def test_create_upload_has_wrong_user(self):
+        second_user = UserProfile.objects.get(pk=999)
+        upload = self.get_upload(
+            abspath=self.packaged_app_path('extension.zip'), user=second_user)
+        response = self.client.post(self.list_url,
+                                    json.dumps({'upload': upload.pk}))
+        eq_(response.status_code, 404)
+
+    def test_invalid_pk(self):
+        upload = self.get_upload(
+            abspath=self.packaged_app_path('extension.zip'), user=self.user)
+        eq_(upload.valid, True)
+        response = self.client.post(self.list_url,
+                                    json.dumps({'upload': upload.pk + 'lol'}))
+        eq_(response.status_code, 404)
+
+    def test_not_validated(self):
+        upload = self.get_upload(
+            abspath=self.packaged_app_path('extension.zip'), user=self.user,
+            validation=json.dumps({'errors': 1}))
+        response = self.client.post(self.list_url,
+                                    json.dumps({'upload': upload.pk}))
+        eq_(response.status_code, 400)
+
+    def test_not_an_addon(self):
+        upload = self.get_upload(
+            abspath=self.packaged_app_path('mozball.zip'), user=self.user)
+        response = self.client.post(self.list_url,
+                                    json.dumps({'upload': upload.pk}))
+        eq_(response.status_code, 400)
+        ok_(u'manifest.json' in response.json['detail'])

--- a/mkt/extensions/urls.py
+++ b/mkt/extensions/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import SimpleRouter
+
+from mkt.extensions.views import ExtensionViewSet, ValidationViewSet
+
+extensions = SimpleRouter()
+extensions.register(r'validation', ValidationViewSet,
+                    base_name='extension-validation')
+extensions.register(r'extension', ExtensionViewSet)

--- a/mkt/extensions/views.py
+++ b/mkt/extensions/views.py
@@ -1,0 +1,111 @@
+import json
+from zipfile import BadZipfile, ZipFile
+
+from django.forms import ValidationError
+from django.http import Http404
+
+import commonware
+from rest_framework import status
+from rest_framework.exceptions import ParseError, PermissionDenied
+from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin
+from rest_framework.parsers import FileUploadParser
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+from tower import ugettext as _
+
+from mkt.api.authentication import (RestAnonymousAuthentication,
+                                    RestOAuthAuthentication,
+                                    RestSharedSecretAuthentication)
+from mkt.api.base import CORSMixin, MarketplaceView
+from mkt.api.authorization import (AllowAppOwner, AllowReadOnlyIfPublic,
+                                   AllowReviewerReadOnly, AnyOf)
+from mkt.extensions.models import Extension
+from mkt.extensions.serializers import ExtensionSerializer
+from mkt.files.models import FileUpload
+from mkt.site.decorators import use_master
+from mkt.submit.views import ValidationViewSet as SubmitValidationViewSet
+
+
+log = commonware.log.getLogger('extensions.views')
+
+
+class ValidationViewSet(SubmitValidationViewSet):
+    # Typical usage:
+    # cat /tmp/extension.zip | curling -X POST --data-binary '@-' \
+    # http://localhost:8000/api/v2/extensions/validation/
+    parser_classes = (FileUploadParser,)
+
+    @use_master
+    def create(self, request, *args, **kwargs):
+        file_obj = request.FILES.get('file', None)
+        if not file_obj:
+            raise ParseError(_('Missing file in request.'))
+
+        self.validate_upload(file_obj)  # Will raise exceptions if appropriate.
+        user = request.user if request.user.is_authenticated() else None
+        upload = FileUpload.from_post(
+            file_obj, file_obj.name, file_obj.size, user=user)
+        # FIXME: spawn validate task that does the real validation checks.
+        # Right now we cheat and just set the upload as valid and processed
+        # directly.
+        upload.update(valid=True)
+        serializer = self.get_serializer(upload)
+        return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
+
+    def validate_upload(self, file_obj):
+        # Do a basic check : is it a zipfile, and does it contain a manifest ?
+        # Be careful to keep this as in-memory zip reading.
+        if file_obj.content_type not in ('application/octet-stream',
+                                         'application/zip'):
+            raise ParseError(
+                _('The file sent has an unsupported content-type'))
+        try:
+            with ZipFile(file_obj, 'r') as z:
+                manifest = z.read('manifest.json')
+        except BadZipfile:
+            raise ParseError(_('The file sent is not a valid ZIP file.'))
+        except KeyError:
+            raise ParseError(
+                _("The archive does not contain a 'manifest.json' file."))
+        try:
+            json.loads(manifest)
+        except ValueError:
+            raise ParseError(
+                _("'manifest.json' in the archive is not a valid JSON file."))
+
+
+class ExtensionViewSet(CORSMixin, MarketplaceView,
+                       CreateModelMixin, RetrieveModelMixin, GenericViewSet):
+    authentication_classes = [RestOAuthAuthentication,
+                              RestSharedSecretAuthentication,
+                              RestAnonymousAuthentication]
+    cors_allowed_methods = ('get', 'put', 'post', 'delete')
+    permission_classes = [AnyOf(AllowAppOwner, AllowReviewerReadOnly,
+                                AllowReadOnlyIfPublic)]
+    queryset = Extension.objects.all()
+    serializer_class = ExtensionSerializer
+
+    def create(self, request, *args, **kwargs):
+        upload_pk = request.DATA.get('upload', '')
+        if not upload_pk:
+            raise ParseError(_('No upload identifier specified.'))
+
+        if not request.user.is_authenticated():
+            raise PermissionDenied(
+                _('You need to be authenticated to perform this action.'))
+
+        try:
+            upload = FileUpload.objects.get(pk=upload_pk, user=request.user)
+        except FileUpload.DoesNotExist:
+            raise Http404(_('No such upload.'))
+        if not upload.valid:
+            raise ParseError(
+                _('The specified upload has not passed validation.'))
+
+        try:
+            obj = Extension.from_upload(upload, user=request.user)
+        except ValidationError as e:
+            raise ParseError(unicode(e))
+        log.info('Extension created: %s' % obj.pk)
+        serializer = self.get_serializer(obj)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1196223

Goes nicely with https://github.com/andymckay/curling/pull/28 (but it's also testable using curl + shared secret, as long as you use `--data-binary` and set the expected headers correctly)