### PR TITLE
Fix "Generic" IARC rating body to PEGI categories... without the "+"

### DIFF
--- a/lib/iarc_v2/mock/SearchCerts.json
+++ b/lib/iarc_v2/mock/SearchCerts.json
@@ -150,9 +150,9 @@
       "RatingAuthorityID": 6,
       "RatingAuthorityShortText": "Generic",
       "RatingLogicVersion": "6.3",
-      "AgeRatingID": 55,
-      "AgeRatingText": "!",
-      "AgeRatingShortText": "EXC",
+      "AgeRatingID": 8,
+      "AgeRatingShortText": "12",
+      "AgeRatingText": "12",
       "NumericLevel": 3,
       "DateCreated": "2015-09-03T18:00:36.747Z",
       "DescriptorList": [

--- a/mkt/constants/iarc_mappings.py
+++ b/mkt/constants/iarc_mappings.py
@@ -40,7 +40,15 @@ RATINGS = {
         '16+': ratingsbodies.GENERIC_16,
         '18+': ratingsbodies.GENERIC_18,
         'RP': ratingsbodies.GENERIC_RP,
-        '!': ratingsbodies.GENERIC_12,
+
+        # Generic AgeRatingText seem to be different from PEGI for some reason,
+        # not including the +, let's have both variants.
+        '3': ratingsbodies.GENERIC_3,
+        '7': ratingsbodies.GENERIC_7,
+        '12': ratingsbodies.GENERIC_12,
+        '16': ratingsbodies.GENERIC_16,
+        '18': ratingsbodies.GENERIC_18,
+
         'default': ratingsbodies.GENERIC_3,
     },
     ratingsbodies.PEGI.id: {


### PR DESCRIPTION
We sadly match on AgeRatingText because it was the most convenient with what we had when we started. It appears that for Generic, IARC rating no longer includes the "+" after the age, at least not always.