### PR TITLE
Add an unsigned download URL for authors & reviewers (bug 1199198)

### DIFF
--- a/docs/api/topics/firefox_os_addons.rst
+++ b/docs/api/topics/firefox_os_addons.rst
@@ -54,11 +54,11 @@ Add-on
 
     **Response**
 
-    :param download_url: The (absolute) URL to the latest signed package for that add-on.
+    :param download_url: The (absolute) URL to the latest signed package for that add-on. That URL may be a 404 if the add-on is not public.
     :type download_url: string
     :param name: The add-on name.
     :type name: string|object
-    :param manifest_url: The (absolute) URL to the mini-manifest for that add-on.
+    :param manifest_url: The (absolute) URL to the mini-manifest for that add-on. That URL may be a 404 if the add-on is not public.
     :type manifest_url: string
     :param slug: The add-on slug (unique string identifier that can be used
         instead of the id to retrieve an add-on).
@@ -66,6 +66,8 @@ Add-on
     :param status: The add-on current status.
         Can be "incomplete", "pending", "public" or "rejected".
     :type status: string
+    :param unsigned_download_url: The (absolute) URL to the latest *unsigned* package for that add-on. Only the add-on author or users with Extensions:Review permission may access it.
+    :type unsigned_download_url: string
     :param version: The add-on current version number.
     :type version: string
 

--- a/mkt/downloads/urls.py
+++ b/mkt/downloads/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 from mkt.downloads.views import download_file
-from mkt.extensions.views import download as download_extension
+from mkt.extensions import views as extensions_views
 from mkt.langpacks.views import download as download_langpack
 
 
@@ -15,5 +15,10 @@ urlpatterns = patterns(
         '(?:/type:(?P<type>\w+))?(?:/.*)?',
         download_langpack, name='langpack.download'),
     url(r'^extension/(?P<uuid>[0-9a-f]{32})/(?P<filename>[^/<>"\']+)$',
-        download_extension, name='extension.download'),
+        extensions_views.download_signed,
+        name='extension.download_signed'),
+    url(r'^extension/unsigned/(?P<uuid>[0-9a-f]{32})/'
+        r'(?P<filename>[^/<>"\']+)$',
+        extensions_views.download_unsigned,
+        name='extension.download_unsigned'),
 )

--- a/mkt/extensions/models.py
+++ b/mkt/extensions/models.py
@@ -36,6 +36,9 @@ class ExtensionManager(ManagerBase):
     def pending(self):
         return self.filter(status=STATUS_PENDING).order_by('id')
 
+    def public(self):
+        return self.filter(status=STATUS_PUBLIC).order_by('id')
+
 
 class Extension(ModelBase):
     uuid = UUIDField(auto=True)
@@ -62,7 +65,7 @@ class Extension(ModelBase):
     @property
     def download_url(self):
         return absolutify(reverse(
-            'extension.download',
+            'extension.download_signed',
             kwargs={'uuid': self.uuid, 'filename': self.filename}))
 
     @property
@@ -226,6 +229,12 @@ class Extension(ModelBase):
 
     def __unicode__(self):
         return u'%s: %s' % (self.pk, self.name)
+
+    @property
+    def unsigned_download_url(self):
+        return absolutify(reverse(
+            'extension.download_unsigned',
+            kwargs={'uuid': self.uuid, 'filename': self.filename}))
 
 
 # Maintain ElasticSearch index.

--- a/mkt/extensions/serializers.py
+++ b/mkt/extensions/serializers.py
@@ -12,11 +12,13 @@ class ExtensionSerializer(ModelSerializer):
     manifest_url = CharField(source='manifest_url', read_only=True)
     name = TranslationSerializerField()
     status = ReverseChoiceField(choices_dict=STATUS_CHOICES_API_v2)
+    unsigned_download_url = CharField(source='unsigned_download_url',
+                                      read_only=True)
 
     class Meta:
         model = Extension
         fields = ['id', 'download_url', 'manifest_url', 'name', 'slug',
-                  'status', 'version']
+                  'status', 'unsigned_download_url', 'version']
 
 
 class ESExtensionSerializer(BaseESSerializer, ExtensionSerializer):

--- a/mkt/extensions/views.py
+++ b/mkt/extensions/views.py
@@ -2,15 +2,16 @@ import hashlib
 import json
 from zipfile import BadZipfile, ZipFile
 
+from django.core.exceptions import PermissionDenied
 from django.db.transaction import non_atomic_requests
 from django.forms import ValidationError
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
 
 import commonware
+from rest_framework import exceptions
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.generics import ListAPIView
 from rest_framework.mixins import (CreateModelMixin, ListModelMixin,
                                    RetrieveModelMixin)
@@ -20,6 +21,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from tower import ugettext as _
 
+from mkt.access.acl import action_allowed
 from mkt.api.authentication import (RestAnonymousAuthentication,
                                     RestOAuthAuthentication,
                                     RestSharedSecretAuthentication)
@@ -53,7 +55,7 @@ class ValidationViewSet(SubmitValidationViewSet):
     def create(self, request, *args, **kwargs):
         file_obj = request.FILES.get('file', None)
         if not file_obj:
-            raise ParseError(_('Missing file in request.'))
+            raise exceptions.ParseError(_('Missing file in request.'))
 
         self.validate_upload(file_obj)  # Will raise exceptions if appropriate.
         user = request.user if request.user.is_authenticated() else None
@@ -71,20 +73,21 @@ class ValidationViewSet(SubmitValidationViewSet):
         # Be careful to keep this as in-memory zip reading.
         if file_obj.content_type not in ('application/octet-stream',
                                          'application/zip'):
-            raise ParseError(
+            raise exceptions.ParseError(
                 _('The file sent has an unsupported content-type'))
         try:
             with ZipFile(file_obj, 'r') as z:
                 manifest = z.read('manifest.json')
         except BadZipfile:
-            raise ParseError(_('The file sent is not a valid ZIP file.'))
+            raise exceptions.ParseError(
+                _('The file sent is not a valid ZIP file.'))
         except KeyError:
-            raise ParseError(
+            raise exceptions.ParseError(
                 _("The archive does not contain a 'manifest.json' file."))
         try:
             json.loads(manifest)
         except ValueError:
-            raise ParseError(
+            raise exceptions.ParseError(
                 _("'manifest.json' in the archive is not a valid JSON file."))
 
 
@@ -105,17 +108,18 @@ class ExtensionViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
             # The listing API only allows you to see extensions you've
             # developed.
             if not self.request.user.is_authenticated():
-                raise PermissionDenied('Anonymous listing not allowed.')
+                raise exceptions.PermissionDenied(
+                    'Anonymous listing not allowed.')
             qs = qs.filter(authors=self.request.user)
         return qs
 
     def create(self, request, *args, **kwargs):
         upload_pk = request.DATA.get('upload', '')
         if not upload_pk:
-            raise ParseError(_('No upload identifier specified.'))
+            raise exceptions.ParseError(_('No upload identifier specified.'))
 
         if not request.user.is_authenticated():
-            raise PermissionDenied(
+            raise exceptions.PermissionDenied(
                 _('You need to be authenticated to perform this action.'))
 
         try:
@@ -123,13 +127,13 @@ class ExtensionViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
         except FileUpload.DoesNotExist:
             raise Http404(_('No such upload.'))
         if not upload.valid:
-            raise ParseError(
+            raise exceptions.ParseError(
                 _('The specified upload has not passed validation.'))
 
         try:
             obj = Extension.from_upload(upload, user=request.user)
         except ValidationError as e:
-            raise ParseError(unicode(e))
+            raise exceptions.ParseError(unicode(e))
         log.info('Extension created: %s' % obj.pk)
         serializer = self.get_serializer(obj)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -191,20 +195,38 @@ class ReviewersExtensionViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
 
 
 @allow_cross_site_request
-def download(request, uuid, **kwargs):
+def _download(request, extension, path, public=True):
+    extension_etag = hashlib.sha256()
+    extension_etag.update(unicode(extension.uuid))
+    extension_etag.update(unicode(extension.file_version))
+    return get_file_response(request, path,
+                             content_type='application/zip',
+                             etag=extension_etag.hexdigest(), public=public)
+
+
+def download_signed(request, uuid, **kwargs):
+    extension = get_object_or_404(Extension.objects.public(), uuid=uuid)
+
+    log.info('Downloading add-on: %s from %s' % (
+             extension.pk, extension.signed_file_path))
+    return _download(request, extension, extension.signed_file_path)
+
+
+def download_unsigned(request, uuid, **kwargs):
     extension = get_object_or_404(Extension, uuid=uuid)
 
-    if extension.is_public():
-        log.info('Downloading add-on: %s from %s' % (
-                 extension.pk, extension.signed_file_path))
-        extension_etag = hashlib.sha256()
-        extension_etag.update(unicode(extension.uuid))
-        extension_etag.update(unicode(extension.file_version))
-        return get_file_response(request, extension.signed_file_path,
-                                 content_type='application/zip',
-                                 etag=extension_etag.hexdigest(), public=True)
+    def is_author():
+        return extension.authors.filter(pk=request.user.pk).exists()
+
+    def is_reviewer():
+        return action_allowed(request, 'Extensions', 'Review')
+
+    if request.user.is_authenticated() and (is_author() or is_reviewer()):
+        log.info('Downloading unsigned add-on: %s from %s' % (
+                 extension.pk, extension.file_path))
+        return _download(request, extension, extension.file_path, public=False)
     else:
-        raise Http404
+        raise PermissionDenied
 
 
 @allow_cross_site_request


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1199198

Note that I'm only providing an unsigned download link for reviewers (and authors), I didn't go all the way and give them a special signed download + special manifest, so they won't be able to directly install non-public add-ons on their devices, but they will be able to download them, and that's enough for the walking skeleton.