### PR TITLE
User dumps should be using private_storage, not public (bug 1195267)

### DIFF
--- a/mkt/webapps/cron.py
+++ b/mkt/webapps/cron.py
@@ -576,11 +576,12 @@ def mkt_gc(**kw):
                         'Deleting old tarball: {0}',
                         storage=public_storage)
 
-    # Delete the dumped user installs over 30 days.
+    # Delete the dumped user installs over 30 days. Those are using private
+    # storage.
     _remove_stale_files(os.path.join(settings.DUMPED_USERS_PATH, 'tarballs'),
                         settings.DUMPED_USERS_DAYS_DELETE,
                         'Deleting old tarball: {0}',
-                        storage=public_storage)
+                        storage=private_storage)
 
     # Delete old files in select directories under TMP_PATH.
     _remove_stale_files(os.path.join(settings.TMP_PATH, 'preview'),

--- a/mkt/webapps/tasks.py
+++ b/mkt/webapps/tasks.py
@@ -562,7 +562,7 @@ def zip_users(*args, **kw):
     remote_target_filename = os.path.join(
         settings.DUMPED_USERS_PATH, 'tarballs', '%s.tgz' % tarball_name)
     copy_to_storage(local_target_file.name, remote_target_filename,
-                    dst_storage=public_storage)
+                    dst_storage=private_storage)
 
     # Clean-up.
     local_target_file.close()

--- a/mkt/webapps/tests/test_crons.py
+++ b/mkt/webapps/tests/test_crons.py
@@ -218,6 +218,15 @@ class TestGarbage(mkt.site.tests.TestCase):
         assert not private_mock.remove.called
         assert public_mock.remove.call_args_list[0][0][0].endswith('lol')
 
+    def test_dump_delete_private(self, public_mock, private_mock):
+        private_mock.listdir.return_value = (['dirlol'], ['lol'])
+        private_mock.modified_time.return_value = self.days_ago(1000)
+
+        mkt_gc()
+        assert private_mock.remove.called
+        assert not public_mock.remove.called
+        assert private_mock.remove.call_args_list[0][0][0].endswith('lol')
+
     def test_new_no_delete(self, public_mock, private_mock):
         public_mock.listdir.return_value = (['dirlol'], ['lol'])
         public_mock.modified_time.return_value = self.days_ago(1)

--- a/mkt/webapps/tests/test_tasks.py
+++ b/mkt/webapps/tests/test_tasks.py
@@ -563,7 +563,7 @@ class TestDumpUserInstalls(mkt.site.tests.TestCase):
         tarball_path = os.path.join(self.export_directory,
                                     'tarballs',
                                     date + '.tgz')
-        self.tarfile_file = public_storage.open(tarball_path)
+        self.tarfile_file = private_storage.open(tarball_path)
         self.tarfile = tarfile.open(fileobj=self.tarfile_file)
         return self.tarfile
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1195267