### PR TITLE
Allows websites to be regionally-restricted to Colombia (bug 1200810):

### DIFF
--- a/mkt/fireplace/views.py
+++ b/mkt/fireplace/views.py
@@ -26,6 +26,8 @@ class SearchView(BaseSearchView):
 
 
 class MultiSearchView(BaseMultiSearchView):
+    allow_colombia = True
+
     def get_serializer_context(self):
         context = super(MultiSearchView, self).get_serializer_context()
         context['serializer_classes'] = {

--- a/mkt/search/forms.py
+++ b/mkt/search/forms.py
@@ -62,6 +62,9 @@ REDIRECTED_CATEGORY_CHOICES = [(old, CATEGORY_CHOICES_DICT[new])
 
 CATEGORY_CHOICES = (('', _lazy(u'All Categories')),) + CATEGORY_CHOICES
 
+# Tag to allow websites to be featured only in Colombia.
+COLOMBIA_WEBSITE = 'website-region-co'
+
 # Tags are only available to admins. They are free-form, and we expose them in
 # the API, but they are not supposed to be manipulated by users atm, so we only
 # allow to search for specific, allowed ones.
@@ -72,6 +75,7 @@ TAG_CHOICES = [
     ('featured-game-adventure', 'featured-game-adventure'),
     ('featured-game-puzzle', 'featured-game-puzzle'),
     ('featured-game-strategy', 'featured-game-strategy'),
+    (COLOMBIA_WEBSITE, COLOMBIA_WEBSITE),
     ('featured-website', 'featured-website'),
 ]
 TAG_CHOICES += [('featured-website-%s' % r, 'featured-website-%s' % r) for


### PR DESCRIPTION
* Creates a new restricted tag (`website-region-co`) that allows editorial to indicate that a website should only be shown in Colombia.
* Updates the base `MultiSearch` endpoint view to add filters preventing websites with that tag from being shown in regions outside of Colombia.
* Updates the base `MultiSearch` endpoint view to add filters allowing websites with that tag to be shown inside of Colombia.
* Disables those filters by default.
* Enables those filters on the Fireplace `MultiSearch` endpoint.

Yes, this is a horrific hack to get this feature request out of the way and allow us to focus on 2.5. Product is aware of this and will not ask for this to be extended to other regions or used past a trial period. If the trial is successful, this commit will be reverted and we will add full region restriction functionality to websites. If not, this commit will be reverted.

r? @ngokevin @robhudson 