### PR TITLE
Minor tweaks to wording on content ratings edit page, also don't show initial cert_id

### DIFF
--- a/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
+++ b/mkt/developers/templates/developers/apps/ratings/ratings_edit.html
@@ -22,6 +22,18 @@
       <h2>{{ _('Get My App Rated') }}</h2>
 
       <div class="island">
+        {% if addon.is_rated() %}
+        <p>
+          {% trans %}
+            Your app has already been age rated and has an
+            International Age Rating Coalition (IARC) certificate attached. To
+            change the rating, click on the button below: that will open a new
+            window where you can fill out a new questionnaire about the
+            contents of your app. Upon completion, the window will close and
+            your app will then have an new age rating and certificate.
+          {% endtrans %}
+        </p>
+        {% else %}
         <p>
           {% trans %}
             To have your app listed on the Marketplace, you must attain an
@@ -32,6 +44,7 @@
             rating.
           {% endtrans %}
         </p>
+        {% endif %}
         <p>
           {% trans privacy_url=settings.IARC_PRIVACY_URL, tos_url=settings.IARC_TOS_URL %}
             By using the IARC ratings certificate tool, you agree to abide by their
@@ -85,25 +98,41 @@
     </section>
 
     <section>
-      <h2>{{ _('Already Have Your App Rated?') }}</h2>
+      <h2>
+        {% if waffle.switch('iarc-upgrade-v2') %}
+          {{ _('Already Have an IARC Certificate?') }}
+        {% else %}
+          {{ _('Already Have Your App Rated?') }}
+        {% endif %}
+      </h2>
 
       <div class="island">
-        <p>
-          {% if waffle.switch('iarc-upgrade-v2') %}
+        {% if waffle.switch('iarc-upgrade-v2') %}
+          <p>
             {% trans %}
               If you have already gotten your app rated via the IARC Global
               Ratings Tool above and already have an IARC certificate, you can
               enter it here and we'll notify IARC to link your Marketplace
               submission with that certificate.
             {% endtrans %}
-          {% else %}
+          </p>
+          {% if addon.is_rated() %}
+            <p>
+              {% trans %}
+                Warning: if a certificate is already attached to your app, this
+                will overwrite it. Use with caution.
+              {% endtrans %}
+            </p>
+          {% endif %}
+        {% else %}
+          <p>
             {% trans %}
               If you have already gotten your app rated via the IARC Global
               Ratings Tool above and already have an IARC security code, you
               can manually enter it here.
             {% endtrans %}
-          {% endif %}
           </p>
+        {% endif %}
         <form method="POST">
           {{ csrf() }}
           {% if waffle.switch('iarc-upgrade-v2') %}

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -1465,7 +1465,7 @@ class TestContentRatingsV2(mkt.site.tests.TestCase):
     def test_existing_cert_form(self):
         response = content_ratings_edit(self.req, app_slug=self.app.app_slug)
         doc = pq(response.content)
-        # V1 fields are not present, V1 is (and empty).
+        # V1 fields are not present, V2 field is (and empty).
         ok_(not doc('#id_submission_id'))
         ok_(not doc('#id_security_code'))
         ok_(doc('#id_cert_id'))
@@ -1475,7 +1475,9 @@ class TestContentRatingsV2(mkt.site.tests.TestCase):
         self.app.set_iarc_certificate(cert_id)
         response = content_ratings_edit(self.req, app_slug=self.app.app_slug)
         doc = pq(response.content)
-        eq_(doc('#id_cert_id').attr('value'), cert_id)
+        # Still empty, we don't want to prefill that form since re-submit it
+        # with the same cert is useless.
+        ok_(not doc('#id_cert_id').attr('value'))
 
     def test_existing_cert_form_submit_error(self):
         self.req.method = 'POST'

--- a/mkt/developers/views.py
+++ b/mkt/developers/views.py
@@ -67,8 +67,7 @@ from mkt.users.models import UserProfile
 from mkt.users.views import _clean_next_url
 from mkt.versions.models import Version
 from mkt.webapps.decorators import app_view
-from mkt.webapps.models import (AddonUser, ContentRating, IARCCert, IARCInfo,
-                                Webapp)
+from mkt.webapps.models import AddonUser, ContentRating, IARCInfo, Webapp
 from mkt.webapps.tasks import _update_manifest, update_manifests
 from mkt.zadmin.models import set_config, unmemoized_get_config
 
@@ -359,10 +358,6 @@ def content_ratings_edit(request, addon_id, addon):
     data = request.POST if request.method == 'POST' else None
 
     if waffle.switch_is_active('iarc-upgrade-v2'):
-        try:
-            initial['cert_id'] = unicode(uuid.UUID(addon.iarc_cert.cert_id))
-        except IARCCert.DoesNotExist:
-            pass
         form_class = IARCV2ExistingCertificateForm
     else:
         try:


### PR DESCRIPTION
Showing the initial certificate ID value has no real benefit, we don't want users to resubmit that form anyway.