### PR TITLE
Add all PEGI categories/descriptors to Generic rating body

### DIFF
--- a/lib/iarc_v2/mock/SearchCerts.json
+++ b/lib/iarc_v2/mock/SearchCerts.json
@@ -150,9 +150,9 @@
       "RatingAuthorityID": 6,
       "RatingAuthorityShortText": "Generic",
       "RatingLogicVersion": "6.3",
-      "AgeRatingID": 8,
-      "AgeRatingText": "12",
-      "AgeRatingShortText": "12",
+      "AgeRatingID": 55,
+      "AgeRatingText": "!",
+      "AgeRatingShortText": "EXC",
       "NumericLevel": 3,
       "DateCreated": "2015-09-03T18:00:36.747Z",
       "DescriptorList": [

--- a/lib/iarc_v2/tests/test_client.py
+++ b/lib/iarc_v2/tests/test_client.py
@@ -101,9 +101,11 @@ class TestGetRatingChanges(TestCase):
         app1 = Webapp.objects.get(pk=app1.pk)
         app2 = Webapp.objects.get(pk=app2.pk)
         eq_(app1.rating_descriptors.to_keys(), ['has_esrb_violence_ref'])
-        eq_(app2.rating_descriptors.to_keys(),
-            ['has_classind_violence', 'has_pegi_moderate_violence',
-             'has_esrb_violence', 'has_usk_violence'])
+        self.assertSetEqual(
+            app2.rating_descriptors.to_keys(),
+            ['has_classind_violence', 'has_generic_moderate_violence',
+             'has_pegi_moderate_violence', 'has_esrb_violence',
+             'has_usk_violence'])
         eq_(res['Result']['ResponseCode'], 'Success')
         eq_(app1.content_ratings.all()[0].get_rating_class(), ESRB_10)
         eq_(app2.content_ratings.all()[0].get_rating_class(), CLASSIND_12)
@@ -271,13 +273,16 @@ class TestSearchCertsAndAttachToCert(TestCase):
         eq_(data,
             {'ResultCode': 'Success', 'ErrorMessage': None, 'ErrorID': None})
         eq_(UUID(app.iarc_cert.cert_id), UUID(cert_id))
-        eq_(app.rating_descriptors.to_keys(),
-            ['has_classind_lang', 'has_pegi_parental_guidance_recommended'])
-        eq_(app.rating_interactives.to_keys(),
+        self.assertSetEqual(
+            app.rating_descriptors.to_keys(),
+            ['has_classind_lang', 'has_generic_parental_guidance_recommended',
+             'has_pegi_parental_guidance_recommended'])
+        self.assertSetEqual(
+            app.rating_interactives.to_keys(),
             ['has_shares_location', 'has_digital_purchases',
              'has_users_interact'])
         eq_(app.get_content_ratings_by_body(),
-            {'generic': '3', 'esrb': '13', 'classind': '12', 'usk': '12',
+            {'generic': '12', 'esrb': '13', 'classind': '12', 'usk': '12',
              'pegi': 'parental-guidance'})
 
     @responses.activate
@@ -316,9 +321,12 @@ class TestSearchCertsAndAttachToCert(TestCase):
         # Compare with mock data. Force reload using .objects.get in order to
         # properly reset the related objects caching.
         app = Webapp.objects.get(pk=app.pk)
-        eq_(app.rating_descriptors.to_keys(),
-            ['has_classind_lang', 'has_pegi_parental_guidance_recommended'])
-        eq_(app.rating_interactives.to_keys(),
+        self.assertSetEqual(
+            app.rating_descriptors.to_keys(),
+            ['has_classind_lang', 'has_generic_parental_guidance_recommended',
+             'has_pegi_parental_guidance_recommended'])
+        self.assertSetEqual(
+            app.rating_interactives.to_keys(),
             ['has_shares_location', 'has_digital_purchases',
              'has_users_interact'])
         eq_(app.content_ratings.all()[0].get_rating_class(), CLASSIND_12)

--- a/mkt/constants/iarc_mappings.py
+++ b/mkt/constants/iarc_mappings.py
@@ -40,6 +40,7 @@ RATINGS = {
         '16+': ratingsbodies.GENERIC_16,
         '18+': ratingsbodies.GENERIC_18,
         'RP': ratingsbodies.GENERIC_RP,
+        '!': ratingsbodies.GENERIC_12,
         'default': ratingsbodies.GENERIC_3,
     },
     ratingsbodies.PEGI.id: {
@@ -145,13 +146,28 @@ DESCS = {
     },
 
     ratingsbodies.GENERIC.id: {
+        u'Criminal Technique Instructions':
+            'has_generic_criminal_technique_instructions',
         u'Discrimination': 'has_generic_discrimination',
         u'Drugs': 'has_generic_drugs',
+        u'Extreme Violence': 'has_generic_extreme_violence',
         u'Fear': 'has_generic_scary',
         u'Gambling': 'has_generic_gambling',
+        u'Horror': 'has_generic_horror',
+        u'Implied Violence': 'has_generic_implied_violence',
         u'Language': 'has_generic_lang',
+        u'Mild Swearing': 'has_generic_mild_swearing',
+        u'Mild Violence': 'has_generic_mild_violence',
+        u'Moderate Violence': 'has_generic_moderate_violence',
+        u'Parental Guidance Recommended':
+            'has_generic_parental_guidance_recommended',
         u'Online': 'has_generic_online',
         u'Sex': 'has_generic_sex_content',
+        u'Sexual Innuendo': 'has_generic_sexual_innuendo',
+        u'Sexual Violence': 'has_generic_sexual_violence',
+        u'Strong Language': 'has_generic_strong_language',
+        u'Strong Violence': 'has_generic_strong_violence',
+        u'Use of Alcohol/Tobacco': 'has_generic_use_of_alcohol_and_tobacco',
         u'Violence': 'has_generic_violence',
     },
 
@@ -298,14 +314,31 @@ DESCS_V2 = {
     },
 
     ratingsbodies.GENERIC.id: {
-        # Yes, "Generic" seems to be using PEGI descriptors for some reason.
+        # Yes, "Generic" is using PEGI keys, that's not a typo: that's how it
+        # works on IARC side.
+        'PEGI_CriminalTechniqueInstructions':
+            'has_generic_criminal_technique_instructions',
         'PEGI_Discrimination': 'has_generic_discrimination',
         'PEGI_Drugs': 'has_generic_drugs',
+        'PEGI_ExtremeViolence': 'has_generic_extreme_violence',
         'PEGI_Fear': 'has_generic_scary',
         'PEGI_Gambling': 'has_generic_gambling',
+        'PEGI_Horror': 'has_generic_horror',
+        'PEGI_ImpliedViolence': 'has_generic_implied_violence',
         'PEGI_Language': 'has_generic_lang',
+        'PEGI_MildSwearing': 'has_generic_mild_swearing',
+        'PEGI_MildViolence': 'has_generic_mild_violence',
+        'PEGI_ModerateViolence': 'has_generic_moderate_violence',
+        'PEGI_NoDescriptors': '',  # No descriptors.
         'PEGI_Online': 'has_generic_online',
+        'PEGI_ParentalGuidanceRecommended':
+            'has_generic_parental_guidance_recommended',
         'PEGI_Sex': 'has_generic_sex_content',
+        'PEGI_SexualInnuendo': 'has_generic_sexual_innuendo',
+        'PEGI_SexualViolence': 'has_generic_sexual_violence',
+        'PEGI_StrongLanguage': 'has_generic_strong_language',
+        'PEGI_StrongViolence': 'has_generic_strong_violence',
+        'PEGI_UseofAlcoholTobacco': 'has_generic_use_of_alcohol_and_tobacco',
         'PEGI_Violence': 'has_generic_violence',
     },
 

--- a/mkt/webapps/migrations/0012_new_generic_descriptors.py
+++ b/mkt/webapps/migrations/0012_new_generic_descriptors.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webapps', '0011_iarc_add_new_descriptors_and_interactives'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_criminal_technique_instructions',
+            field=models.BooleanField(default=False, help_text='Criminal Technique Instructions'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_extreme_violence',
+            field=models.BooleanField(default=False, help_text='Extreme Violence'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_horror',
+            field=models.BooleanField(default=False, help_text='Horror'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_implied_violence',
+            field=models.BooleanField(default=False, help_text='Implied Violence'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_mild_swearing',
+            field=models.BooleanField(default=False, help_text='Mild Swearing'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_mild_violence',
+            field=models.BooleanField(default=False, help_text='Mild Violence'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_moderate_violence',
+            field=models.BooleanField(default=False, help_text='Moderate Violence'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_parental_guidance_recommended',
+            field=models.BooleanField(default=False, help_text='Parental Guidance Recommended'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_sexual_innuendo',
+            field=models.BooleanField(default=False, help_text='Sexual Innuendo'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_sexual_violence',
+            field=models.BooleanField(default=False, help_text='Sexual Violence'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_strong_language',
+            field=models.BooleanField(default=False, help_text='Strong Language'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_strong_violence',
+            field=models.BooleanField(default=False, help_text='Strong Violence'),
+        ),
+        migrations.AddField(
+            model_name='ratingdescriptors',
+            name='has_generic_use_of_alcohol_and_tobacco',
+            field=models.BooleanField(default=False, help_text='Use of Alcohol/Tobacco'),
+        ),
+    ]


### PR DESCRIPTION
As requested by IARC:
- Generic has no records in Descriptor table, it uses the complete set of PEGI descriptors
- Generic has no records in AgeRating table either, it uses the complete set of PEGI age ratings, but for ageRatingID 55 it shows a 12+ icon, i.e. when PEGI shows an exclamation point icon Generic shows “12+”.
