### PR TITLE
Update add-ons permission checks to use ContentTools:AddonSubmit.

### DIFF
--- a/docs/api/topics/firefox_os_addons.rst
+++ b/docs/api/topics/firefox_os_addons.rst
@@ -27,7 +27,7 @@ Detail
 
     .. note::
         Non public add-ons can only be viewed by their authors or extension
-        reviewers (users with the *Extensions:Review* permission)
+        reviewers (users with the *ContentTools:AddonReview* permission)
 
     A single add-on.
 
@@ -181,7 +181,7 @@ Detail
 
     .. note::
         Non public add-ons versions can only be viewed by their authors or
-        extension reviewers (users with the *Extensions:Review* permission)
+        extension reviewers (users with the *ContentTools:AddonReview* permission)
 
     A single add-on version.
 
@@ -201,9 +201,9 @@ Detail
 
     :resjson string created: The creation date for this version.
     :resjson string download_url: The (absolute) URL to the latest signed package for that add-on. That URL may be a 404 if the add-on is not public.
-    :resjson string reviewer_mini_manifest_url: The (absolute) URL to the reviewer-specific mini_manifest URL (allowing reviewers to install a non-public version) for this version. Only users with Extensions:Review permission may access it.
+    :resjson string reviewer_mini_manifest_url: The (absolute) URL to the reviewer-specific mini_manifest URL (allowing reviewers to install a non-public version) for this version. Only users with ContentTools:AddonReview permission may access it.
     :resjson string status: The add-on version current status. Can be *pending*, *obsolete*, *public* or *rejected*.
-    :resjson string unsigned_download_url: The (absolute) URL to the latest *unsigned* package for that add-on. Only the add-on author or users with Extensions:Review permission may access it.
+    :resjson string unsigned_download_url: The (absolute) URL to the latest *unsigned* package for that add-on. Only the add-on author or users with ContentTools:AddonReview permission may access it.
     :resjson string version: The version number for this add-on version.
 
     :param int id: The add-on id
@@ -221,7 +221,7 @@ List
 
     .. note::
         Non public add-ons versions can only be viewed by their authors or
-        extension reviewers (users with the *Extensions:Review* permission)
+        extension reviewers (users with the *ContentTools:AddonReview* permission)
 
     A list of versions attached to an add-on.
 
@@ -394,7 +394,7 @@ List
 
 .. http:get:: /api/v2/extensions/queue/
 
-    .. note:: Requires authentication and the Extensions:Review permission.
+    .. note:: Requires authentication and the ContentTools:AddonReview permission.
 
     The list of add-ons in the review queue.
 

--- a/mkt/extensions/permissions.py
+++ b/mkt/extensions/permissions.py
@@ -6,7 +6,7 @@ from mkt.access import acl
 class AllowExtensionReviewerReadOnly(BasePermission):
     def has_permission(self, request, view):
         return request.method in SAFE_METHODS and acl.action_allowed(
-            request, 'Extensions', 'Review')
+            request, 'ContentTools', 'AddonReview')
 
     def has_object_permission(self, request, view, object):
         # The object does not matter: as long as it's for a read-only action,

--- a/mkt/extensions/tests/test_permissions.py
+++ b/mkt/extensions/tests/test_permissions.py
@@ -41,7 +41,7 @@ class TestAllowExtensionReviewerReadOnly(TestCase):
 
     def test_has_permission_reviewer(self):
         self.user = UserProfile.objects.get(pk=2519)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         for verb in self.safe_methods:
             eq_(self.permission.has_permission(self._request(verb), 'myview'),
                 True)
@@ -67,7 +67,7 @@ class TestAllowExtensionReviewerReadOnly(TestCase):
 
     def test_has_object_permission_reviewer(self):
         self.user = UserProfile.objects.get(pk=2519)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         obj = Mock()
 
         for verb in self.safe_methods:

--- a/mkt/extensions/tests/test_views.py
+++ b/mkt/extensions/tests/test_views.py
@@ -723,13 +723,13 @@ class TestReviewersExtensionViewSetGet(RestOAuth):
         eq_(response.status_code, 403)
 
     def test_list_logged_in_with_rights_status(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         response = self.client.get(self.list_url)
         eq_(response.status_code, 200)
         eq_(len(response.json['objects']), 1)
 
     def test_list_logged_in_with_rights_deleted(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         # Deleted extensions do not show up in the review queue.
         self.extension.update(deleted=True)
         response = self.client.get(self.list_url)
@@ -737,7 +737,7 @@ class TestReviewersExtensionViewSetGet(RestOAuth):
         eq_(len(response.json['objects']), 0)
 
     def test_list_logged_in_with_rights_disabled(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         # Disabled extensions do not show up in the review queue.
         self.extension.update(disabled=True)
         response = self.client.get(self.list_url)
@@ -745,7 +745,7 @@ class TestReviewersExtensionViewSetGet(RestOAuth):
         eq_(len(response.json['objects']), 0)
 
     def test_list_logged_in_with_rights(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         response = self.client.get(self.list_url)
         eq_(response.status_code, 200)
         data = response.json['objects'][0]
@@ -781,12 +781,12 @@ class TestReviewersExtensionViewSetGet(RestOAuth):
 
     def test_detail_logged_in_with_rights_status_public(self):
         self.version.update(status=STATUS_PUBLIC)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         response = self.client.get(self.url)
         eq_(response.status_code, 404)
 
     def test_detail_logged_in_with_rights(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         response = self.client.get(self.url)
         eq_(response.status_code, 200)
         data = response.json
@@ -818,14 +818,14 @@ class TestReviewersExtensionViewSetGet(RestOAuth):
         self.test_detail_logged_in_with_rights()
 
     def test_detail_logged_in_with_rights_deleted(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         # Deleted extensions do not show up in the review queue.
         self.extension.update(deleted=True)
         response = self.client.get(self.url)
         eq_(response.status_code, 404)
 
     def test_detail_logged_in_with_rights_disabled(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         # Disabled extensions do not show up in the review queue.
         self.extension.update(disabled=True)
         response = self.client.get(self.url)
@@ -1106,7 +1106,7 @@ class TestExtensionVersionViewSetPost(UploadTest, RestOAuth):
         eq_(response.status_code, 403)
 
     def test_post_non_existing_extension(self):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.list_url = reverse('api-v2:extension-version-list', kwargs={
             'extension_pk': self.extension.pk + 42})
         self.publish_url = reverse('api-v2:extension-version-publish', kwargs={
@@ -1177,7 +1177,7 @@ class TestExtensionVersionViewSetPost(UploadTest, RestOAuth):
 
     @mock.patch('mkt.extensions.models.ExtensionVersion.sign_file')
     def test_publish_disabled(self, sign_file_mock):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.extension.update(disabled=True)
         response = self.client.post(self.publish_url)
         eq_(response.status_code, 403)
@@ -1185,7 +1185,7 @@ class TestExtensionVersionViewSetPost(UploadTest, RestOAuth):
 
     @mock.patch('mkt.extensions.models.ExtensionVersion.sign_file')
     def test_publish(self, sign_file_mock):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         sign_file_mock.return_value = 665
         response = self.client.post(self.publish_url, data=json.dumps({
             'message': u'Nîce extension'
@@ -1204,7 +1204,7 @@ class TestExtensionVersionViewSetPost(UploadTest, RestOAuth):
 
     @mock.patch.object(ExtensionVersion, 'remove_public_signed_file')
     def test_reject_disabled(self, remove_public_signed_file_mock):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.extension.update(disabled=True)
         response = self.client.post(self.reject_url)
         eq_(response.status_code, 403)
@@ -1212,7 +1212,7 @@ class TestExtensionVersionViewSetPost(UploadTest, RestOAuth):
 
     @mock.patch.object(ExtensionVersion, 'remove_public_signed_file')
     def test_reject(self, remove_public_signed_file_mock):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         remove_public_signed_file_mock.return_value = 666
         response = self.client.post(self.reject_url, data=json.dumps({
             'message': u'Bâd extension'
@@ -1395,7 +1395,7 @@ class TestExtensionNonAPIViews(TestCase):
         response = self.client.get(self.version.download_url)
         eq_(response.status_code, 404)
 
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
         response = self.client.get(self.version.download_url)
         # Even authors and reviewers can't access it: it doesn't exist.
@@ -1403,7 +1403,7 @@ class TestExtensionNonAPIViews(TestCase):
 
     def test_download_signed_deleted(self):
         self.extension.update(deleted=True)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
         response = self.client.get(self.version.download_url)
         # Even authors and reviewers can't access it: it doesn't exist.
@@ -1411,7 +1411,7 @@ class TestExtensionNonAPIViews(TestCase):
 
     def test_download_signed_version_deleted(self):
         self.version.update(deleted=True)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
         response = self.client.get(self.version.download_url)
         # Even authors and reviewers can't access it: it doesn't exist.
@@ -1429,7 +1429,7 @@ class TestExtensionNonAPIViews(TestCase):
 
     def test_download_signed_reviewer_deleted(self):
         self.extension.update(deleted=True)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
 
         ok_(self.version.reviewer_download_url)
@@ -1438,7 +1438,7 @@ class TestExtensionNonAPIViews(TestCase):
 
     def test_download_signed_reviewer_version_deleted(self):
         self.version.update(deleted=True)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
 
         ok_(self.version.reviewer_download_url)
@@ -1451,7 +1451,7 @@ class TestExtensionNonAPIViews(TestCase):
     @mock.patch.object(ExtensionVersion, 'reviewer_sign_if_necessary')
     def test_download_signed_reviewer_with_reviewer_permission(
             self, reviewer_sign_if_necessary_mock):
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.version.update(status=STATUS_PENDING)
         ok_(self.version.reviewer_download_url)
         self.login(self.user)
@@ -1470,7 +1470,7 @@ class TestExtensionNonAPIViews(TestCase):
     def test_download_signed_reviewer_with_reviewer_permission_using_storage(
             self, private_storage_mock, reviewer_sign_if_necessary_mock):
         private_storage_mock.url = lambda path: 'https://s3.priv/%s' % path
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.version.update(status=STATUS_PENDING)
         ok_(self.version.reviewer_download_url)
         self.login(self.user)
@@ -1519,7 +1519,7 @@ class TestExtensionNonAPIViews(TestCase):
         response = self.client.get(self.version.unsigned_download_url)
         eq_(response.status_code, 403)
 
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         response = self.client.get(self.version.unsigned_download_url)
         eq_(response.status_code, 200)
 
@@ -1542,7 +1542,7 @@ class TestExtensionNonAPIViews(TestCase):
         response = self.client.get(self.version.unsigned_download_url)
         eq_(response.status_code, 403)
 
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         response = self.client.get(self.version.unsigned_download_url)
         self.assert3xx(response, expected_path)
 
@@ -1602,7 +1602,7 @@ class TestExtensionNonAPIViews(TestCase):
         self.version.update(status=STATUS_PENDING)
         ok_(self.version.reviewer_mini_manifest_url)
         ok_(self.version.reviewer_mini_manifest)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
         response = self.client.get(self.version.reviewer_mini_manifest_url)
         eq_(response.status_code, 200)
@@ -1611,7 +1611,7 @@ class TestExtensionNonAPIViews(TestCase):
 
     def test_reviewer_mini_manifest_etag(self):
         self.version.update(status=STATUS_PENDING)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
         response = self.client.get(self.version.reviewer_mini_manifest_url)
         eq_(response.status_code, 200)
@@ -1642,7 +1642,7 @@ class TestExtensionNonAPIViews(TestCase):
     def test_reviewer_mini_manifest_deleted(self):
         self.version.update(status=STATUS_PENDING)
         self.extension.update(deleted=True)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
         # `reviewer_mini_manifest_url` exists but is a 404 when the extension
         # or the version is deleted.
@@ -1652,7 +1652,7 @@ class TestExtensionNonAPIViews(TestCase):
 
     def test_reviewer_mini_manifest_version_deleted(self):
         self.version.update(status=STATUS_PENDING, deleted=True)
-        self.grant_permission(self.user, 'Extensions:Review')
+        self.grant_permission(self.user, 'ContentTools:AddonReview')
         self.login(self.user)
         # `reviewer_mini_manifest_url` exists but is a 404 when the extension
         # or the version is deleted.

--- a/mkt/extensions/views.py
+++ b/mkt/extensions/views.py
@@ -182,8 +182,8 @@ class ReviewersExtensionViewSet(CORSMixin, SlugOrIdMixin, MarketplaceView,
     cors_allowed_methods = ('get', 'post')
     permission_classes = (ByHttpMethod({
         'options': AllowAny,
-        'post': GroupPermission('Extensions', 'Review'),
-        'get': GroupPermission('Extensions', 'Review'),
+        'post': GroupPermission('ContentTools', 'AddonReview'),
+        'get': GroupPermission('ContentTools', 'AddonReview'),
     }),)
     queryset = Extension.objects.without_deleted().pending()
     serializer_class = ExtensionSerializer
@@ -303,7 +303,7 @@ def download_signed_reviewer(request, uuid, **kwargs):
         extension.versions.without_deleted(), pk=kwargs['version_id'])
 
     def is_reviewer():
-        return action_allowed(request, 'Extensions', 'Review')
+        return action_allowed(request, 'ContentTools', 'AddonReview')
 
     if request.user.is_authenticated() and is_reviewer():
         version.reviewer_sign_if_necessary()
@@ -329,7 +329,7 @@ def download_unsigned(request, uuid, **kwargs):
         return extension.authors.filter(pk=request.user.pk).exists()
 
     def is_reviewer():
-        return action_allowed(request, 'Extensions', 'Review')
+        return action_allowed(request, 'ContentTools', 'AddonReview')
 
     if request.user.is_authenticated() and (is_author() or is_reviewer()):
         log.info('Downloading unsigned add-on: %s version %s from %s' % (
@@ -362,7 +362,7 @@ def mini_manifest_reviewer(request, uuid, **kwargs):
         extension.versions.without_deleted(), pk=kwargs['version_id'])
 
     def is_reviewer():
-        return action_allowed(request, 'Extensions', 'Review')
+        return action_allowed(request, 'ContentTools', 'AddonReview')
 
     if request.user.is_authenticated() and is_reviewer():
         manifest = version.reviewer_mini_manifest


### PR DESCRIPTION
r? @washort @ngokevin 

Separately, mat and I created groups and permissions for extension review. This replaces all instances of `Extensions:Review` with `ContentTools:AddonReview`.