### PR TITLE
silence migration change-detector

### DIFF
--- a/mkt/feed/migrations/0002_auto_20150727_1017.py
+++ b/mkt/feed/migrations/0002_auto_20150727_1017.py
@@ -47,7 +47,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='feedshelf',
             name='description',
-            field=mkt.translations.fields.PurifiedField(related_name='FeedShelf_description_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'description', to_field=b'id', blank=True, to=mkt.translations.models.PurifiedTranslation, short=True, require_locale=True, unique=True),
+            field=mkt.translations.fields.TranslatedField(related_name='FeedShelf_description_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'description', to_field=b'id', blank=True, to=mkt.translations.models.Translation, short=True, require_locale=True, unique=True),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -115,7 +115,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='feedcollection',
             name='description',
-            field=mkt.translations.fields.PurifiedField(related_name='FeedCollection_description_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'description', to_field=b'id', blank=True, to=mkt.translations.models.PurifiedTranslation, short=True, require_locale=True, unique=True),
+            field=mkt.translations.fields.TranslatedField(related_name='FeedCollection_description_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'description', to_field=b'id', blank=True, to=mkt.translations.models.Translation, short=True, require_locale=True, unique=True),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -155,7 +155,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='feedapp',
             name='description',
-            field=mkt.translations.fields.PurifiedField(related_name='FeedApp_description_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'description', to_field=b'id', blank=True, to=mkt.translations.models.PurifiedTranslation, short=True, require_locale=True, unique=True),
+            field=mkt.translations.fields.TranslatedField(related_name='FeedApp_description_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'description', to_field=b'id', blank=True, to=mkt.translations.models.Translation, short=True, require_locale=True, unique=True),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -167,7 +167,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='feedapp',
             name='pullquote_text',
-            field=mkt.translations.fields.PurifiedField(related_name='FeedApp_pullquote_text_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'pullquote_text', to_field=b'id', blank=True, to=mkt.translations.models.PurifiedTranslation, short=True, require_locale=True, unique=True),
+            field=mkt.translations.fields.TranslatedField(related_name='FeedApp_pullquote_text_set+', null=True, on_delete=django.db.models.deletion.SET_NULL, db_column=b'pullquote_text', to_field=b'id', blank=True, to=mkt.translations.models.Translation, short=True, require_locale=True, unique=True),
             preserve_default=True,
         ),
     ]


### PR DESCRIPTION
I forgot when adding ceae509788 that the migration stuff couldn't detect that no DB changes were needed; it wanted to generate a migration that would drop some foreign keys and re-add the same constraints with the same names. Thus, here are some changes to convince it everything is OK. 