### PR TITLE
Store icon_hash for FxOS Add-ons in Elasticsearch (bug 1217441)

### DIFF
--- a/mkt/extensions/indexers.py
+++ b/mkt/extensions/indexers.py
@@ -67,6 +67,7 @@ class ExtensionIndexer(BaseIndexer):
                         'position_offset_gap': 100,
                     },
                     'device': {'type': 'byte'},
+                    'icon_hash': cls.string_not_indexed(),
                     'is_deleted': {'type': 'boolean'},
                     'is_disabled': {'type': 'boolean'},
                     'last_updated': {'format': 'dateOptionalTime',
@@ -128,8 +129,8 @@ class ExtensionIndexer(BaseIndexer):
         # Attach translations for searching and indexing.
         attach_trans_dict(cls.get_model(), [obj])
 
-        attrs = ('author', 'created', 'default_language', 'id', 'last_updated',
-                 'modified', 'slug', 'status')
+        attrs = ('author', 'created', 'default_language', 'icon_hash', 'id',
+                 'last_updated', 'modified', 'slug', 'status')
         doc = dict(zip(attrs, attrgetter(*attrs)(obj)))
 
         doc['device'] = obj.devices

--- a/mkt/extensions/serializers.py
+++ b/mkt/extensions/serializers.py
@@ -77,7 +77,7 @@ class ESExtensionSerializer(BaseESSerializer, ExtensionSerializer):
         # Set basic attributes we'll need on the fake instance using the data
         # from ES.
         self._attach_fields(
-            obj, data, ('author', 'created', 'default_language',
+            obj, data, ('author', 'created', 'default_language', 'icon_hash',
                         'last_updated', 'modified', 'slug', 'status',
                         'version'))
 

--- a/mkt/extensions/tests/test_views.py
+++ b/mkt/extensions/tests/test_views.py
@@ -339,7 +339,8 @@ class TestExtensionViewSetGet(RestOAuth):
         self.user2 = UserProfile.objects.get(pk=999)
         self.extension = Extension.objects.create(
             author=u'My Favourité Author',
-            description=u'Mÿ Extension Description', name=u'Mŷ Extension')
+            description=u'Mÿ Extension Description', icon_hash='654321',
+            name=u'Mŷ Extension')
         self.version = ExtensionVersion.objects.create(
             extension=self.extension, size=4242, status=STATUS_PENDING,
             version='0.42')
@@ -597,6 +598,7 @@ class TestExtensionSearchView(RestOAuth, ESTestCase):
         self.extension = Extension.objects.create(
             author=u'MäÄägnificent Author',
             description=u'Mâgnificent Extension Description',
+            icon_hash='abcdef',
             name=u'Mâgnificent Extension',
             last_updated=self.last_updated_date)
         self.version = ExtensionVersion.objects.create(
@@ -874,7 +876,8 @@ class ReviewQueueTestMixin(object):
         self.user = UserProfile.objects.get(pk=2519)
 
         another_extension = Extension.objects.create(
-            name=u'Anothër Extension', description=u'Anothër Description')
+            name=u'Anothër Extension', description=u'Anothër Description',
+            icon_hash='fdecba')
         ExtensionVersion.objects.create(
             extension=another_extension, size=888, status=STATUS_PUBLIC,
             version='0.1')
@@ -940,7 +943,8 @@ class TestReviewerExtensionViewSet(ReviewQueueTestMixin, RestOAuth):
         super(TestReviewerExtensionViewSet, self).setUp()
         self.list_url = reverse('api-v2:extension-queue-list')
         self.extension = Extension.objects.create(
-            name=u'Än Extension', description=u'Än Extension Description')
+            name=u'Än Extension', description=u'Än Extension Description',
+            icon_hash='123456')
         self.version = ExtensionVersion.objects.create(
             status=STATUS_PENDING, extension=self.extension, size=999,
             version='48.1516.2342')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1217441

Otherwise we can't return the correct icon url in search results.