### PR TITLE
Bug 1236810 - Update TV template and manifest.webapp

### DIFF
--- a/mkt/commonplace/templates/commonplace/index_tv.html
+++ b/mkt/commonplace/templates/commonplace/index_tv.html
@@ -8,16 +8,13 @@
     <link rel="stylesheet" href="{{ media(repo + '/css/include.css') }}">
   </head>
 
-  <body class="home" data-media="media/" contextmenu="contextmenu">
+  <body class="home" contextmenu="contextmenu" data-media="{{ MEDIA_URL }}" data-repo="{{ repo }}">
     <noscript><p>Sorry, you need JavaScript to use this site.</p></noscript>
 
     <main>
       <div id="page" class="page" role="main"></div>
     </main>
 
-    <menu type="context" id="contextmenu">
-      <menuitem></menuitem>
-    </menu>
     <script type="text/javascript" src="{{ media(repo + '/js/include.js') }}" defer></script>
   </body>
 </html>

--- a/mkt/tvplace/templates/tvplace/manifest.webapp
+++ b/mkt/tvplace/templates/tvplace/manifest.webapp
@@ -6,10 +6,9 @@
         "url": "http://mozilla.org"
     },
     "icons": {
-        "336": "https://marketplace.cdn.mozilla.net/media/img/mkt/logos/128.png",
+        "336": "https://marketplace-dev-cdn.allizom.org/media/marketplace-tv-front-end/img/app-icons/appic_web_apps.png"
     },
     "launch_path": "/tv/",
-    "appcache_path": "manifest.appcache",
-    "name": "Firefox Web Apps",
-    "type": "web",
+    "name": "Web Apps",
+    "type": "web"
 }


### PR DESCRIPTION
I would like to update some settings for TV Marketplace.

1. The url of locale files is incorrect now. Adding `data-media` and `data-repo` on body should fix this problem.
2. menu/menuitem has moved to the homepage template, so it should be removed from index. See this [Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1241402) for more details.
3. Point to TV Marketplace icon.
4. Remove appcache.
5. Name should be 'Web Apps'.

Thanks :)