### PR TITLE
Fix multi-line strings and collapse whitespace following tower removal

### DIFF
--- a/mkt/developers/templates/developers/api.html
+++ b/mkt/developers/templates/developers/api.html
@@ -25,7 +25,7 @@
           There are two main uses for the Marketplace API. From another web site
           using a traditional OAuth flow or from a command line tool.
 
-          The difference is discussed in the  <a href="https://firefox-marketplace-api.readthedocs.org/en/latest/topics/authentication.html#oauth">Marketplace documentation</a>. Any testing should occur on the <a href="https://marketplace-dev.allizom.org">development server</a> and not the production server.
+          The difference is discussed in the <a href="https://firefox-marketplace-api.readthedocs.org/en/latest/topics/authentication.html#oauth">Marketplace documentation</a>. Any testing should occur on the <a href="https://marketplace-dev.allizom.org">development server</a> and not the production server.
         </p>
       {% endtrans %}
       {% if not roles %}

--- a/mkt/developers/templates/developers/apps/edit/admin.html
+++ b/mkt/developers/templates/developers/apps/edit/admin.html
@@ -70,8 +70,9 @@
             <label for="id_mozilla_contact">
               {{ _('Mozilla Contact') }}
               {{ tip(None,
-                _("An e-mail address (or addresses separated by commas) of this
-                   app's Mozilla contact that will be CC'd on any reviewer emails.")) }}
+                _("An e-mail address (or addresses separated by commas) of "
+                  "this app's Mozilla contact that will be CC'd on any "
+                  "reviewer emails.")) }}
                    <span class="hint">{{ _('Enter email addresses, separated by commas') }}</span>
             </label>
           </th>
@@ -89,7 +90,8 @@
             <label for="id_vip_app">
               {{ _('Mozilla VIP App') }}
               {{ tip(None,
-                _("Is this a very important app that should always be handled by Mozilla Staff or Senior App Reviewers?")) }}
+                _("Is this a very important app that should always be handled "
+                  "by Mozilla Staff or Senior App Reviewers?")) }}
                    <span class="hint">{{ _('Use sparingly') }}</span>
             </label>
           </th>
@@ -107,7 +109,8 @@
             <label for="id_priority_review">
               {{ _('Priority review needed') }}
               {{ tip(None,
-                _("The app will be treated as a priority and placed the top of the review queue")) }}
+                _("The app will be treated as a priority and placed the top "
+                  "of the review queue")) }}
                    <span class="hint">{{ _('This will persist until first approval') }}</span>
             </label>
           </th>

--- a/mkt/developers/templates/developers/apps/edit/basic.html
+++ b/mkt/developers/templates/developers/apps/edit/basic.html
@@ -20,10 +20,12 @@
             <label data-for="name">
               {{ _('Name') }}
               {{ tip(None,
-                    _('The app name is one of the fields used to return search results in the Firefox Marketplace.
-                       The app name also appears on the app’s detail page. Be sure you’ve included a descriptive
-                       name in your app manifest. If you want to change the app name, you’ll need to do that in
-                       your app manifest.')) }}
+                    _("The app name is one of the fields used to return "
+                      "search results in the Firefox Marketplace. The app "
+                      "name also appears on the app’s detail page. Be sure "
+                      "you’ve included a descriptive name in your app "
+                      "manifest. If you want to change the app name, you’ll "
+                      "need to do that in your app manifest.")) }}
             </label>
           </th>
           <td>
@@ -118,8 +120,11 @@
             <label data-for="description">
               {{ _('Description') }}
               {{ tip(None,
-                    _("The app description is one of the fields used to return search results in the Firefox Marketplace. The app description
-                       also appears on the app's detail page. Be sure to include a description that accurately represents your app.")) }}
+                    _("The app description is one of the fields used to "
+                      "return search results in the Firefox Marketplace. "
+                      "The app description also appears on the app's detail "
+                      "page. Be sure to include a description that accurately "
+                      "represents your app.")) }}
             </label>
             {{ req_if_edit }}
           </th>
@@ -166,9 +171,10 @@
             <th>
               <label data-for="releasenotes">
                 {{ _('Release Notes') }}
-                {{ tip(None, _('Information about changes in the latest release, new features,
-                                known bugs, and other useful information specific to this
-                                release/version.')) }}
+                {{ tip(None, _("Information about changes in the latest "
+                               "release, new features, known bugs, and other "
+                               "useful information specific to this "
+                               "release/version.")) }}
               </label>
             </th>
             <td>
@@ -187,9 +193,9 @@
         <tr>
           <th>
             {{ tip(_('Categories'),
-                   _("Categories are the primary way users browse through apps.
-                      Choose any that fit your app's functionality for the
-                      most exposure.")) }}
+                   _("Categories are the primary way users browse through "
+                     "apps. Choose any that fit your app's functionality for "
+                     "the most exposure.")) }}
             {{ req_if_edit }}
           </th>
           <td id="addon-categories-edit"

--- a/mkt/developers/templates/developers/apps/edit/details.html
+++ b/mkt/developers/templates/developers/apps/edit/details.html
@@ -34,10 +34,10 @@
             <label data-for="homepage">
               {{ _("Homepage") }}
               {{ tip(None,
-                     _("If your app has another homepage, enter its
-                        address here. If your website is localized into other
-                        languages multiple translations of this field can be
-                        added.")) }}
+                     _("If your app has another homepage, enter its "
+                       "address here. If your website is localized into other "
+                       "languages multiple translations of this field can be "
+                       "added.")) }}
             </label>
           </th>
           <td>

--- a/mkt/developers/templates/developers/apps/edit/support.html
+++ b/mkt/developers/templates/developers/apps/edit/support.html
@@ -20,10 +20,10 @@
             <label data-for="support_email">
               {{ _("Email") }}
               {{ tip(None,
-                     _("The email address used by end users to contact you
-                        with support issues. If you have different addresses
-                        for each language multiple translations of this field
-                        can be added.")) }}
+                     _("The email address used by end users to contact you "
+                       "with support issues. If you have different addresses "
+                       "for each language multiple translations of this field "
+                       "can be added.")) }}
             </label>
           </th>
           <td>
@@ -40,10 +40,10 @@
             <label data-for="support_url">
               {{ _("Website") }}
               {{ tip(None,
-                     _("If your app has a support website or forum, enter
-                        its address here. If your website is localized into
-                        other languages, multiple translations of this
-                        field can be added.")) }}
+                     _("If your app has a support website or forum, enter "
+                       "its address here. If your website is localized into "
+                       "other languages, multiple translations of this field "
+                       "can be added.")) }}
             </label>
           </th>
           <td>

--- a/mkt/developers/templates/developers/apps/edit/technical.html
+++ b/mkt/developers/templates/developers/apps/edit/technical.html
@@ -18,7 +18,8 @@
             <label for="id_is_offline">
               {{ _('Works Offline') }}
               {{ tip(None,
-                     _('If your app works without an Internet connection then we will list that your app &quot;Works Offline&quot;.')) }}
+                     _("If your app works without an Internet connection then "
+                       "we will list that your app &quot;Works Offline&quot;.")) }}
             </label>
           </th>
           <td>
@@ -33,12 +34,13 @@
         <tr>
           <th>
             {{ tip(_("Public Stats?"),
-                   _("Whether the install and usage stats of your app can
-                      be displayed in our online viewer.")) }}
+                   _("Whether the install and usage stats of your app can be "
+                     "displayed in our online viewer.")) }}
           </th>
           <td>
             {{ flags(_("This app's stats are publicly viewable."),
-                     addon.public_stats if not editable else form.public_stats, editable,
+                     addon.public_stats if not editable else form.public_stats,
+                     editable,
                      _("No, this app's stats are not publicly viewable.")) }}
           </td>
         </tr>
@@ -77,7 +79,8 @@
             <label for="id_guid">
               {{ _('GUID') }}
               {{ tip(None,
-                     _('Internal identifier for this app on the Firefox Marketplace.')) }}
+                     _("Internal identifier for this app on the "
+                       "Firefox Marketplace.")) }}
             </label>
           </th>
           <td>

--- a/mkt/developers/templates/developers/apps/owner.html
+++ b/mkt/developers/templates/developers/apps/owner.html
@@ -86,11 +86,9 @@
       <p>{{ _('Apps can have any number of team members with 4 possible roles:') }}</p>
       <dl>
         <dt>{{ _('Owner') }}</dt>
-        <dd>{{ _("Can manage all aspects of the app's listing, including
-            adding and removing other team members") }}</dd>
+        <dd>{{ _("Can manage all aspects of the app's listing, including adding and removing other team members") }}</dd>
         <dt>{{ _('Developer') }}</dt>
-        <dd>{{ _("Can manage all aspects of the app's listing, except
-            for adding and removing other team members and managing payments") }}</dd>
+        <dd>{{ _("Can manage all aspects of the app's listing, except for adding and removing other team members and managing payments") }}</dd>
         <dt>{{ _('Viewer') }}</dt>
         <dd>{{ _("Can view the app's settings but cannot make any changes") }}</dd>
         <dt>{{ _('Support') }}</dt>

--- a/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
+++ b/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
@@ -109,8 +109,9 @@
                 <td>
                   {{ form.submission_id }}
                   {{ tip(None,
-                           _('The submission ID can be found on the certificate sent to you.
-                              It is a numeric value like &quot;14&quot;.')) }}
+                           _("The submission ID can be found on the "
+                             "certificate sent to you. It is a numeric value "
+                             "like &quot;14&quot;.")) }}
                   {{ form.submission_id.errors }}
                 </td>
               </tr>
@@ -124,8 +125,9 @@
                 <td>
                   {{ form.security_code }}
                   {{ tip(None,
-                           _('The security code can be found on the certificate sent to you.
-                              It is a mix of letters and numbers like &quot;AB12CD3&quot;.')) }}
+                           _("The security code can be found on the "
+                             "certificate sent to you. It is a mix of letters "
+                             "and numbers like &quot;AB12CD3&quot;.")) }}
                   {{ form.security_code.errors }}
                 </td>
               </tr>

--- a/mkt/developers/templates/developers/apps/version_edit.html
+++ b/mkt/developers/templates/developers/apps/version_edit.html
@@ -23,10 +23,7 @@
           <tr>
             <th>
               <label data-for="{{ form.releasenotes.auto_id }}">{{ _('Version Notes') }}
-              {{ tip(None, _('Information about changes in this release, new features,
-                              known bugs, and other useful information specific to this
-                              release/version. This information is also shown in the
-                              Apps Manager when updating.')) }}
+              {{ tip(None, _('Information about changes in this release, new features, known bugs, and other useful information specific to this release/version. This information is also shown in the Apps Manager when updating.')) }}
               </label>
             </th>
             <td>
@@ -38,9 +35,7 @@
           <tr>
             <th>
               <label for="{{ form.approvalnotes.auto_id }}">{{ _('Notes for Reviewers') }}</label>
-              {{ tip(None, _('Optionally, enter any information that may be useful
-                              to the Reviewer reviewing this app, such as test
-                              account information.')) }}
+              {{ tip(None, _('Optionally, enter any information that may be useful to the Reviewer reviewing this app, such as test account information.')) }}
             </th>
             <td>
               {{ form.approvalnotes.errors }}

--- a/mkt/developers/templates/developers/payments/in-app-config.html
+++ b/mkt/developers/templates/developers/payments/in-app-config.html
@@ -20,10 +20,10 @@
     <div id="in-app-config" class="devhub-form island">
       <form class="item in-app-config" method="post" action="{{ request.path }}">
         <p>
-          {{ _('The Firefox Marketplace allows your app to take in-app payments.
-                The <a href="{guide}">in-app payment guide</a> explains how to
-                configure your app for payments with the parameters below.
-                ')|f(guide='https://developer.mozilla.org/en-US/Marketplace/Monetization/In-app_payments_section/Introduction_In-app_Payments') }}
+          {{ _('The Firefox Marketplace allows your app to take in-app '
+               'payments. The <a href="{guide}">in-app payment guide</a> '
+               'explains how to configure your app for payments with the '
+               'parameters below.')|f(guide='https://developer.mozilla.org/en-US/Marketplace/Monetization/In-app_payments_section/Introduction_In-app_Payments') }}
         </p>
         {{ csrf() }}
         <table>

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -167,7 +167,7 @@ def delete(request, addon_id, addon):
         return redirect(request.GET.get('to') or
                         reverse('mkt.developers.apps'))
     else:
-        msg = _('Password was incorrect.  App was not deleted.')
+        msg = _('Password was incorrect. App was not deleted.')
         messages.error(request, msg)
         return redirect(addon.get_dev_url('versions'))
 

--- a/mkt/extensions/validation.py
+++ b/mkt/extensions/validation.py
@@ -36,7 +36,7 @@ class ExtensionValidator(object):
             u'longer than 132 characters.'),
         'ICON_INCORRECT_DIMENSIONS': _(
             u'The icon file `%(icon_path)s` is not the specified dimensions '
-            u' of %(icon_size)s x %(icon_size)s as defined in the manifest.'),
+            u'of %(icon_size)s x %(icon_size)s as defined in the manifest.'),
         'ICON_DOES_NOT_EXIST': _(
             u'The icon file `%(icon_path)s` is referenced in the manifest but'
             u' does not exist in the ZIP file.'),

--- a/mkt/search/templates/search/down.html
+++ b/mkt/search/templates/search/down.html
@@ -7,8 +7,8 @@
   <header>
   </header>
   <div class="island prose">
-    <p>{{ _('Search is temporarily unavailable. Please try again in a few
-             minutes.') }}</p>
+    <p>{{ _("Search is temporarily unavailable. Please try again in a few "
+            "minutes.") }}</p>
   </div>
 </section>
 {% endblock %}

--- a/mkt/site/log.py
+++ b/mkt/site/log.py
@@ -486,7 +486,7 @@ class ESCALATE_MANUAL(_LOG):
 class VIDEO_ERROR(_LOG):
     id = 74
     format = _(u'Video removed from {addon} because of a problem with '
-               u'the video. ')
+               u'the video.')
     short = _(u'Video removed')
 
 

--- a/mkt/site/templates/site/403.html
+++ b/mkt/site/templates/site/403.html
@@ -8,8 +8,8 @@
       <h1>{{ _('Oops! Not allowed.') }}</h1>
       <p>{{ _("You tried to do something that you weren't allowed to.") }}</p>
     {% if because_csrf %}
-      <p>{{ _('Try going back to the previous page, refreshing and trying
-              again.') }}</p>
+      <p>{{ _("Try going back to the previous page, refreshing and trying "
+              "again.") }}</p>
     {% endif %}
   </section>
 {% endblock %}

--- a/mkt/site/templates/site/404.html
+++ b/mkt/site/templates/site/404.html
@@ -8,13 +8,13 @@
     <h1>{{ _("We're sorry, but we can't find what you're looking for.") }}</h1>
     <div class="island prose">
       <p>
-        {{ _("The page or file you requested wasn't found on our site. It's
-             possible that you clicked a link that's out of date, or typed in
-             the address incorrectly.") }}
+        {{ _("The page or file you requested wasn't found on our site. It's "
+             "possible that you clicked a link that's out of date, or typed "
+             "in the address incorrectly.") }}
       </p>
       <ul>
-        <li>{{ _("If you typed in the address, please double check the
-                 spelling.") }}</li>
+        <li>{{ _("If you typed in the address, please double check the "
+                 "spelling.") }}</li>
         <li>
             {% trans home=url('home') %}
               Visit the <a class="sync" href="{{ home }}">Firefox Marketplace

--- a/mkt/submit/forms.py
+++ b/mkt/submit/forms.py
@@ -296,7 +296,7 @@ class AppDetailsBasicForm(AppSupportFormMixin, TranslationFormMixin,
         widget=TransTextarea(attrs={'rows': 6}),
         help_text=_lazy(
             u'A privacy policy explains how you handle data received '
-            u'through your app.  For example: what data do you receive? '
+            u'through your app. For example: what data do you receive? '
             u'How do you use it? Who do you share it with? Do you '
             u'receive personal information? Do you take steps to make '
             u'it anonymous? What choices do users have to control what '

--- a/mkt/submit/templates/submit/details.html
+++ b/mkt/submit/templates/submit/details.html
@@ -57,10 +57,13 @@
                     {{ _('Name') }}
                   </label>
                   {{ tip(None,
-                         _('The app name is one of the fields used to return search results in the Firefox Marketplace.
-                            The app name also appears on the app’s detail page. Be sure you’ve included a descriptive
-                            name in your app manifest. If you want to change the app name, you’ll need to do that in
-                            your app manifest.')) }}
+                         _("The app name is one of the fields used to return "
+                           "search results in the Firefox Marketplace. The "
+                           "app name also appears on the app’s detail page. "
+                           "Be sure you’ve included a descriptive name in "
+                           "your app manifest. If you want to change the app "
+                           "name, you’ll need to do that in your app "
+                           "manifest.")) }}
                 </th>
                 <td>
                   {{ addon.name }}


### PR DESCRIPTION
tower used to fix those strings for us magically, removing extraneous whitespace, so now we have to do it ourselves and be careful :)

Follows https://github.com/mozilla/zamboni/commit/18a4f4cfaf7e21fbce5d3fd4ce60824242971d2b and https://github.com/mozilla/zamboni/commit/cf2cea4bcd2e56d3119ad9aca591162925613266