### PR TITLE
Pass . to stats-po.sh in omg_new_l10n.sh so it works with BSD and gnu…

### DIFF
--- a/locale/omg_new_l10n.sh
+++ b/locale/omg_new_l10n.sh
@@ -138,7 +138,7 @@ updated.  Unless something unusual is happening, we do weekly pushes on
 Tuesdays so any strings committed by then will go live.  To give you an idea of
 the number of new strings I will calculate untranslated strings below.
 
-`./stats-po.sh`
+`./stats-po.sh .`
 
 Source files: $EMAIL_SOURCE
 


### PR DESCRIPTION
… find. (Previously done for all other string extraction repos except this one on 2015/12/03.)