### PR TITLE
Fix tvplace search ordering

### DIFF
--- a/mkt/tvplace/views.py
+++ b/mkt/tvplace/views.py
@@ -33,8 +33,20 @@ class MultiSearchView(BaseMultiSearchView):
 
     def get_queryset(self):
         qs = BaseMultiSearchView.get_queryset(self)
-        return qs.filter(Bool(must=[F('term', device=mkt.DEVICE_TV.id)])
-                         ).sort('-tv_featured')
+        return self.order_queryset(
+            qs.filter(Bool(must=[F('term', device=mkt.DEVICE_TV.id)])))
+
+    def order_queryset(self, qs):
+        # We sort by featured first, and then, by score (will be descending
+        # automatically) if there is a query, otherwise by -reviewed so we get
+        # recent results first.
+        if self.request.GET.get('q'):
+            fallback_field = '_score'
+        else:
+            fallback_field = '-reviewed'
+        return qs.sort(
+            {'tv_featured': {'order': 'desc', 'missing': 0}},
+            fallback_field)
 
 
 def manifest(request):


### PR DESCRIPTION
If `tv_featured` was absent the ordering was unstable. To fix it, sort by relevancy or by reviewed date depending on the query, and make sure to handle missing `tv_featured` value.