### PR TITLE
Changed fy to fy_NL per pontoon changes. The former is still symlinke…

### DIFF
--- a/mkt/settings.py
+++ b/mkt/settings.py
@@ -515,7 +515,7 @@ ALLOW_SELF_REVIEWS = True
 # A smaller range of languages for the Marketplace.
 AMO_LANGUAGES = (
     'af', 'ar', 'bg', 'bn-BD', 'bn-IN', 'ca', 'cs', 'cy', 'da', 'de', 'dsb',
-    'ee', 'el', 'en-GB', 'en-US', 'es', 'eu', 'ff', 'fr', 'fy', 'ga-IE',
+    'ee', 'el', 'en-GB', 'en-US', 'es', 'eu', 'ff', 'fr', 'fy_NL', 'ga-IE',
     'ha', 'hi-IN', 'hsb', 'hu', 'id', 'ig', 'it', 'ja', 'ko', 'nb-NO', 'nl',
     'pl', 'pt-BR', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sr-Latn', 'sv-SE',
     'sw', 'tr', 'uk', 'wo', 'xh', 'yo', 'zh-CN', 'zh-TW', 'zu',


### PR DESCRIPTION
…d, but may as well make things line up. (pa --> pa_IN was also done, but that language is not yet added.)