### PR TITLE
Never consider deleted versions in Extension.objects.pending() (bug 1213027)

### DIFF
--- a/mkt/extensions/models.py
+++ b/mkt/extensions/models.py
@@ -46,7 +46,8 @@ class ExtensionQuerySet(models.QuerySet):
             return self.get(slug=identifier)
 
     def pending(self):
-        return self.filter(disabled=False, versions__status=STATUS_PENDING)
+        return self.filter(disabled=False, versions__deleted=False,
+                           versions__status=STATUS_PENDING)
 
     def public(self):
         return self.filter(disabled=False, status=STATUS_PUBLIC)

--- a/mkt/extensions/tests/test_models.py
+++ b/mkt/extensions/tests/test_models.py
@@ -1234,6 +1234,10 @@ class TestExtensionQuerySetAndManager(TestCase):
             extension=extension2, status=STATUS_PENDING, version='2.1')
         ExtensionVersion.objects.create(
             extension=extension2, status=STATUS_PUBLIC, version='2.2')
+        extension3 = Extension.objects.create()
+        ExtensionVersion.objects.create(
+            extension=extension3, deleted=True, status=STATUS_PENDING,
+            version='3.1')
         Extension.objects.create(status=STATUS_PUBLIC)
         Extension.objects.create(status=STATUS_NULL)
         disabled_extension = Extension.objects.create(disabled=True)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1213027

It's a little unfortunate there is no easy way to combine queryset methods properly here. It would have been great to be able to write something like:

`Extension.objects.without_deleted().filter(disabled=False).filter(
    versions=ExtensionVersion.objects.pending().without_deleted())`

But this causes a nasty subselect. We probably never care about deleted versions when looking for pending add-ons, so let's keep it simple and modify the pending() queryset method directly.