### PR TITLE
Add popularity and trending models for FxOS Add-ons (bug 1206737)

### DIFF
--- a/mkt/extensions/indexers.py
+++ b/mkt/extensions/indexers.py
@@ -84,6 +84,12 @@ class ExtensionIndexer(BaseIndexer):
             }
         }
 
+        # Attach boost field, because we are going to need search by relevancy.
+        cls.attach_boost_mapping(mapping)
+
+        # Attach popularity and trending.
+        cls.attach_trending_and_popularity_mappings(mapping)
+
         # Add extra mapping for translated fields, containing the "raw"
         # translations.
         cls.attach_translation_mappings(mapping, cls.translated_fields)
@@ -123,6 +129,9 @@ class ExtensionIndexer(BaseIndexer):
         # Find the first reviewed date (used in sort).
         doc['reviewed'] = obj.versions.public().aggregate(
             Min('reviewed')).get('reviewed__min')
+
+        # Add boost, popularity, trending values.
+        doc.update(cls.extract_popularity_trending_boost(obj))
 
         # Handle localized fields. This adds both the field used for search and
         # the one with all translations for the API.

--- a/mkt/extensions/migrations/0012_extension_popularity_and_trending.py
+++ b/mkt/extensions/migrations/0012_extension_popularity_and_trending.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('extensions', '0011_extensionversion_reviewed'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ExtensionPopularity',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('value', models.FloatField(default=0.0)),
+                ('region', models.PositiveIntegerField(default=0, db_index=True)),
+                ('extension', models.ForeignKey(related_name='popularity', to='extensions.Extension')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='WebsiteTrending',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('value', models.FloatField(default=0.0)),
+                ('region', models.PositiveIntegerField(default=0, db_index=True)),
+                ('extension', models.ForeignKey(related_name='trending', to='extensions.Extension')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterUniqueTogether(
+            name='websitetrending',
+            unique_together=set([('extension', 'region')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='extensionpopularity',
+            unique_together=set([('extension', 'region')]),
+        ),
+    ]

--- a/mkt/extensions/models.py
+++ b/mkt/extensions/models.py
@@ -147,6 +147,16 @@ class Extension(ModelBase):
     def get_indexer(self):
         return ExtensionIndexer
 
+    def is_dummy_content_for_qa(self):
+        """
+        Returns whether this extension is a dummy extension used for testing
+        only or not.
+
+        Used by mkt.search.utils.extract_popularity_trending_boost() - the
+        method needs to exist, but we are not using it yet.
+        """
+        return False
+
     def is_public(self):
         return self.status == STATUS_PUBLIC
 
@@ -451,6 +461,26 @@ class ExtensionVersion(ModelBase):
         }
         return absolutify(
             reverse('extension.download_unsigned', kwargs=kwargs))
+
+
+class ExtensionPopularity(ModelBase):
+    extension = models.ForeignKey(Extension, related_name='popularity')
+    value = models.FloatField(default=0.0)
+    # When region=0, we count across all regions.
+    region = models.PositiveIntegerField(null=False, default=0, db_index=True)
+
+    class Meta:
+        unique_together = ('extension', 'region')
+
+
+class WebsiteTrending(ModelBase):
+    extension = models.ForeignKey(Extension, related_name='trending')
+    value = models.FloatField(default=0.0)
+    # When region=0, it's trending using install counts across all regions.
+    region = models.PositiveIntegerField(null=False, default=0, db_index=True)
+
+    class Meta:
+        unique_together = ('extension', 'region')
 
 
 # Update ElasticSearch index on save.

--- a/mkt/extensions/tests/test_indexers.py
+++ b/mkt/extensions/tests/test_indexers.py
@@ -7,7 +7,7 @@ from mkt.constants.base import STATUS_PENDING, STATUS_PUBLIC
 from mkt.site.tests import ESTestCase, TestCase
 from mkt.extensions.indexers import ExtensionIndexer
 from mkt.extensions.models import Extension, ExtensionVersion
-from mkt.search.utils import get_boost
+from mkt.search.utils import BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT, get_boost
 
 
 class TestExtensionIndexer(TestCase):
@@ -107,8 +107,9 @@ class TestExtensionIndexer(TestCase):
         extension, version = self._extension_factory()
         # No installs.
         doc = self._get_doc(extension)
-        # Boost is multiplied by 4 if it's public.
-        eq_(doc['boost'], 1.0 * 4)
+        # Boost is multiplied by BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT if it's
+        # public.
+        eq_(doc['boost'], 1.0 * BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT)
         eq_(doc['popularity'], 0)
 
         # Add some popularity.

--- a/mkt/extensions/tests/test_indexers.py
+++ b/mkt/extensions/tests/test_indexers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
+import mock
 from nose.tools import eq_, ok_
 
 from mkt.constants.base import STATUS_PENDING, STATUS_PUBLIC
@@ -103,6 +104,7 @@ class TestExtensionIndexer(TestCase):
         eq_(doc['name_l10n_english'], [name['en-US']])
         eq_(doc['name_sort'], name['en-US'].lower())
 
+    @mock.patch('mkt.search.indexers.MATURE_REGION_IDS', [42])
     def test_popularity(self):
         extension, version = self._extension_factory()
         # No installs.
@@ -117,26 +119,27 @@ class TestExtensionIndexer(TestCase):
         # Test an adolescent region.
         extension.popularity.create(region=2, value=10.0)
         # Test a mature region.
-        extension.popularity.create(region=7, value=10.0)
+        extension.popularity.create(region=42, value=10.0)
 
         doc = self._get_doc(extension)
         eq_(doc['boost'], get_boost(extension))
         eq_(doc['popularity'], 50)
-        eq_(doc['popularity_7'], 10)
+        eq_(doc['popularity_42'], 10)
         # Adolescent regions popularity value is not stored.
         ok_('popularity_2' not in doc)
 
+    @mock.patch('mkt.search.indexers.MATURE_REGION_IDS', [42])
     def test_trending(self):
         extension, version = self._extension_factory()
         extension.trending.create(region=0, value=10.0)
         # Test an adolescent region.
         extension.trending.create(region=2, value=50.0)
         # Test a mature region.
-        extension.trending.create(region=7, value=50.0)
+        extension.trending.create(region=42, value=50.0)
 
         doc = self._get_doc(extension)
         eq_(doc['trending'], 10.0)
-        eq_(doc['trending_7'], 50.0)
+        eq_(doc['trending_42'], 50.0)
 
         # Adolescent regions trending value is not stored.
         ok_('trending_2' not in doc)

--- a/mkt/search/utils.py
+++ b/mkt/search/utils.py
@@ -8,6 +8,9 @@ from statsd import statsd
 from mkt.constants.base import VALID_STATUSES
 
 
+BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT = 4.0
+
+
 class Search(dslSearch):
 
     def execute(self):
@@ -70,6 +73,6 @@ def get_boost(obj):
 
     # We give a little extra boost to approved apps.
     if obj.status in VALID_STATUSES:
-        boost *= 4
+        boost *= BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT
 
     return boost

--- a/mkt/webapps/tests/test_indexers.py
+++ b/mkt/webapps/tests/test_indexers.py
@@ -2,6 +2,7 @@
 from django.test.utils import override_settings
 
 import json
+import mock
 from nose.tools import eq_, ok_
 
 import mkt
@@ -207,6 +208,7 @@ class TestWebappIndexer(TestCase):
         obj, doc = self._get_doc()
         eq_(doc['installs_allowed_from'], ['http://a.com', 'http://b.com'])
 
+    @mock.patch('mkt.search.indexers.MATURE_REGION_IDS', [42])
     def test_installs_to_popularity(self):
         # No installs.
         obj, doc = self._get_doc()
@@ -220,12 +222,12 @@ class TestWebappIndexer(TestCase):
         # Test an adolescent region.
         self.app.popularity.create(region=2, value=10.0)
         # Test a mature region.
-        self.app.popularity.create(region=7, value=10.0)
+        self.app.popularity.create(region=42, value=10.0)
 
         obj, doc = self._get_doc()
         eq_(doc['boost'], get_boost(self.app))
         eq_(doc['popularity'], 50)
-        eq_(doc['popularity_7'], 10)
+        eq_(doc['popularity_42'], 10)
         # Adolescent regions popularity value is not stored.
         ok_('popularity_2' not in doc)
 
@@ -239,16 +241,17 @@ class TestWebappIndexer(TestCase):
         eq_(doc['trending'], 0)
         eq_(doc['trending_7'], 0)
 
+    @mock.patch('mkt.search.indexers.MATURE_REGION_IDS', [42])
     def test_trending(self):
         self.app.trending.create(region=0, value=10.0)
         # Test an adolescent region.
         self.app.trending.create(region=2, value=50.0)
         # Test a mature region.
-        self.app.trending.create(region=7, value=50.0)
+        self.app.trending.create(region=42, value=50.0)
 
         obj, doc = self._get_doc()
         eq_(doc['trending'], 10.0)
-        eq_(doc['trending_7'], 50.0)
+        eq_(doc['trending_42'], 50.0)
         # Adolescent regions trending value is not stored.
         ok_('trending_2' not in doc)
 

--- a/mkt/webapps/tests/test_indexers.py
+++ b/mkt/webapps/tests/test_indexers.py
@@ -7,7 +7,7 @@ from nose.tools import eq_, ok_
 import mkt
 from mkt.constants.applications import DEVICE_TYPES
 from mkt.reviewers.models import EscalationQueue, RereviewQueue
-from mkt.search.utils import get_boost
+from mkt.search.utils import BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT, get_boost
 from mkt.site.fixtures import fixture
 from mkt.site.tests import ESTestCase, TestCase
 from mkt.site.utils import version_factory
@@ -210,8 +210,9 @@ class TestWebappIndexer(TestCase):
     def test_installs_to_popularity(self):
         # No installs.
         obj, doc = self._get_doc()
-        # Boost is multiplied by 4 if it's public.
-        eq_(doc['boost'], 1 * 4)
+        # Boost is multiplied by BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT if it's
+        # public.
+        eq_(doc['boost'], 1 * BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT)
         eq_(doc['popularity'], 0)
 
         # Many installs.
@@ -232,7 +233,7 @@ class TestWebappIndexer(TestCase):
     def test_popularity_qa_app(self):
         self.app.popularity.create(region=0, value=50.0)
         obj, doc = self._get_doc()
-        eq_(doc['boost'], 1 * 4)
+        eq_(doc['boost'], 1 * BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT)
         eq_(doc['popularity'], 0)
         eq_(doc['popularity_7'], 0)
         eq_(doc['trending'], 0)

--- a/mkt/websites/tests/test_indexers.py
+++ b/mkt/websites/tests/test_indexers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 from nose.tools import eq_, ok_
 
 from mkt.constants.applications import DEVICE_DESKTOP, DEVICE_GAIA
@@ -107,6 +108,7 @@ class TestWebsiteIndexer(TestCase):
         eq_(doc['name_l10n_english'], [name['en-US']])
         eq_(doc['name_sort'], name['en-US'].lower())
 
+    @mock.patch('mkt.search.indexers.MATURE_REGION_IDS', [42])
     def test_installs_to_popularity(self):
         self.obj = website_factory()
         # No installs.
@@ -121,26 +123,27 @@ class TestWebsiteIndexer(TestCase):
         # Test an adolescent region.
         self.obj.popularity.create(region=2, value=10.0)
         # Test a mature region.
-        self.obj.popularity.create(region=7, value=10.0)
+        self.obj.popularity.create(region=42, value=10.0)
 
         doc = self._get_doc()
         eq_(doc['boost'], get_boost(self.obj))
         eq_(doc['popularity'], 50)
-        eq_(doc['popularity_7'], 10)
+        eq_(doc['popularity_42'], 10)
         # Adolescent regions popularity value is not stored.
         ok_('popularity_2' not in doc)
 
+    @mock.patch('mkt.search.indexers.MATURE_REGION_IDS', [42])
     def test_trending(self):
         self.obj = website_factory()
         self.obj.trending.create(region=0, value=10.0)
         # Test an adolescent region.
         self.obj.trending.create(region=2, value=50.0)
         # Test a mature region.
-        self.obj.trending.create(region=7, value=50.0)
+        self.obj.trending.create(region=42, value=50.0)
 
         doc = self._get_doc()
         eq_(doc['trending'], 10.0)
-        eq_(doc['trending_7'], 50.0)
+        eq_(doc['trending_42'], 50.0)
 
         # Adolescent regions trending value is not stored.
         ok_('trending_2' not in doc)

--- a/mkt/websites/tests/test_indexers.py
+++ b/mkt/websites/tests/test_indexers.py
@@ -3,7 +3,7 @@ from nose.tools import eq_, ok_
 
 from mkt.constants.applications import DEVICE_DESKTOP, DEVICE_GAIA
 from mkt.constants.regions import URY, USA
-from mkt.search.utils import get_boost
+from mkt.search.utils import BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT, get_boost
 from mkt.site.tests import ESTestCase, TestCase
 from mkt.tags.models import Tag
 from mkt.websites.indexers import WebsiteIndexer
@@ -111,8 +111,9 @@ class TestWebsiteIndexer(TestCase):
         self.obj = website_factory()
         # No installs.
         doc = self._get_doc()
-        # Boost is multiplied by 4 if it's public.
-        eq_(doc['boost'], 1.0 * 4)
+        # Boost is multiplied by BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT if it's
+        # public.
+        eq_(doc['boost'], 1.0 * BOOST_MULTIPLIER_FOR_PUBLIC_CONTENT)
         eq_(doc['popularity'], 0)
 
         # Add some popularity.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1206737

Base code that we'll need to store popularity (installs numbers) for FxOS Add-ons.