### PR TITLE
allow content-disposition for add-on/extension validation view

### DIFF
--- a/mkt/extensions/tests/test_views.py
+++ b/mkt/extensions/tests/test_views.py
@@ -62,6 +62,11 @@ class TestExtensionValidationViewSet(MktPaths, RestOAuth):
                                   content_type='application/zip', **headers)
         eq_(response.status_code, 400)
 
+    def test_cors(self):
+        response = self.anon.post(self.list_url)
+        self.assertCORS(response, 'get', 'post',
+                        headers=['Content-Disposition', 'Content-Type'])
+
     def test_create_missing_content_disposition(self):
         headers = {
             'HTTP_CONTENT_TYPE': 'application/zip',

--- a/mkt/extensions/views.py
+++ b/mkt/extensions/views.py
@@ -34,6 +34,7 @@ class ValidationViewSet(SubmitValidationViewSet):
     # Typical usage:
     # cat /tmp/extension.zip | curling -X POST --data-binary '@-' \
     # http://localhost:8000/api/v2/extensions/validation/
+    cors_allowed_headers = ('Content-Disposition', 'Content-Type')
     parser_classes = (FileUploadParser,)
 
     @use_master


### PR DESCRIPTION
Docs say ```Content-Disposition header must be set to form-data; name="binary_data"; filename="extension.zip"```, but the client is unable to set it with CORS.

So when I try to post file data, I get "Missing file in request".