### PR TITLE
Changes default extension sort to id DESC (bug 1210949).

### DIFF
--- a/mkt/extensions/models.py
+++ b/mkt/extensions/models.py
@@ -96,7 +96,7 @@ class Extension(ModelBase):
         'author', 'description', 'default_language', 'name')
 
     class Meta:
-        ordering = ('id', )
+        ordering = ('-id', )
         index_together = (('deleted', 'disabled', 'status'),)
 
     @cached_property(writable=True)

--- a/mkt/extensions/tests/test_models.py
+++ b/mkt/extensions/tests/test_models.py
@@ -1222,7 +1222,7 @@ class TestExtensionQuerySetAndManager(TestCase):
             deleted=True, status=STATUS_PUBLIC)
         Extension.objects.create(status=STATUS_NULL)
         Extension.objects.create(status=STATUS_PUBLIC, disabled=True)
-        eq_(list(Extension.objects.public()), [extension1, extension2])
+        eq_(list(Extension.objects.public()), [extension2, extension1])
         eq_(list(Extension.objects.without_deleted().public()), [extension1])
 
     def test_pending(self):
@@ -1240,7 +1240,7 @@ class TestExtensionQuerySetAndManager(TestCase):
         ExtensionVersion.objects.create(
             extension=disabled_extension, status=STATUS_PENDING, version='3.1')
 
-        eq_(list(Extension.objects.pending()), [extension1, extension2])
+        eq_(list(Extension.objects.pending()), [extension2, extension1])
         eq_(list(Extension.objects.without_deleted().pending()), [extension1])
 
 


### PR DESCRIPTION
r? @ngokevin 

The right way to fix this is to set up a sort query param, but beta and whatnot. This is probably good enough for now.