### PR TITLE
Add IARC v2 mappings and a basic de-serializer (bug 1228364, bug 1228371)

### DIFF
--- a/lib/iarc/serializers.py
+++ b/lib/iarc/serializers.py
@@ -1,0 +1,66 @@
+from rest_framework.exceptions import ParseError
+
+from mkt.constants.iarc_mappings import (BODIES, DESCS_V2, INTERACTIVES_V2,
+                                         RATINGS)
+from mkt.site.utils import cached_property
+
+
+class IARCV2RatingListSerializer(object):
+    """Class that is used to de-serialize json sent/received from IARC to our
+    ratings/descriptors/interactive model instances for a given app.
+
+    Not a true rest-framework serializer, because there is little point: it
+    has to deal with several instances for each model, and we don't care about
+    serializing back to json."""
+
+    def __init__(self, instance=None, data=None):
+        self.instance = instance
+        self.data = data
+
+    @cached_property
+    def validated_data(self):
+        validated_data = {
+            'descriptors': set(),
+            'interactives': set(),
+            'ratings': {},
+
+        }
+        rating_list = self.data.get('RatingList')
+        if not rating_list:
+            return None
+
+        for raw_info in rating_list:
+            body = BODIES.get(raw_info['RatingAuthorityShortText'].lower())
+            if not body:
+                # Ignore unknown rating bodies.
+                continue
+            validated_data['ratings'][body] = RATINGS[body.id].get(
+                raw_info['AgeRatingText'], RATINGS[body.id]['default'])
+
+            for raw_descriptor in raw_info['DescriptorList']:
+                descriptor = DESCS_V2[body.id].get(raw_descriptor[
+                    'DescriptorText'])
+                if descriptor:
+                    validated_data['descriptors'].add(descriptor)
+
+            for raw_interactive in raw_info['InteractiveElementList']:
+                interactive = INTERACTIVES_V2.get(raw_interactive[
+                    'InteractiveElementText'])
+                if interactive:
+                    validated_data['interactives'].add(interactive)
+
+        return validated_data
+
+    def is_valid(self):
+        return bool(self.validated_data)
+
+    def save(self):
+        if not self.instance:
+            raise ValueError('Can not save without an instance.')
+
+        if not self.is_valid():
+            raise ParseError('Can not save with invalid data.')
+
+        self.instance.set_descriptors(self.validated_data['descriptors'])
+        self.instance.set_interactives(self.validated_data['interactives'])
+        self.instance.set_content_ratings(self.validated_data['ratings'])

--- a/lib/iarc/tests/test_serializers.py
+++ b/lib/iarc/tests/test_serializers.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+import mock
+from nose.tools import eq_
+from rest_framework.exceptions import ParseError
+
+import mkt.site.tests
+from mkt.constants import ratingsbodies
+from lib.iarc.serializers import IARCV2RatingListSerializer
+
+
+class TestIARCV2RatingListSerializer(mkt.site.tests.TestCase):
+    def test_validate_no_rating_list(self):
+        serializer = IARCV2RatingListSerializer(None, {})
+        eq_(serializer.validated_data, None)
+        eq_(serializer.is_valid(), False)
+
+    def test_validate_rating_list_empty(self):
+        serializer = IARCV2RatingListSerializer(None, {'RatingList': []})
+        eq_(serializer.validated_data, None)
+        eq_(serializer.is_valid(), False)
+
+    def test_validate_with_unknown_body(self):
+        data = {
+            'RatingList': [
+                {
+                    'RatingAuthorityShortText': 'Blah',
+                    'AgeRatingText': '12+',
+                }
+            ]
+        }
+        serializer = IARCV2RatingListSerializer(None, data)
+        # The unknown body should not generate an error
+        eq_(serializer.validated_data,
+            {'descriptors': set([]), 'interactives': set([]), 'ratings': {}})
+        eq_(serializer.is_valid(), True)
+
+    def test_validate_multiple_bodies_with_redundant_info(self):
+        data = {
+            'RatingList': [
+                {
+                    'RatingAuthorityShortText': 'Generic',
+                    'AgeRatingText': '12+',
+                    'DescriptorList': [{'DescriptorText': 'PEGI_Violence'}],
+                    'InteractiveElementList': [
+                        {'InteractiveElementText': 'IE_UsersInteract'},
+                        {'InteractiveElementText': 'IE_SharesLocation'},
+                        {'InteractiveElementText': 'IE_DigitalPurchases'}
+                    ]
+                },
+                {
+                    'RatingAuthorityShortText': 'PEGI',
+                    'AgeRatingText': '12+',
+                    'DescriptorList': [
+                        {'DescriptorText': 'PEGI_Violence'},
+                        {'DescriptorText': 'PEGI_Online'},
+                    ],
+                    'InteractiveElementList': [
+                        {'InteractiveElementText': 'IE_UsersInteract'},
+                        {'InteractiveElementText': 'IE_DigitalPurchases'}
+                    ]
+                },
+                {
+                    'RatingAuthorityShortText': 'ESRB',
+                    'AgeRatingText': 'Teen',
+                    'DescriptorList': [],
+                    'InteractiveElementList': []
+                },
+            ]
+        }
+        expected_data = {
+            'descriptors': set(['has_generic_violence',
+                                'has_pegi_online',
+                                'has_pegi_violence']),
+            'interactives': set(['has_shares_location',
+                                 'has_digital_purchases',
+                                 'has_users_interact']),
+            'ratings': {
+                ratingsbodies.ESRB: ratingsbodies.ESRB_T,
+                ratingsbodies.GENERIC: ratingsbodies.GENERIC_12,
+                ratingsbodies.PEGI: ratingsbodies.PEGI_12,
+            },
+        }
+        serializer = IARCV2RatingListSerializer(None, data)
+        self.assertSetEqual(
+            serializer.validated_data['descriptors'],
+            expected_data['descriptors'])
+        self.assertSetEqual(
+            serializer.validated_data['interactives'],
+            expected_data['interactives'])
+        eq_(
+            serializer.validated_data['ratings'],
+            expected_data['ratings'])
+        eq_(serializer.is_valid(), True)
+        return serializer
+
+    def test_save_with_no_instance(self):
+        serializer = IARCV2RatingListSerializer(data={})
+        with self.assertRaises(ValueError):
+            serializer.save()
+
+    @mock.patch.object(IARCV2RatingListSerializer, 'is_valid')
+    def test_save_with_invalid_data(self, is_valid_mock):
+        is_valid_mock.return_value = False
+        serializer = IARCV2RatingListSerializer(instance=object())
+        with self.assertRaises(ParseError):
+            serializer.save()
+
+    def test_save_success(self):
+        serializer = self.test_validate_multiple_bodies_with_redundant_info()
+        serializer.instance = mock.Mock()
+        serializer.save()
+
+        eq_(serializer.instance.set_descriptors.call_count, 1)
+        eq_(serializer.instance.set_descriptors.call_args[0][0],
+            serializer.validated_data['descriptors'])
+
+        eq_(serializer.instance.set_interactives.call_count, 1)
+        eq_(serializer.instance.set_interactives.call_args[0][0],
+            serializer.validated_data['interactives'])
+
+        eq_(serializer.instance.set_content_ratings.call_count, 1)
+        eq_(serializer.instance.set_content_ratings.call_args[0][0],
+            serializer.validated_data['ratings'])

--- a/mkt/constants/iarc_mappings.py
+++ b/mkt/constants/iarc_mappings.py
@@ -64,8 +64,10 @@ RATINGS = {
 # WARNING: When adding a new rating descriptor here also include a migration.
 #          All descriptor keys must be prefixed by the rating body (e.g. USK_).
 #
-# These are used to dynamically generate the field list for the
-# RatingDescriptors Django model in mkt.webapps.models.
+# Together with DESCS_V2 below these are used to dynamically generate the field
+# list for the RatingDescriptors Django model in mkt.webapps.models.
+# (The model has both v1 and v2 keys, and it's fine, the extra keys are
+#  simply irrelevant depending on the version).
 DESCS = {
     ratingsbodies.CLASSIND.id: {
         u'Atos Crim\xEDnosos': 'has_classind_criminal_acts',
@@ -189,14 +191,152 @@ DESCS = {
     },
 }
 
-# Change {body: {'key': 'val'}} to {'val': 'key'}.
-REVERSE_DESCS_BY_BODY = [
-    dict([(unicode(v), unicode(k)) for k, v in body_mapping.iteritems()])
-    for body, body_mapping in DESCS.iteritems()]
-REVERSE_DESCS = {}
-for mapping in REVERSE_DESCS_BY_BODY:
-    REVERSE_DESCS.update(mapping)
+# WARNING: When adding a new rating descriptor here also include a migration.
+#          All descriptor keys must be prefixed by the rating body (e.g. USK_).
+#
+# Together with DESCS above these are used to dynamically generate the field
+# list for the RatingDescriptors Django model in mkt.webapps.models.
+# (The model has both v1 and v2 keys, and it's fine, the extra keys are
+#  simply irrelevant depending on the version).
+DESCS_V2 = {
+    ratingsbodies.CLASSIND.id: {
+        'ClassInd_AtosCriminosos': 'has_classind_criminal_acts',
+        'ClassInd_ConteudoImpactante': 'has_classind_shocking',
+        'ClassInd_ConteudoSexual': 'has_classind_sex_content',
+        'ClassInd_Drogas': 'has_classind_drugs',
+        'ClassInd_DrogasIlicitas': 'has_classind_drugs_illegal',
+        'ClassInd_DrogasLicitas': 'has_classind_drugs_legal',
+        'ClassInd_LinguagemImpropria': 'has_classind_lang',
+        'ClassInd_Naohainadequacoes': '',  # No descriptors.
+        'ClassInd_Nudez': 'has_classind_nudity',
+        'ClassInd_Sexo': 'has_classind_sex',
+        'ClassInd_SexoExplicito': 'has_classind_sex_explicit',
+        'ClassInd_Violencia': 'has_classind_violence',
+        'ClassInd_ViolenciaExtrema': 'has_classind_violence_extreme',
+    },
 
+    ratingsbodies.ESRB.id: {
+        'ESRB_AlcoholandTobaccoReference': 'has_esrb_alcohol_tobacco_ref',
+        'ESRB_AlcoholReference': 'has_esrb_alcohol_tobacco_ref',
+        'ESRB_AnimatedBlood': 'has_esrb_animated_blood',
+        'ESRB_Blood': 'has_esrb_blood',
+        'ESRB_BloodandGore': 'has_esrb_blood_gore',
+        'ESRB_CartoonViolence': 'has_esrb_cartoon_violence',
+        'ESRB_ComicMischief': 'has_esrb_comic_mischief',
+        'ESRB_CrudeHumor': 'has_esrb_crude_humor',
+        'ESRB_DiverseContentDiscretionAdvised': '',
+        'ESRB_DrugAlcoholandTobaccoReference':
+            'has_esrb_drug_alcohol_tobacco_ref',
+        'ESRB_DrugandAlcoholReference': 'has_esrb_drug_alcohol_ref',
+        'ESRB_DrugandTobaccoReference': 'has_esrb_drug_tobacco_ref',
+        'ESRB_DrugReference': 'has_esrb_drug_ref',
+        'ESRB_FantasyViolence': 'has_esrb_fantasy_violence',
+        'ESRB_IntenseViolence': 'has_esrb_intense_violence',
+        'ESRB_Language': 'has_esrb_lang',
+        'ESRB_Lyrics': 'has_esrb_lyrics',
+        'ESRB_MatureHumor': 'has_esrb_mature_humor',
+        'ESRB_MildBlood': 'has_esrb_mild_blood',
+        'ESRB_MildCartoonViolence': 'has_esrb_mild_cartoon_violence',
+        'ESRB_MildFantasyViolence': 'has_esrb_mild_fantasy_violence',
+        'ESRB_MildLanguage': 'has_esrb_mild_lang',
+        'ESRB_MildLyrics': 'has_esrb_mild_lyrics',
+        'ESRB_MildSexualContent': 'has_esrb_mild_sexual_content',
+        'ESRB_MildSexualThemes': 'has_esrb_mild_sexual_themes',
+        'ESRB_MildSuggestiveThemes': 'has_esrb_mild_suggestive_themes',
+        'ESRB_MildViolence': 'has_esrb_mild_violence',
+        'ESRB_NoDescriptors': '',  # No Descriptors.
+        'ESRB_Nudity': 'has_esrb_nudity',
+        'ESRB_PartialNudity': 'has_esrb_partial_nudity',
+        'ESRB_RealGambling': 'has_esrb_real_gambling',
+        'ESRB_SexualContent': 'has_esrb_sex_content',
+        'ESRB_SexualThemes': 'has_esrb_sex_themes',
+        'ESRB_SexualViolence': 'has_esrb_sex_violence',
+        'ESRB_SimulatedGambling': 'has_esrb_sim_gambling',
+        'ESRB_StrongLanguage': 'has_esrb_strong_lang',
+        'ESRB_StrongLyrics': 'has_esrb_strong_lyrics',
+        'ESRB_StrongSexualContent': 'has_esrb_strong_sex_content',
+        'ESRB_SuggestiveThemes': 'has_esrb_suggestive',
+        'ESRB_TobaccoReference': 'has_esrb_tobacco_ref',
+        'ESRB_UseofAlcohol': 'has_esrb_alcohol_use',
+        'ESRB_UseofAlcoholandTobacco': 'has_esrb_alcohol_tobacco_use',
+        'ESRB_UseofDrugs': 'has_esrb_drug_use',
+        'ESRB_UseofDrugsAlcoholandTobacco':
+            'has_esrb_drug_alcohol_tobacco_use',
+        'ESRB_UseofDrugsandAlcohol': 'has_esrb_drug_alcohol_use',
+        'ESRB_UseofDrugsandTobacco': 'has_esrb_drug_tobacco_use',
+        'ESRB_UseofTobacco': 'has_esrb_tobacco_use',
+        'ESRB_Violence': 'has_esrb_violence',
+        'ESRB_ViolentReferences': 'has_esrb_violence_ref',
+    },
+
+    ratingsbodies.GENERIC.id: {
+        # Yes, "Generic" seems to be using PEGI descriptors for some reason.
+        'PEGI_Discrimination': 'has_generic_discrimination',
+        'PEGI_Drugs': 'has_generic_drugs',
+        'PEGI_Fear': 'has_generic_scary',
+        'PEGI_Gambling': 'has_generic_gambling',
+        'PEGI_Language': 'has_generic_lang',
+        'PEGI_Online': 'has_generic_online',
+        'PEGI_Sex': 'has_generic_sex_content',
+        'PEGI_Violence': 'has_generic_violence',
+    },
+
+    ratingsbodies.PEGI.id: {
+        'PEGI_CriminalTechniqueInstructions': '',
+        'PEGI_Discrimination': 'has_pegi_discrimination',
+        'PEGI_Drugs': 'has_pegi_drugs',
+        'PEGI_ExtremeViolence': '',
+        'PEGI_Fear': 'has_pegi_scary',
+        'PEGI_Gambling': 'has_pegi_gambling',
+        'PEGI_Horror': 'has_pegi_horror',
+        'PEGI_ImpliedViolence': '',
+        'PEGI_Language': 'has_pegi_lang',
+        'PEGI_MildSwearing': '',
+        'PEGI_MildViolence': '',
+        'PEGI_ModerateViolence': '',
+        'PEGI_NoDescriptors': '',  # No descriptors.
+        'PEGI_Online': 'has_pegi_online',
+        'PEGI_ParentalGuidanceRecommended': '',
+        'PEGI_Sex': 'has_pegi_sex_content',
+        'PEGI_SexualInnuendo': '',
+        'PEGI_SexualViolence': '',
+        'PEGI_StrongLanguage': '',
+        'PEGI_StrongViolence': '',
+        'PEGI_UseofAlcoholTobacco': '',
+        'PEGI_Violence': 'has_pegi_violence',
+    },
+
+    ratingsbodies.USK.id: {
+        'USK_AbstrakteGewalt': 'has_usk_abstract_violence',
+        'USK_Alkoholkonsum': 'has_usk_alcohol',
+        'USK_AndeutungenSexuellerGewalt': 'has_usk_sex_violence_ref',
+        'USK_AngstigendeInhalte': 'has_usk_scary',
+        'USK_Diskriminierung': 'has_usk_discrimination',
+        'USK_Drogenkonsum': 'has_usk_drug_use',
+        'USK_ExpliziteGewalt': 'has_usk_explicit_violence',
+        'USK_ExpliziteSprache': 'has_usk_lang',
+        'USK_GelegentlichesFluchen': 'has_usk_some_swearing',
+        'USK_Gewalt': 'has_usk_violence',
+        'USK_GruselHorror': 'has_usk_horror',
+        'USK_NacktheitErotik': 'has_usk_nudity',
+        'USK_NoDescriptors': '',    # No Descriptors.
+        'USK_SelteneSchreckmomente': 'has_usk_some_scares',
+        'USK_SexErotik': 'has_usk_sex_content',  # 'Erotik/Sexuelle Inhalte'.
+        'USK_SexuelleAndeutungen': 'has_usk_sex_ref',
+        'USK_SexuelleGewalt': 'has_usk_sex_violence',
+        'USK_ShopStreamingService': '',
+        'USK_Tabakkonsum': 'has_usk_tobacco',
+    }
+
+}
+
+# Change {body: {'key': 'val'}} to {'val': 'key'}, combining v1 and v2 dicts.
+_REVERSE_DESCS_BY_BODY = [
+    {unicode(v): unicode(k) for k, v in body_mapping.items() if v}
+    for body, body_mapping in DESCS_V2.items() + DESCS.items()]
+REVERSE_DESCS = {}
+for mapping in _REVERSE_DESCS_BY_BODY:
+    REVERSE_DESCS.update(mapping)
 
 # WARNING: When adding a new interactive element here also include a migration.
 #
@@ -209,5 +349,12 @@ INTERACTIVES = {
     'Digital Purchases': 'has_digital_purchases',
 }
 
-REVERSE_INTERACTIVES = dict(
-    (v, k) for k, v in INTERACTIVES.iteritems())
+INTERACTIVES_V2 = {
+    'IE_UsersInteract': 'has_users_interact',
+    'IE_SharesInfo': 'has_shares_info',
+    'IE_SharesLocation': 'has_shares_location',
+    'IE_DigitalPurchases': 'has_digital_purchases',
+}
+
+REVERSE_INTERACTIVES = {v: k for k, v
+                        in INTERACTIVES_V2.items() + INTERACTIVES.items()}

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -2061,15 +2061,14 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
         data -- list of database flags ('has_usk_lang')
         """
         create_kwargs = {}
-        for body in mkt.iarc_mappings.DESCS:
-            for desc, db_flag in mkt.iarc_mappings.DESCS[body].items():
-                create_kwargs[db_flag] = db_flag in data
+        for db_flag in mkt.constants.iarc_mappings.REVERSE_DESCS.keys():
+            create_kwargs[db_flag] = db_flag in data
 
-        rd, created = RatingDescriptors.objects.get_or_create(
+        instance, created = RatingDescriptors.objects.get_or_create(
             addon=self, defaults=create_kwargs)
         if not created:
-            rd.update(modified=datetime.datetime.now(),
-                      **create_kwargs)
+            instance.update(modified=datetime.datetime.now(),
+                            **create_kwargs)
 
     @use_master
     def set_interactives(self, data):
@@ -2079,7 +2078,7 @@ class Webapp(UUIDModelMixin, OnChangeMixin, ModelBase):
         data -- list of database flags ('has_users_interact')
         """
         create_kwargs = {}
-        for interactive, db_flag in mkt.iarc_mappings.INTERACTIVES.items():
+        for db_flag in mkt.constants.iarc_mappings.REVERSE_INTERACTIVES.keys():
             create_kwargs[db_flag] = db_flag in data
 
         ri, created = RatingInteractives.objects.get_or_create(
@@ -2513,6 +2512,7 @@ class RatingDescriptors(ModelBase, DynamicBoolFieldsMixin):
     def iarc_deserialize(self, body=None):
         """Map our descriptor strings back to the IARC ones (comma-sep.)."""
         keys = self.to_keys()
+        # FIXME: convert IARC v2 constants to text.
         if body:
             keys = [key for key in keys if body.iarc_name.lower() in key]
         return ', '.join(iarc_mappings.REVERSE_DESCS.get(desc) for desc
@@ -2540,6 +2540,7 @@ class RatingInteractives(ModelBase, DynamicBoolFieldsMixin):
         return u'%s: %s' % (self.id, self.addon.name)
 
     def iarc_deserialize(self):
+        # FIXME: convert IARC v2 constants to text.
         """Map our descriptor strings back to the IARC ones (comma-sep.)."""
         return ', '.join(iarc_mappings.REVERSE_INTERACTIVES.get(inter)
                          for inter in self.to_keys())


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1228364
https://bugzilla.mozilla.org/show_bug.cgi?id=1228371

The mapping additions should be backwards-compatible - at the moment they do not add new database fields, but even if they did it would still work (they'd still be false and ignored)