### PR TITLE
commbadge + firefox OS add-ons

### DIFF
--- a/mkt/api/v2/urls.py
+++ b/mkt/api/v2/urls.py
@@ -7,7 +7,8 @@ import mkt.feed.views as views
 from mkt.api.base import SubRouterWithFormat
 from mkt.api.v1.urls import urlpatterns as v1_urls
 from mkt.api.views import endpoint_removed
-from mkt.comm.views import CommAppListView, ThreadViewSetV2
+from mkt.comm.views import (CommAppListView, CommExtensionListView,
+                            ThreadViewSetV2)
 from mkt.extensions.urls import urlpatterns as extensions_urlpatterns
 from mkt.games.views import DailyGamesView
 from mkt.langpacks.views import LangPackViewSet
@@ -73,6 +74,9 @@ urlpatterns = patterns(
 
     url(r'^comm/app/%s' % mkt.APP_SLUG,
         CommAppListView.as_view({'get': 'list'}), name='comm-app-list'),
+    url(r'^comm/extension/%s' % mkt.APP_SLUG,
+        CommExtensionListView.as_view({'get': 'list'}),
+        name='comm-extension-list'),
     url(r'^comm/thread', include(comm_thread.urls)),
 
     url(r'^extensions/', include(extensions_urlpatterns)),

--- a/mkt/comm/forms.py
+++ b/mkt/comm/forms.py
@@ -9,12 +9,18 @@ from tower import ugettext as _, ugettext_lazy as _lazy
 from mkt.api.forms import SluggableModelChoiceField
 from mkt.comm.models import CommunicationThread
 from mkt.constants import comm
+from mkt.extensions.models import Extension
 from mkt.webapps.models import Webapp
 
 
 class AppSlugForm(happyforms.Form):
     app = SluggableModelChoiceField(queryset=Webapp.with_deleted.all(),
                                     sluggable_to_field_name='app_slug')
+
+
+class ExtensionSlugForm(happyforms.Form):
+    extension = SluggableModelChoiceField(queryset=Extension.objects.all(),
+                                          sluggable_to_field_name='slug')
 
 
 class CreateCommNoteForm(happyforms.Form):

--- a/mkt/comm/migrations/0003_auto_20150915_1245.py
+++ b/mkt/comm/migrations/0003_auto_20150915_1245.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('extensions', '0006_auto_20150914_0745'),
+        ('comm', '0002_auto_20150727_1017'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='communicationthread',
+            name='_extension',
+            field=models.ForeignKey(related_name='threads', db_column=b'_extension_id', to='extensions.Extension', null=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='communicationthread',
+            name='_extension_version',
+            field=models.ForeignKey(related_name='threads', db_column=b'extension_version_id', to='extensions.ExtensionVersion', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='communicationthread',
+            name='_addon',
+            field=models.ForeignKey(related_name='threads', db_column=b'addon_id', to='webapps.Webapp', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterUniqueTogether(
+            name='communicationthread',
+            unique_together=set([('_addon', '_version'), ('_extension', '_extension_version')]),
+        ),
+    ]

--- a/mkt/comm/serializers.py
+++ b/mkt/comm/serializers.py
@@ -125,7 +125,6 @@ class ThreadSerializer(ModelSerializer):
 
 
 class CommVersionSerializer(ModelSerializer):
-
     class Meta:
         model = Version
         fields = ('id', 'deleted', 'version')
@@ -141,7 +140,6 @@ class ThreadSerializerV2(ThreadSerializer):
 
 
 class CommVersionSimpleSerializer(ModelSerializer):
-
     class Meta(CommVersionSerializer.Meta):
         fields = ('id', 'version')
 

--- a/mkt/comm/templates/comm/emails/approval.html
+++ b/mkt/comm/templates/comm/emails/approval.html
@@ -1,12 +1,12 @@
 {% extends 'comm/emails/base.html' %}
 
 {% block content %}
-Congratulations! {{ app.name }} has been approved and is now published on the Firefox Marketplace.
+Congratulations! {{ obj.name }} has been approved and is now published on the Firefox Marketplace.
 
-{% if app.status == mkt.STATUS_UNLISTED %}
+{% if obj.status == mkt.STATUS_UNLISTED %}
 Your app is approved but not published on category listing pages nor in search results. Only those with the URL can find and install your app.
 
-If you would like your app included in search results and listing pages visit its Manage Status page: {{ app.get_dev_url('versions')|absolutify }}
+If you would like your app included in search results and listing pages visit its Manage Status page: {{ obj.get_dev_url('versions')|absolutify }}
 
 {% endif %}
 {% include 'comm/emails/includes/details.html' %}

--- a/mkt/comm/templates/comm/emails/approval_private.html
+++ b/mkt/comm/templates/comm/emails/approval_private.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Congratulations! {{ app.name }} has been approved for the Firefox Marketplace.
+Congratulations! {{ obj.name }} has been approved for the Firefox Marketplace.
 
 Your app is now in a private state, because you either requested that the app not be automatically published after approval, or we noticed something during review that we didn't think was serious enough to warrant rejecting your app, but wanted to give you the option to fix it if you'd like.
 

--- a/mkt/comm/templates/comm/emails/disabled.html
+++ b/mkt/comm/templates/comm/emails/disabled.html
@@ -1,7 +1,7 @@
 {% extends 'comm/emails/base.html' -%}
 
 {% block content %}
-{{ app.name }} has been banned by an admin or senior reviewer.
+{{ obj.name }} has been banned by an admin or senior reviewer.
 
 {% include 'comm/emails/includes/details.html' %}
 {% include 'comm/emails/includes/questions.html' %}

--- a/mkt/comm/templates/comm/emails/escalation_developer.html
+++ b/mkt/comm/templates/comm/emails/escalation_developer.html
@@ -1,7 +1,7 @@
 {% extends 'comm/emails/base.html' -%}
 
 {% block content %}
-{{ app.name }} has been escalated for an admin review by a reviewer.
+{{ obj.name }} has been escalated for an admin review by a reviewer.
 
 Your app is now in our escalated review queue, and it will need to be checked by one of our senior comm. This means that your review will probably take longer than usual. You don't need to take any further action - we will contact you if any more information is required from you. Thanks for your understanding.
 

--- a/mkt/comm/templates/comm/emails/generic.html
+++ b/mkt/comm/templates/comm/emails/generic.html
@@ -1,7 +1,7 @@
 {% extends 'comm/emails/base.html' %}
 
 {% block content %}
-A note was posted on a thread for {{ app.name }}.
+A note was posted on a thread for {{ obj.name }}.
 
 {% include "comm/emails/includes/details.html" %}
 {% endblock %}

--- a/mkt/comm/templates/comm/emails/includes/details.html
+++ b/mkt/comm/templates/comm/emails/includes/details.html
@@ -4,6 +4,8 @@
     "{{ note.body }}"
 {% endif %}
 
-App: {{ app.name }}
-URL: {{ app.get_url_path()|absolutify }}
+App: {{ obj.name }}
+{% if obj.get_url_path %}
+URL: {{ obj.get_url_path()|absolutify }}
+{% endif %}
 

--- a/mkt/comm/templates/comm/emails/more_info_required.html
+++ b/mkt/comm/templates/comm/emails/more_info_required.html
@@ -1,7 +1,7 @@
 {% extends 'comm/emails/base.html' -%}
 
 {% block content %}
-A message about your app, {{ app.name }}:
+A message about your app, {{ obj.name }}:
 
 {% include 'comm/emails/includes/details.html' %}
 {% endblock %}

--- a/mkt/comm/templates/comm/emails/rejection.html
+++ b/mkt/comm/templates/comm/emails/rejection.html
@@ -1,10 +1,10 @@
 {% extends 'comm/emails/base.html' %}
 
 {% block content %}
-After reviewing your submission for {{ app.name }}, we have determined that it does not currently meet our requirements for approval.
+After reviewing your submission for {{ obj.name }}, we have determined that it does not currently meet our requirements for approval.
 
 {% include 'comm/emails/includes/details.html' %}
 {% include 'comm/emails/includes/questions.html' %}
 
-Once the concerns above have been addressed, you may resubmit your app from the My Submissions page at {{ app.get_dev_url('versions')|absolutify }}.
+Once the concerns above have been addressed, you may resubmit your app from the My Submissions page at {{ obj.get_dev_url('versions')|absolutify }}.
 {% endblock %}

--- a/mkt/comm/templates/comm/emails/tarako.html
+++ b/mkt/comm/templates/comm/emails/tarako.html
@@ -1,8 +1,8 @@
 {%- if note.note_type == comm.ADDITIONAL_REVIEW_PASSED -%}
-{{ app.name }} has passed the low-memory device review. It will now
+{{ obj.name }} has passed the low-memory device review. It will now
 be shown to low-memory devices.
 {% else %}
-{{ app.name }} has not passed the low-memory device review. It will
+{{ obj.name }} has not passed the low-memory device review. It will
 not be shown to low-memory devices.
 {% endif %}
 

--- a/mkt/comm/tests/test_utils_.py
+++ b/mkt/comm/tests/test_utils_.py
@@ -8,7 +8,7 @@ from mkt.comm.tests.test_views import AttachmentManagementMixin
 from mkt.comm.utils import create_comm_note
 from mkt.constants import comm
 from mkt.site.tests import TestCase, user_factory
-from mkt.site.utils import app_factory
+from mkt.site.utils import app_factory, extension_factory
 
 
 class TestCreateCommNote(TestCase, AttachmentManagementMixin):
@@ -103,6 +103,99 @@ class TestCreateCommNote(TestCase, AttachmentManagementMixin):
 
         thread, note = create_comm_note(
             self.app, self.app.current_version, self.user, 'lol',
+            note_type=comm.APPROVAL, attachments=attach_formset)
+
+        eq_(note.attachments.count(), 2)
+
+
+class TestCreateCommNoteExtensions(TestCase, AttachmentManagementMixin):
+
+    def setUp(self):
+        self.user = user_factory()
+        self.grant_permission(self.user, '*:*')
+        self.extension = extension_factory()
+
+    def test_create_thread(self):
+        # Default permissions.
+        thread, note = create_comm_note(
+            self.extension, self.extension.latest_version, self.user, 'huehue',
+            note_type=comm.APPROVAL)
+
+        # Check Thread.
+        eq_(thread.obj, self.extension)
+        eq_(thread._extension, self.extension)
+        eq_(thread.version, self.extension.latest_version)
+        eq_(thread._extension_version, self.extension.latest_version)
+
+        expected = {
+            'public': False, 'developer': True, 'reviewer': True,
+            'senior_reviewer': True, 'mozilla_contact': True, 'staff': True}
+        for perm, has_perm in expected.items():
+            eq_(getattr(thread, 'read_permission_%s' % perm), has_perm, perm)
+
+        # Check Note.
+        eq_(note.thread, thread)
+        eq_(note.author, self.user)
+        eq_(note.body, 'huehue')
+        eq_(note.note_type, comm.APPROVAL)
+
+        # Check CC.
+        eq_(thread.thread_cc.count(), 1)
+        assert thread.thread_cc.filter(user=self.user).exists()
+
+    def test_create_note_existing_thread(self):
+        # Initial note.
+        thread, note = create_comm_note(
+            self.extension, self.extension.latest_version, self.user, 'huehue')
+
+        # Second person joins thread.
+        thread, last_word = create_comm_note(
+            self.extension, self.extension.latest_version, user_factory(),
+            'euheuh!', note_type=comm.MORE_INFO_REQUIRED)
+
+        eq_(thread.thread_cc.count(), 2)
+
+    def test_create_note_no_author(self):
+        thread, note = create_comm_note(
+            self.extension, self.extension.latest_version, None, 'huehue')
+        eq_(note.author, None)
+
+    @mock.patch('mkt.comm.utils.post_create_comm_note', new=mock.Mock)
+    def test_create_note_reviewer_type(self):
+        for note_type in comm.REVIEWER_NOTE_TYPES:
+            thread, note = create_comm_note(
+                self.extension, self.extension.latest_version, None, 'huehue',
+                note_type=note_type)
+            eq_(note.read_permission_developer, False)
+
+    @mock.patch('mkt.comm.utils.post_create_comm_note', new=mock.Mock)
+    def test_custom_perms(self):
+        thread, note = create_comm_note(
+            self.extension, self.extension.latest_version, self.user,
+            'escalatedquickly', note_type=comm.ESCALATION,
+            perms={'developer': False, 'staff': True})
+
+        expected = {
+            'public': False, 'developer': False, 'reviewer': True,
+            'senior_reviewer': True, 'mozilla_contact': True, 'staff': True}
+        for perm, has_perm in expected.items():
+            eq_(getattr(thread, 'read_permission_%s' % perm), has_perm, perm)
+
+    @mock.patch('mkt.comm.utils.post_create_comm_note', new=mock.Mock)
+    def test_attachments(self):
+        attach_formdata = self._attachment_management_form(num=2)
+        attach_formdata.update(self._attachments(num=2))
+        attach_formset = CommAttachmentFormSet(
+            attach_formdata,
+            {'form-0-attachment':
+                SimpleUploadedFile(
+                    'lol', attach_formdata['form-0-attachment'].read()),
+             'form-1-attachment':
+                SimpleUploadedFile(
+                    'lol2', attach_formdata['form-1-attachment'].read())})
+
+        thread, note = create_comm_note(
+            self.extension, self.extension.latest_version, self.user, 'lol',
             note_type=comm.APPROVAL, attachments=attach_formset)
 
         eq_(note.attachments.count(), 2)

--- a/mkt/commonplace/urls.py
+++ b/mkt/commonplace/urls.py
@@ -80,6 +80,9 @@ urlpatterns = patterns(
         name='commonplace.operatordashboard'),
 
     # Content Tools:
+    url('^content/addon/%s/review$' % mkt.APP_SLUG, views.commonplace,
+        {'repo': 'marketplace-content-tools'},
+        name='commonplace.content.addon_review'),
     url('^content/.*$', views.commonplace,
         {'repo': 'marketplace-content-tools'},
         name='commonplace.content'),

--- a/mkt/site/tests/__init__.py
+++ b/mkt/site/tests/__init__.py
@@ -42,7 +42,8 @@ from mkt.search.indexers import BaseIndexer
 from mkt.site.fixtures import fixture
 from mkt.site.storage_utils import (copy_stored_file, local_storage,
                                     private_storage)
-from mkt.site.utils import app_factory, website_factory  # NOQA
+from mkt.site.utils import (app_factory, extension_factory,  # NOQA
+                            website_factory)  # NOQA
 from mkt.translations.hold import clean_translations
 from mkt.translations.models import Translation
 from mkt.users.models import UserProfile

--- a/mkt/site/utils.py
+++ b/mkt/site/utils.py
@@ -575,6 +575,16 @@ def app_factory(status=mkt.STATUS_PUBLIC, version_kw={}, file_kw={}, **kw):
     return app
 
 
+def extension_factory(status=mkt.STATUS_PUBLIC, **kw):
+    from mkt.extensions.models import Extension
+    name = u'Extension %s' % unicode(uuid.uuid4()).replace('-', '')
+
+    extension = Extension.objects.create(
+        name=name, slug=name.replace(' ', '-').lower()[:30], **kw)
+    extension.versions.create(status=status, version='0.1')
+    return extension
+
+
 def file_factory(**kw):
     from mkt.files.models import File
     v = kw['version']


### PR DESCRIPTION
- For logging all developer/reviewer actions, and email communications.
- I set comments wherever I detect app vs extension (```# grep: comm-content-type```)
