### PR TITLE
Correctly add detail to validation exceptions.

### DIFF
--- a/mkt/extensions/tests/test_validation.py
+++ b/mkt/extensions/tests/test_validation.py
@@ -49,8 +49,8 @@ class TestExtensionValidator(TestCase):
             yield
         except Exception, e:
             eq_(e.__class__, ParseError)
-            eq_(e.message['key'], key)
-            eq_(e.message['message'], ExtensionValidator.errors[key])
+            eq_(e.detail['key'], key)
+            eq_(e.detail['message'], ExtensionValidator.errors[key])
         else:
             self.fail('Does not raise a ParseError.')
 

--- a/mkt/extensions/tests/test_views.py
+++ b/mkt/extensions/tests/test_views.py
@@ -246,6 +246,7 @@ class TestExtensionViewSetPost(UploadTest, RestOAuth):
         response = self.client.post(
             self.list_url, json.dumps({'validation_id': upload.pk}))
         eq_(response.status_code, 400)
+        eq_(u'NO_MANIFEST', response.json['detail']['key'])
 
 
 class TestExtensionViewSetDelete(RestOAuth):

--- a/mkt/extensions/validation.py
+++ b/mkt/extensions/validation.py
@@ -66,12 +66,10 @@ class ExtensionValidator(object):
         self.file_obj = file_obj
 
     def error(self, error_key):
-        error = ParseError()
-        error.message = {
+        raise ParseError(detail={
             'key': error_key,
             'message': self.errors[error_key],
-        }
-        raise error
+        })
 
     def validate(self):
         """


### PR DESCRIPTION
DRF exceptions apparently don't handle messages in the same way as Python's do by default.