### PR TITLE
Bug 1236810 - Update TV Marketplace icon URL to production server

### DIFF
--- a/mkt/tvplace/templates/tvplace/manifest.webapp
+++ b/mkt/tvplace/templates/tvplace/manifest.webapp
@@ -6,7 +6,7 @@
         "url": "http://mozilla.org"
     },
     "icons": {
-        "336": "https://marketplace-dev-cdn.allizom.org/media/marketplace-tv-front-end/img/app-icons/appic_web_apps.png"
+        "336": "https://marketplace.cdn.mozilla.net/media/marketplace-tv-front-end/img/app-icons/appic_web_apps.png"
     },
     "launch_path": "/tv/",
     "name": "Web Apps",


### PR DESCRIPTION
Since the assets of TV Marketplace had push to the production server, we should change the icon url in manifest to the production server.