### PR TITLE
allow charset in mimetype in add-on validation

### DIFF
--- a/mkt/extensions/tests/test_views.py
+++ b/mkt/extensions/tests/test_views.py
@@ -3,6 +3,7 @@ import json
 
 from django.core.urlresolvers import reverse
 
+import mock
 from nose.tools import eq_, ok_
 
 from mkt.api.tests.test_oauth import RestOAuth
@@ -49,6 +50,12 @@ class TestExtensionValidationViewSet(MktPaths, RestOAuth):
         eq_(upload.user, None)
 
     def test_create_logged_in(self):
+        upload = self._test_create_success(client=self.client)
+        eq_(upload.user, self.user)
+
+    @mock.patch('mkt.extensions.views.ValidationViewSet._get_content_type')
+    def test_content_type_with_charset(self, content_mock):
+        content_mock.return_value = 'application/zip; charset=UTF-8'
         upload = self._test_create_success(client=self.client)
         eq_(upload.user, self.user)
 

--- a/mkt/extensions/views.py
+++ b/mkt/extensions/views.py
@@ -54,11 +54,17 @@ class ValidationViewSet(SubmitValidationViewSet):
         serializer = self.get_serializer(upload)
         return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
 
+    def _get_content_type(self, file_obj):
+        """Split out for easier mock-testing."""
+        return file_obj.content_type
+
     def validate_upload(self, file_obj):
         # Do a basic check : is it a zipfile, and does it contain a manifest ?
         # Be careful to keep this as in-memory zip reading.
-        if file_obj.content_type not in ('application/octet-stream',
-                                         'application/zip'):
+
+        # Strip charset before check(e.g., application/zip; charset=UTF-8).
+        content_type = self._get_content_type(file_obj).split(';')[0]
+        if content_type not in ('application/octet-stream', 'application/zip'):
             raise ParseError(
                 _('The file sent has an unsupported content-type'))
         try:


### PR DESCRIPTION
My zip's content type was being detected as ```application/zip; charset=UTF-8```, even though the request was sending ```application/zip``` for the content-type header. The view set was not expecting the charset portion.