### PR TITLE
don't use perms for reviewer log endpoint

### DIFF
--- a/mkt/comm/models.py
+++ b/mkt/comm/models.py
@@ -260,6 +260,7 @@ class CommunicationThreadCC(ModelBase):
 class CommunicationNoteManager(models.Manager):
 
     def with_perms(self, profile, thread=None):
+        """Warning: very slow, dangerous to apply on unfiltered querysets."""
         qs = self.all()
         if thread:
             qs = self.filter(thread=thread)

--- a/mkt/comm/views.py
+++ b/mkt/comm/views.py
@@ -206,7 +206,9 @@ class NoteListView(CORSMixin, ListAPIView, MarketplaceView):
     cors_allowed_methods = ['get']
 
     def get_queryset(self):
-        return CommunicationNote.objects.with_perms(self.request.user)
+        return (CommunicationNote.objects.all()
+                                 .select_related('thread', 'author')
+                                 .prefetch_related('attachments'))
 
 
 class AttachmentViewSet(CreateModelMixin, CommViewSet):


### PR DESCRIPTION
i hold the record for slowest endpoint in zamboni