### PR TITLE
Add texts for IARC mappings (bug 1228364)

### DIFF
--- a/mkt/constants/iarc_mappings.py
+++ b/mkt/constants/iarc_mappings.py
@@ -191,6 +191,13 @@ DESCS = {
     },
 }
 
+# Change {body: {'key': 'val'}} to {'val': 'key'}. Used to deserialize our
+# data back to IARC.
+REVERSE_DESCS = {}
+for mapping in [{unicode(v): unicode(k) for k, v in body_mapping.items() if v}
+                for body, body_mapping in DESCS.items()]:
+    REVERSE_DESCS.update(mapping)
+
 # WARNING: When adding a new rating descriptor here also include a migration.
 #          All descriptor keys must be prefixed by the rating body (e.g. USK_).
 #
@@ -327,16 +334,15 @@ DESCS_V2 = {
         'USK_ShopStreamingService': '',
         'USK_Tabakkonsum': 'has_usk_tobacco',
     }
-
 }
 
-# Change {body: {'key': 'val'}} to {'val': 'key'}, combining v1 and v2 dicts.
-_REVERSE_DESCS_BY_BODY = [
-    {unicode(v): unicode(k) for k, v in body_mapping.items() if v}
-    for body, body_mapping in DESCS_V2.items() + DESCS.items()]
-REVERSE_DESCS = {}
-for mapping in _REVERSE_DESCS_BY_BODY:
-    REVERSE_DESCS.update(mapping)
+# Change {body: {'key': 'val'}} to {'val': 'key'}. Used to deserialize our
+# data back to IARC.
+REVERSE_DESCS_V2 = {}
+for mapping in [{unicode(v): unicode(k) for k, v in body_mapping.items() if v}
+                for body, body_mapping in DESCS_V2.items()]:
+    REVERSE_DESCS_V2.update(mapping)
+
 
 # WARNING: When adding a new interactive element here also include a migration.
 #
@@ -349,6 +355,8 @@ INTERACTIVES = {
     'Digital Purchases': 'has_digital_purchases',
 }
 
+REVERSE_INTERACTIVES = {v: k for k, v in INTERACTIVES.items()}
+
 INTERACTIVES_V2 = {
     'IE_UsersInteract': 'has_users_interact',
     'IE_SharesInfo': 'has_shares_info',
@@ -356,5 +364,11 @@ INTERACTIVES_V2 = {
     'IE_DigitalPurchases': 'has_digital_purchases',
 }
 
-REVERSE_INTERACTIVES = {v: k for k, v
-                        in INTERACTIVES_V2.items() + INTERACTIVES.items()}
+REVERSE_INTERACTIVES_V2 = {v: k for k, v in INTERACTIVES_V2.items()}
+
+# Human readable text for descriptors and interactives should not be translated
+# by us, the rating bodies are very specific about the texts. Instead, we use
+# the V1 descriptors and interactives, since V1 used text instead of constants.
+# When we phase out v1, we'll just add a dict of strings here instead.
+HUMAN_READABLE_DESCS_AND_INTERACTIVES = dict(
+    REVERSE_DESCS.items() + REVERSE_INTERACTIVES.items())

--- a/mkt/constants/tests/test_iarc_mappings.py
+++ b/mkt/constants/tests/test_iarc_mappings.py
@@ -1,0 +1,22 @@
+from nose.tools import ok_
+
+import mkt.site.tests
+
+from mkt.constants.iarc_mappings import (
+    HUMAN_READABLE_DESCS_AND_INTERACTIVES, REVERSE_DESCS, REVERSE_DESCS_V2,
+    REVERSE_INTERACTIVES, REVERSE_INTERACTIVES_V2)
+
+
+class TestIARCMappings(mkt.site.tests.TestCase):
+
+    def test_all_human_readable_strings_are_present(self):
+        for key in REVERSE_DESCS:
+            ok_(key in HUMAN_READABLE_DESCS_AND_INTERACTIVES)
+        for key in REVERSE_DESCS_V2:
+            ok_(key in HUMAN_READABLE_DESCS_AND_INTERACTIVES)
+        for key in REVERSE_INTERACTIVES:
+            ok_(key in HUMAN_READABLE_DESCS_AND_INTERACTIVES)
+        for key in REVERSE_INTERACTIVES_V2:
+            ok_(key in HUMAN_READABLE_DESCS_AND_INTERACTIVES)
+        for value in HUMAN_READABLE_DESCS_AND_INTERACTIVES.values():
+            ok_('__proxy__' not in unicode(value))

--- a/mkt/developers/templates/developers/apps/ratings/ratings_summary.html
+++ b/mkt/developers/templates/developers/apps/ratings/ratings_summary.html
@@ -40,10 +40,10 @@
                   {% set desc_icon = body.label in desc_icons and desc_icons[body.label][descriptor] %}
                   {% if desc_icon %}
                     <img src="{{ media(desc_icon) }}" class="icon"
-                         title="{{ mkt.iarc_mappings.REVERSE_DESCS[descriptor] }}">
+                         title="{{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[descriptor] }}">
                   {% else %}
                     <span class="dot-sep descriptor">
-                      {{ mkt.iarc_mappings.REVERSE_DESCS[descriptor] }}
+                      {{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[descriptor] }}
                     </span>
                   {% endif %}
                 {% else %}
@@ -62,7 +62,7 @@
           <div class="names">
             {% for interactive in interactives %}
               <span class="dot-sep interactive">
-                {{ mkt.iarc_mappings.REVERSE_INTERACTIVES[interactive] }}
+                {{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[interactive] }}
               </span>
             {% endfor %}
           </div>
@@ -70,7 +70,7 @@
           {% for interactive in interactives %}
             {% if inter_icons[interactive] %}
               <img src="{{ media(inter_icons[interactive]) }}" class="icon"
-                   title="{{ mkt.iarc_mappings.REVERSE_INTERACTIVES[interactive] }}">
+                   title="{{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[interactive] }}">
             {% endif %}
           {% endfor %}
         </div>

--- a/mkt/webapps/serializers.py
+++ b/mkt/webapps/serializers.py
@@ -15,6 +15,7 @@ from mkt.api.fields import (ESTranslationSerializerField, LargeTextField,
                             TranslationSerializerField)
 from mkt.constants.applications import DEVICE_TYPES
 from mkt.constants.categories import CATEGORY_CHOICES
+from mkt.constants.iarc_mappings import HUMAN_READABLE_DESCS_AND_INTERACTIVES
 from mkt.constants.payments import PROVIDER_BANGO
 from mkt.features.utils import load_feature_profile
 from mkt.prices.models import AddonPremium, Price
@@ -159,14 +160,14 @@ class AppSerializer(serializers.ModelSerializer):
                 app.rating_descriptors.to_keys_by_body(body)
                 if hasattr(app, 'rating_descriptors') else []),
             'descriptors_text': (
-                [mkt.iarc_mappings.REVERSE_DESCS[key] for key in
-                 app.rating_descriptors.to_keys_by_body(body)]
+                [HUMAN_READABLE_DESCS_AND_INTERACTIVES[key]
+                 for key in app.rating_descriptors.to_keys_by_body(body)]
                 if hasattr(app, 'rating_descriptors') else []),
             'interactives': (
                 app.rating_interactives.to_keys()
                 if hasattr(app, 'rating_interactives') else []),
             'interactives_text': (
-                [mkt.iarc_mappings.REVERSE_INTERACTIVES[key] for key in
+                [HUMAN_READABLE_DESCS_AND_INTERACTIVES[key] for key in
                  app.rating_interactives.to_keys()]
                 if hasattr(app, 'rating_interactives') else []),
         }
@@ -504,13 +505,14 @@ class ESAppSerializer(BaseESSerializer, AppSerializer):
             'descriptors': [key for key in
                             obj.es_data.get('content_descriptors', [])
                             if prefix in key],
-            'descriptors_text': [mkt.iarc_mappings.REVERSE_DESCS[key] for key
+            'descriptors_text': [HUMAN_READABLE_DESCS_AND_INTERACTIVES[key]
+                                 for key
                                  in obj.es_data.get('content_descriptors')
                                  if prefix in key],
             'interactives': obj.es_data.get('interactive_elements', []),
-            'interactives_text': [mkt.iarc_mappings.REVERSE_INTERACTIVES[key]
-                                  for key in
-                                  obj.es_data.get('interactive_elements')]
+            'interactives_text': [HUMAN_READABLE_DESCS_AND_INTERACTIVES[key]
+                                  for key
+                                  in obj.es_data.get('interactive_elements')]
         }
 
     def get_feature_compatibility(self, app):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1228364

Went back & forth a lot and it seems like the simplest solution. We can't pollute the `REVERSE_*` dicts, as they are used for de-serialization with IARC. Instead, we create a new dict with the human-readable text, and use that where we display text.