### PR TITLE
Make mini-manifest a Webapp manifest, not an extension manifest (bug 1199189)

### DIFF
--- a/docs/api/topics/firefox_os_addons.rst
+++ b/docs/api/topics/firefox_os_addons.rst
@@ -58,8 +58,8 @@ Add-on
     :type download_url: string
     :param name: The add-on name.
     :type name: string|object
-    :param manifest_url: The (absolute) URL to the mini-manifest for that add-on. That URL may be a 404 if the add-on is not public.
-    :type manifest_url: string
+    :param mini_manifest_url: The (absolute) URL to the `mini-manifest <https://developer.mozilla.org/docs/Mozilla/Marketplace/Options/Packaged_apps#Publishing_on_Firefox_Marketplace>`_ for that add-on. That URL may be a 404 if the add-on is not public.
+    :type mini_manifest_url: string
     :param slug: The add-on slug (unique string identifier that can be used
         instead of the id to retrieve an add-on).
     :type slug: string

--- a/mkt/extensions/serializers.py
+++ b/mkt/extensions/serializers.py
@@ -9,7 +9,7 @@ from mkt.search.serializers import BaseESSerializer
 
 class ExtensionSerializer(ModelSerializer):
     download_url = CharField(source='download_url', read_only=True)
-    manifest_url = CharField(source='manifest_url', read_only=True)
+    mini_manifest_url = CharField(source='mini_manifest_url', read_only=True)
     name = TranslationSerializerField()
     status = ReverseChoiceField(choices_dict=STATUS_CHOICES_API_v2)
     unsigned_download_url = CharField(source='unsigned_download_url',
@@ -17,7 +17,7 @@ class ExtensionSerializer(ModelSerializer):
 
     class Meta:
         model = Extension
-        fields = ['id', 'download_url', 'manifest_url', 'name', 'slug',
+        fields = ['id', 'download_url', 'mini_manifest_url', 'name', 'slug',
                   'status', 'unsigned_download_url', 'version']
 
 

--- a/mkt/extensions/tests/test_models.py
+++ b/mkt/extensions/tests/test_models.py
@@ -164,26 +164,37 @@ class TestExtensionMethodsAndProperties(TestCase):
         eq_(Extension().file_version, 0)
 
     @override_settings(SITE_URL='https://marketpace.example.com/')
-    def test_manifest_url(self):
+    def test_mini_manifest_url(self):
         extension = Extension(pk=43, version='0.43.0',
                               uuid='12345678123456781234567812abcdef')
-        eq_(extension.manifest_url,
+        eq_(extension.mini_manifest_url,
             'https://marketpace.example.com/extension/'
             '12345678123456781234567812abcdef/manifest.json')
 
     def test_mini_manifest(self):
-        manifest = {'foo': {'bar': 1}}
+        manifest = {
+            'author': 'Me',
+            'description': 'Blah',
+            'manifest_version': 2,
+            'name': u'Ëxtension',
+            'version': '0.44',
+        }
         extension = Extension(pk=44, version='0.44.0', manifest=manifest,
                               uuid='abcdefabcdefabcdefabcdefabcdef12')
         expected_manifest = {
-            'foo': {'bar': 1},
+            'description': 'Blah',
+            'developer': {
+                'name': 'Me'
+            },
+            'name': u'Ëxtension',
             'package_path': extension.download_url,
+            'version': '0.44',
         }
         eq_(extension.mini_manifest, expected_manifest)
 
         # Make sure that mini_manifest is a deepcopy.
-        extension.mini_manifest['foo']['bar'] = 42
-        eq_(extension.manifest['foo']['bar'], 1)
+        extension.mini_manifest['name'] = u'Faîl'
+        eq_(extension.manifest['name'], u'Ëxtension')
 
     @mock.patch('mkt.extensions.models.sign_app')
     @mock.patch('mkt.extensions.models.private_storage')

--- a/mkt/extensions/views.py
+++ b/mkt/extensions/views.py
@@ -30,6 +30,7 @@ from mkt.api.permissions import (AllowAppOwner, AllowReadOnlyIfPublic,
                                  AllowReviewerReadOnly, AnyOf, ByHttpMethod,
                                  GroupPermission)
 from mkt.api.paginator import ESPaginator
+from mkt.constants.apps import MANIFEST_CONTENT_TYPE
 from mkt.extensions.indexers import ExtensionIndexer
 from mkt.extensions.models import Extension
 from mkt.extensions.serializers import (ExtensionSerializer,
@@ -236,6 +237,7 @@ def mini_manifest(request, uuid, **kwargs):
     if extension.is_public():
         # Let ETag/Last-Modified be handled by the generic middleware for now.
         # If that turns out to be a problem, we'll set them manually.
-        return JsonResponse(extension.mini_manifest)
+        return JsonResponse(extension.mini_manifest,
+                            content_type=MANIFEST_CONTENT_TYPE)
     else:
         raise Http404

--- a/mkt/urls.py
+++ b/mkt/urls.py
@@ -40,7 +40,7 @@ urlpatterns = patterns(
     url('^langpack/%s/manifest.webapp$' % mkt.ADDON_UUID,
         mini_langpack_manifest, name='langpack.manifest'),
     url('^extension/(?P<uuid>[0-9a-f]{32})/manifest.json$',
-        mini_extension_manifest, name='extension.manifest'),
+        mini_extension_manifest, name='extension.mini_manifest'),
 
     # Dev Ecosystem
     ('^developers/', include('mkt.ecosystem.urls')),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1199189

We need the manifest.json inside the zip to follow the Web Extensions format, and the mini-manifest to follow Mozilla's "App Manifest" format to make add-ons to be installable and updatable on FxOS.

See https://etherpad.mozilla.org/converting-fxos-addons and 'PSA: add-ons changes are coming' thread on mozilla.dev.b2g.