### PR TITLE
Implement "rejected" status for FxOS Add-ons (bug 1211023)

### DIFF
--- a/docs/api/topics/firefox_os_addons.rst
+++ b/docs/api/topics/firefox_os_addons.rst
@@ -250,14 +250,15 @@ Delete
 Add-on Statuses
 ===============
 
-* There are 3 possible values for the ``status`` property of an add-on: *public*, *pending* or *incomplete*.
+* There are 4 possible values for the ``status`` property of an add-on: *public*, *pending*, *rejected* or *incomplete*.
 * There are 4 possible values for the ``status`` property on an add-on version: *public*, *obsolete*, *pending*, *rejected*.
 
 Add-on ``status`` directly depend on the ``status`` of its versions:
 
 * Add-ons with at least one *public* version are *public*.
 * Add-ons with no *public* version and at least one *pending* version are *pending*.
-* Add-ons with no *public* or *pending* version are *incomplete*.
+* Add-ons with no *public* or *pending* version, and at least one *rejected* version are *rejected*.
+* Add-ons with no *public*, *pending* or *rejected* version are *incomplete*.
 
 In addition, Add-ons also have a ``disabled`` property that can be set to ``true``
 by the developer to disable the add-on. Disabled add-ons are hidden from the public

--- a/mkt/extensions/tests/test_models.py
+++ b/mkt/extensions/tests/test_models.py
@@ -604,6 +604,20 @@ class TestExtensionStatusChanges(TestCase):
         eq_(extension.latest_version, new_public_version)
         eq_(extension.latest_public_version, new_public_version)
 
+    def test_new_version_rejected(self):
+        extension = Extension.objects.create()
+        eq_(extension.status, STATUS_NULL)
+        version = ExtensionVersion.objects.create(
+            extension=extension, status=STATUS_REJECTED, version='0.1')
+        eq_(extension.status, STATUS_REJECTED)
+        eq_(extension.latest_version, version)
+
+        new_version = ExtensionVersion.objects.create(
+            extension=extension, status=STATUS_REJECTED, version='0.2')
+        extension.reload()
+        eq_(extension.status, STATUS_REJECTED)
+        eq_(extension.latest_version, new_version)
+
     def test_update_fields_from_manifest_when_version_is_made_public(self):
         new_manifest = {
             'author': u' New Authôr',
@@ -1069,15 +1083,13 @@ class TestExtensionAndExtensionVersionMethodsAndProperties(TestCase):
         eq_(remove_public_signed_file_mock.call_count, 1)
         eq_(version.size, 667)
         eq_(version.status, STATUS_REJECTED)
-        # At the moment Extension are not rejected, merely set back to
-        # incomplete since they no longer have a pending or public version.
-        eq_(extension.status, STATUS_NULL)
+        eq_(extension.status, STATUS_REJECTED)
 
         # Also reload to make sure the changes hit the database.
         version.reload()
         eq_(version.size, 667)
         eq_(version.status, STATUS_REJECTED)
-        eq_(extension.reload().status, STATUS_NULL)
+        eq_(extension.reload().status, STATUS_REJECTED)
 
 
 class TestExtensionPopularity(TestCase):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1211023

We already had it for versions, but we want it for add-ons as well.