### PR TITLE
Kill obsolete and useless custom SQL (bug 1069396)

### DIFF
--- a/mkt/files/sql/file.sql
+++ b/mkt/files/sql/file.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `files` DROP FOREIGN KEY `version_id_refs_id_e75e6066`;
-ALTER TABLE `files` ADD CONSTRAINT `version_id_refs_id_e75e6066` FOREIGN KEY (`version_id`) REFERENCES `versions` (`id`) ON DELETE CASCADE;

--- a/mkt/versions/sql/version.sql
+++ b/mkt/versions/sql/version.sql
@@ -1,3 +1,0 @@
--- DROP and ADD constraint to add `ON DELETE CASCADE`.
-ALTER TABLE `versions` DROP FOREIGN KEY `addon_id_refs_id_0b364cd2`;
-ALTER TABLE `versions` ADD CONSTRAINT `addon_id_refs_id_0b364cd2` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`) ON DELETE CASCADE;

--- a/mkt/webapps/sql/addoncategory.sql
+++ b/mkt/webapps/sql/addoncategory.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `addons_categories` DROP FOREIGN KEY `addon_id_refs_id_dd972ca1`;
-ALTER TABLE `addons_categories` ADD CONSTRAINT `addon_id_refs_id_dd972ca1` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`) ON DELETE CASCADE;

--- a/mkt/webapps/sql/addonuser.sql
+++ b/mkt/webapps/sql/addonuser.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `addons_users` DROP FOREIGN KEY `addon_id_refs_id_0ace0094`;
-ALTER TABLE `addons_users` ADD CONSTRAINT `addon_id_refs_id_0ace0094` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`) ON DELETE CASCADE;

--- a/mkt/webapps/sql/webapp.sql
+++ b/mkt/webapps/sql/webapp.sql
@@ -1,7 +1,0 @@
--- These are all the indexes you really need to run zamboni.  They're
--- explicitly used in queries.  We drop them all in one file because that's easy.
-
-CREATE INDEX created_type_idx ON addons (created);
-CREATE INDEX rating_type_idx ON addons (bayesianrating);
-CREATE INDEX last_updated_type_idx ON addons (last_updated);
-CREATE INDEX type_status_inactive_idx ON addons (status, inactive);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1069396

r? @washort : these have been obsolete for a while, right ? Especially following the switch to django migrations ?