### PR TITLE
Remove icons for IARC descriptors/interactives

### DIFF
--- a/mkt/constants/ratingsbodies.py
+++ b/mkt/constants/ratingsbodies.py
@@ -425,37 +425,5 @@ IARC_ICONS = {
             '18': pth('USK_18.png'),
             'rating-refused': pth('USK_RR.png')
         }
-    },
-    'descriptors': {
-        'pegi': {
-            'has_pegi_discrimination':
-                pth('descriptors/pegi_discrimination.png'),
-            'has_pegi_drugs': pth('descriptors/pegi_drugs.png'),
-            'has_pegi_gambling': pth('descriptors/pegi_gambling.png'),
-            'has_pegi_lang': pth('descriptors/pegi_language.png'),
-            'has_pegi_nudity': pth('descriptors/pegi_nudity.png'),
-            'has_pegi_online': pth('descriptors/pegi_online.png'),
-            'has_pegi_scary': pth('descriptors/pegi_fear.png'),
-            'has_pegi_sex_content': pth('descriptors/pegi_sex.png'),
-            'has_pegi_violence': pth('descriptors/pegi_violence.png'),
-
-            'has_pegi_digital_purchases': pth(
-                'descriptors/pegi_inapp_purchase_option.png'),
-            'has_pegi_shares_info': pth(
-                'descriptors/pegi_personal_data_sharing.png'),
-            'has_pegi_shares_location': pth(
-                'descriptors/pegi_location_data_sharing.png'),
-            'has_pegi_users_interact': pth(
-                'descriptors/pegi_social_interaction_functionality.png'),
-        }
-    },
-    'interactive_elements': {
-        'has_shares_info': pth('interactives/ESRB_shares-info_small.png'),
-        'has_shares_location':
-            pth('interactives/ESRB_shares-location_small.png'),
-        'has_users_interact':
-            pth('interactives/ESRB_users-interact_small.png'),
-        'has_digital_purchases': pth(
-            'interactives/ESRB_digital-purchases_small.png'),
     }
 }

--- a/mkt/developers/templates/developers/apps/ratings/ratings_summary.html
+++ b/mkt/developers/templates/developers/apps/ratings/ratings_summary.html
@@ -35,17 +35,10 @@
               <td class="content-rating">
                 {% include "developers/includes/content_rating_icon.html" %}</td>
               <td class="content-descriptors">
-                {% set desc_icons = mkt.ratingsbodies.IARC_ICONS.descriptors %}
                 {% for descriptor in addon.rating_descriptors.to_keys_by_body(body.label) %}
-                  {% set desc_icon = body.label in desc_icons and desc_icons[body.label][descriptor] %}
-                  {% if desc_icon %}
-                    <img src="{{ media(desc_icon) }}" class="icon"
-                         title="{{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[descriptor] }}">
-                  {% else %}
-                    <span class="dot-sep descriptor">
-                      {{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[descriptor] }}
-                    </span>
-                  {% endif %}
+                  <span class="dot-sep descriptor">
+                    {{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[descriptor] }}
+                  </span>
                 {% else %}
                   &mdash;
                 {% endfor %}
@@ -66,13 +59,6 @@
               </span>
             {% endfor %}
           </div>
-          {% set inter_icons = mkt.ratingsbodies.IARC_ICONS.interactive_elements %}
-          {% for interactive in interactives %}
-            {% if inter_icons[interactive] %}
-              <img src="{{ media(inter_icons[interactive]) }}" class="icon"
-                   title="{{ mkt.iarc_mappings.HUMAN_READABLE_DESCS_AND_INTERACTIVES[interactive] }}">
-            {% endif %}
-          {% endfor %}
         </div>
       {% endif %}
     </div>

--- a/mkt/developers/tests/test_views.py
+++ b/mkt/developers/tests/test_views.py
@@ -1385,7 +1385,7 @@ class TestContentRatings(mkt.site.tests.TestCase):
         self.assertSetEqual([name.text for name in doc('.name')],
                             [body.name for body in ratings])
         self.assertSetEqual([name.text.strip() for name in doc('.descriptor')],
-                            ['Sexo'])
+                            ['Language', 'Sexo'])
         self.assertSetEqual(
             [name.text.strip() for name in doc('.interactive')],
             ['Users Interact'])


### PR DESCRIPTION
"IARC no longer uses icons for those"

Fireplace pull request: mozilla/fireplace#1604