### PR TITLE
Remove thumbtype field from Preview model (bug 1202409)

### DIFF
--- a/mkt/webapps/fakedata.py
+++ b/mkt/webapps/fakedata.py
@@ -86,7 +86,6 @@ def generate_previews(app, n=1):
         img = gen.generate(unicode(app.name) + unichr(i), 320, 480,
                            output_format="png")
         p = Preview.objects.create(addon=app, filetype="image/png",
-                                   thumbtype="image/png",
                                    caption="screenshot " + str(i),
                                    position=i)
         fn = tempfile.mktemp()
@@ -401,14 +400,12 @@ def generate_app_from_spec(name, categories, type, status, num_previews=1,
             copy_stored_file(f, t, src_storage=local_storage,
                              dst_storage=private_storage)
             p = Preview.objects.create(addon=app, filetype="video/webm",
-                                       thumbtype="image/png",
                                        caption="video " + str(i),
                                        position=i)
             resize_video(t, p.pk)
     if preview_files:
         for i, f in enumerate(preview_files):
             p = Preview.objects.create(addon=app, filetype="image/png",
-                                       thumbtype="image/png",
                                        caption="screenshot " + str(i),
                                        position=i + len(video_files))
             t = tempfile.mktemp()

--- a/mkt/webapps/migrations/0006_remove_preview_thumbtype.py
+++ b/mkt/webapps/migrations/0006_remove_preview_thumbtype.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webapps', '0005_iarccert'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='preview',
+            name='thumbtype',
+        ),
+    ]

--- a/mkt/webapps/models.py
+++ b/mkt/webapps/models.py
@@ -220,7 +220,6 @@ class AddonUser(models.Model):
 class Preview(ModelBase):
     addon = models.ForeignKey('Webapp', related_name='previews')
     filetype = models.CharField(max_length=25)
-    thumbtype = models.CharField(max_length=25)
     caption = TranslatedField()
 
     position = models.IntegerField(default=0)

--- a/mkt/webapps/tests/test_models.py
+++ b/mkt/webapps/tests/test_models.py
@@ -523,7 +523,6 @@ class TestPreviewModel(mkt.site.tests.TestCase):
     def setUp(self):
         app = Webapp.objects.create()
         self.preview = Preview.objects.create(addon=app, filetype='image/png',
-                                              thumbtype='image/png',
                                               caption='my preview')
 
     def test_as_dict(self):

--- a/mkt/webapps/tests/test_serializers.py
+++ b/mkt/webapps/tests/test_serializers.py
@@ -158,7 +158,7 @@ class TestAppSerializer(mkt.site.tests.TestCase):
 
     def test_with_preview(self):
         obj = Preview.objects.create(**{
-            'filetype': 'image/png', 'thumbtype': 'image/png',
+            'filetype': 'image/png',
             'addon': self.app})
         preview = self.serialize(self.app)['previews'][0]
         self.assertSetEqual(preview, ['filetype', 'id', 'image_url',


### PR DESCRIPTION
Bug : https://bugzilla.mozilla.org/show_bug.cgi?id=1202409

 Removed 'thumbtype' fields from Preview model which are of no use to the codebase.
 Created migrations.